### PR TITLE
Defensive copying in use of KSPSolve

### DIFF
--- a/examples/fenics/basal_sliding/basal.py
+++ b/examples/fenics/basal_sliding/basal.py
@@ -375,10 +375,9 @@ ref, J = forward(beta_sq_ref)
 stop_manager()
 
 ddJ = SingleBlockHessian(J)
-M_solver = KrylovSolver("cg", "sor")
+M_solver = KrylovSolver(assemble(inner(test, trial) * dx), "cg", "sor")
 M_solver.parameters.update({"relative_tolerance": 1.0e-12,
                             "absolute_tolerance": 1.0e-16})
-M_solver.set_operator(assemble(inner(test, trial) * dx))
 A_action_calls = [0]
 
 

--- a/examples/fenics/basal_sliding/basal_fp.py
+++ b/examples/fenics/basal_sliding/basal_fp.py
@@ -321,10 +321,9 @@ ref, J = forward(beta_sq_ref)
 stop_manager()
 
 ddJ = SingleBlockHessian(J)
-M_solver = KrylovSolver("cg", "sor")
+M_solver = KrylovSolver(assemble(inner(test, trial) * dx), "cg", "sor")
 M_solver.parameters.update({"relative_tolerance": 1.0e-12,
                             "absolute_tolerance": 1.0e-16})
-M_solver.set_operator(assemble(inner(test, trial) * dx))
 A_action_calls = [0]
 
 

--- a/examples/fenics/transport/transport.py
+++ b/examples/fenics/transport/transport.py
@@ -333,7 +333,7 @@ def project(b, space, name):
     x = Function(space, name=name)
     test, trial = TestFunction(space), TrialFunction(space)
     M = assemble(inner(test, trial) * dx)
-    LUSolver(M, "umfpack").solve(x.vector(), b.vector())
+    LUSolver(M, "umfpack").solve(x.vector(), b.vector().copy())
     return x
 
 

--- a/python/tlm_adjoint/equations.py
+++ b/python/tlm_adjoint/equations.py
@@ -550,7 +550,7 @@ class EquationSolver(Equation):
                     # Construct and cache the linear solver
                     self._forward_J_solver, J_solver = \
                         linear_solver_cache().linear_solver(
-                            self._J, J_mat, bcs=self._bcs,
+                            self._J, J_mat.copy(), bcs=self._bcs,
                             form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                             linear_solver_parameters=self._linear_solver_parameters)  # noqa: E501
             else:
@@ -718,7 +718,7 @@ class EquationSolver(Equation):
                                          nl_deps)))
                 self._adjoint_J_solver, J_solver = \
                     linear_solver_cache().linear_solver(
-                        J, J_mat, bcs=self._hbcs,
+                        J, J_mat.copy(), bcs=self._hbcs,
                         form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                         linear_solver_parameters=self._adjoint_solver_parameters)  # noqa: E501
 

--- a/python/tlm_adjoint/equations.py
+++ b/python/tlm_adjoint/equations.py
@@ -550,7 +550,7 @@ class EquationSolver(Equation):
                     # Construct and cache the linear solver
                     self._forward_J_solver, J_solver = \
                         linear_solver_cache().linear_solver(
-                            self._J, J_mat.copy(), bcs=self._bcs,
+                            self._J, matrix_copy(J_mat), bcs=self._bcs,
                             form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                             linear_solver_parameters=self._linear_solver_parameters)  # noqa: E501
             else:
@@ -718,7 +718,7 @@ class EquationSolver(Equation):
                                          nl_deps)))
                 self._adjoint_J_solver, J_solver = \
                     linear_solver_cache().linear_solver(
-                        J, J_mat.copy(), bcs=self._hbcs,
+                        J, matrix_copy(J_mat), bcs=self._hbcs,
                         form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                         linear_solver_parameters=self._adjoint_solver_parameters)  # noqa: E501
 

--- a/python/tlm_adjoint_fenics/backend_code_generator_interface.py
+++ b/python/tlm_adjoint_fenics/backend_code_generator_interface.py
@@ -206,12 +206,12 @@ def assemble_linear_solver(A_form, b_form=None, bcs=[],
     if b_form is None:
         A, b = assemble_matrix(
             A_form, bcs, form_compiler_parameters=form_compiler_parameters)
-        solver = linear_solver(A, linear_solver_parameters)
     else:
         A, b = assemble_system(
             A_form, b_form, bcs=bcs,
             form_compiler_parameters=form_compiler_parameters)
-        solver = linear_solver(A, linear_solver_parameters)
+
+    solver = linear_solver(A.copy(), linear_solver_parameters)
 
     return solver, A, b
 

--- a/python/tlm_adjoint_fenics/backend_code_generator_interface.py
+++ b/python/tlm_adjoint_fenics/backend_code_generator_interface.py
@@ -40,6 +40,7 @@ __all__ = \
         "function_vector",
         "homogenize",
         "linear_solver",
+        "matrix_copy",
         "matrix_multiply",
         "parameters_key",
         "process_adjoint_solver_parameters",
@@ -250,6 +251,10 @@ def homogenize(bc):
     hbc = backend_DirichletBC(bc)
     hbc.homogenize()
     return hbc
+
+
+def matrix_copy(A):
+    return A.copy()
 
 
 def matrix_multiply(A, x, tensor=None, addto=False):

--- a/python/tlm_adjoint_firedrake/backend.py
+++ b/python/tlm_adjoint_firedrake/backend.py
@@ -32,7 +32,9 @@ backend_FunctionSpace = firedrake.functionspaceimpl.WithGeometry
 backend_LinearSolver = LinearSolver
 backend_LinearVariationalProblem = LinearVariationalProblem
 backend_LinearVariationalSolver = LinearVariationalSolver
+backend_Matrix = firedrake.matrix.Matrix
 backend_NonlinearVariationalSolver = NonlinearVariationalSolver
+backend_ScalarType = firedrake.utils.ScalarType
 backend_Vector = Vector
 backend_assemble = assemble
 backend_project = project
@@ -51,7 +53,9 @@ __all__ = \
         "backend_LinearSolver",
         "backend_LinearVariationalProblem",
         "backend_LinearVariationalSolver",
+        "backend_Matrix",
         "backend_NonlinearVariationalSolver",
+        "backend_ScalarType",
         "backend_Vector",
         "backend_assemble",
         "backend_project",

--- a/python/tlm_adjoint_firedrake/backend_code_generator_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_code_generator_interface.py
@@ -297,7 +297,7 @@ def assemble_linear_solver(A_form, b_form=None, bcs=[],
         **assemble_arguments(2, form_compiler_parameters,
                              linear_solver_parameters))
 
-    solver = linear_solver(A, linear_solver_parameters)
+    solver = linear_solver(A.copy(), linear_solver_parameters)
 
     return solver, A, b
 

--- a/tests/fenics/test_overrides.py
+++ b/tests/fenics/test_overrides.py
@@ -56,10 +56,9 @@ def test_overrides(setup_test, test_leaks):
                                A_tensor=A, b_tensor=b, add_values=True)
         bc.apply(A, b)
 
-        solver = KrylovSolver("gmres", "sor")
+        solver = KrylovSolver(A, "gmres", "sor")
         solver.parameters.update({"relative_tolerance": 1.0e-14,
                                   "absolute_tolerance": 1.0e-16})
-        solver.set_operator(A)
         solver.solve(G.vector(), b)
 
         return G
@@ -71,10 +70,9 @@ def test_overrides(setup_test, test_leaks):
         b = assemble(inner(test, F) * dx)
         bc.apply(A, b)
 
-        solver = KrylovSolver("gmres", "sor")
+        solver = KrylovSolver(A, "gmres", "sor")
         solver.parameters.update({"relative_tolerance": 1.0e-14,
                                   "absolute_tolerance": 1.0e-16})
-        solver.set_operator(A)
         solver.solve(G.vector(), b)
 
         return G
@@ -86,10 +84,9 @@ def test_overrides(setup_test, test_leaks):
         b = A * F.vector()
         bc.apply(A, b)
 
-        solver = KrylovSolver("gmres", "sor")
+        solver = KrylovSolver(A, "gmres", "sor")
         solver.parameters.update({"relative_tolerance": 1.0e-14,
                                   "absolute_tolerance": 1.0e-16})
-        solver.set_operator(A)
         solver.solve(G.vector(), b)
 
         return G


### PR DESCRIPTION
PETSc KSP objects can in principle change the matrix and/or right-hand-side vector. Add some defensive copying to work around this.