### PR TITLE
Add missing zeroing of the forward solution in LinearEquation.forward_solve

### DIFF
--- a/python/tlm_adjoint/base_equations.py
+++ b/python/tlm_adjoint/base_equations.py
@@ -1357,6 +1357,8 @@ class LinearEquation(Equation):
             deps = self.dependencies()
 
         if self._A is None:
+            for x in X:
+                function_zero(x)
             B = X
         else:
             B = tuple(function_new(x) for x in X)

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -40,6 +40,7 @@ def test_AssignmentSolver(setup_test, test_leaks):
         AssignmentSolver(x, y[0]).solve()
         for i in range(len(y) - 1):
             AssignmentSolver(y[i], y[i + 1]).solve()
+        NormSqSolver(y[-1], z).solve()  # Should have no effect on sensitivity
         NormSqSolver(y[-1], z).solve()
 
         x_norm_sq = Constant(name="x_norm_sq")

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -41,6 +41,7 @@ def test_AssignmentSolver(setup_test, test_leaks):
         AssignmentSolver(x, y[0]).solve()
         for i in range(len(y) - 1):
             AssignmentSolver(y[i], y[i + 1]).solve()
+        NormSqSolver(y[-1], z).solve()  # Should have no effect on sensitivity
         NormSqSolver(y[-1], z).solve()
 
         x_norm_sq = Constant(name="x_norm_sq")

--- a/tests/numpy/test_equations.py
+++ b/tests/numpy/test_equations.py
@@ -37,6 +37,7 @@ def test_AssignmentSolver(setup_test, test_leaks):
         AssignmentSolver(x, y[0]).solve()
         for i in range(len(y) - 1):
             AssignmentSolver(y[i], y[i + 1]).solve()
+        NormSqSolver(y[-1], z).solve()  # Should have no effect on sensitivity
         NormSqSolver(y[-1], z).solve()
 
         x_norm_sq = Constant(name="x_norm_sq")


### PR DESCRIPTION
Leads to adjoint inconsistency if the forward solution is non-zero (seen in fenics_ice).