### PR TITLE
Skip ghost elements in greedy_coloring

### DIFF
--- a/python/tlm_adjoint_fenics/fenics_equations.py
+++ b/python/tlm_adjoint_fenics/fenics_equations.py
@@ -57,6 +57,10 @@ def greedy_coloring(space):
 
     node_node_graph = tuple(set() for i in range(N))
     for i in range(space.mesh().num_cells()):
+
+        if Cell(space.mesh(), i).is_ghost():
+            continue
+
         cell_nodes = dofmap.cell_dofs(i)
         for j in cell_nodes:
             for k in cell_nodes:


### PR DESCRIPTION
The presence of ghost elements (ghost_mode = 'shared facet') in my parallel mesh was tripping up the greedy coloring.

Just running tests just now.