### PR TITLE
Firedrake backend: Reduce solver tolerances in the basal_sliding examples

### DIFF
--- a/examples/firedrake/basal_sliding/basal.py
+++ b/examples/firedrake/basal_sliding/basal.py
@@ -152,7 +152,7 @@ def forward(beta_sq, ref=None, h_filename=None, speed_filename=None):
                 solver_parameters={"ksp_type": "cg",
                                    "pc_type": "hypre",
                                    "pc_hypre_type": "boomeramg",
-                                   "ksp_rtol": 1.0e-12,
+                                   "ksp_rtol": 1.0e-13,
                                    "ksp_atol": 1.0e-16,
                                    "mat_type": "aij"},
                 match_quadrature=True,
@@ -186,7 +186,7 @@ def forward(beta_sq, ref=None, h_filename=None, speed_filename=None):
                                      "ksp_type": "cg",
                                      "pc_type": "hypre",
                                      "pc_hypre_type": "boomeramg",
-                                     "ksp_rtol": 1.0e-12,
+                                     "ksp_rtol": 1.0e-13,
                                      "ksp_atol": 1.0e-16,
                                      "snes_rtol": 0.0,
                                      "snes_atol": max(1.0e-16,
@@ -200,12 +200,12 @@ def forward(beta_sq, ref=None, h_filename=None, speed_filename=None):
                                      "ksp_type": "cg",
                                      "pc_type": "hypre",
                                      "pc_hypre_type": "boomeramg",
-                                     "ksp_rtol": 1.0e-12,
+                                     "ksp_rtol": 1.0e-13,
                                      "ksp_atol": 1.0e-16,
                                      "snes_rtol": 0.0,
                                      "snes_atol": max(1.0e-16,
                                                       min(1.0e3,
-                                                          1.0e-11 * r_norm)),
+                                                          1.0e-12 * r_norm)),
                                      "snes_max_it": 10,
                                      "snes_error_if_not_converged": True,
                                      "mat_type": "aij"},
@@ -239,7 +239,7 @@ def forward(beta_sq, ref=None, h_filename=None, speed_filename=None):
             - dt * inner(test_h, div(U * (h + H_0))) * dx,
             F_h, solver_parameters={"ksp_type": "cg",
                                     "pc_type": "sor",
-                                    "ksp_rtol": 1.0e-12,
+                                    "ksp_rtol": 1.0e-13,
                                     "ksp_atol": 1.0e-16})
 
     def solve_elevation_rhs(U, h, F_h):
@@ -353,7 +353,7 @@ ddJ = SingleBlockHessian(J)
 M_solver = LinearSolver(assemble(inner(test, trial) * dx),
                         solver_parameters={"ksp_type": "cg",
                                            "pc_type": "sor",
-                                           "ksp_rtol": 1.0e-12,
+                                           "ksp_rtol": 1.0e-13,
                                            "ksp_atol": 1.0e-16,
                                            "mat_type": "aij"})
 A_action_calls = [0]
@@ -427,7 +427,7 @@ if debug:
     assert min_order > 1.99
 
     min_order = taylor_test(forward_ref_J, beta_sq, J_val=J.value(), ddJ=ddJ,
-                            seed=2.0e-3)
+                            seed=1.0e-3)
     assert min_order > 2.99
 
     min_order = taylor_test_tlm(forward_ref_J, beta_sq,

--- a/examples/firedrake/basal_sliding/basal_fp.py
+++ b/examples/firedrake/basal_sliding/basal_fp.py
@@ -156,7 +156,7 @@ def forward(beta_sq, ref=None, h_filename=None, speed_filename=None):
                               solver_parameters={"ksp_type": "cg",
                                                  "pc_type": "hypre",
                                                  "pc_hypre_type": "boomeramg",
-                                                 "ksp_rtol": 1.0e-12,
+                                                 "ksp_rtol": 1.0e-13,
                                                  "ksp_atol": 1.0e-16,
                                                  "mat_type": "aij"},
                               adjoint_solver_parameters={"ksp_type": "preonly",
@@ -188,7 +188,7 @@ def forward(beta_sq, ref=None, h_filename=None, speed_filename=None):
             - dt * inner(test_h, div(U * (h + H_0))) * dx,
             F_h, solver_parameters={"ksp_type": "cg",
                                     "pc_type": "sor",
-                                    "ksp_rtol": 1.0e-12,
+                                    "ksp_rtol": 1.0e-13,
                                     "ksp_atol": 1.0e-16})
 
     def solve_elevation_rhs(U, h, F_h):
@@ -302,7 +302,7 @@ ddJ = SingleBlockHessian(J)
 M_solver = LinearSolver(assemble(inner(test, trial) * dx),
                         solver_parameters={"ksp_type": "cg",
                                            "pc_type": "sor",
-                                           "ksp_rtol": 1.0e-12,
+                                           "ksp_rtol": 1.0e-13,
                                            "ksp_atol": 1.0e-16,
                                            "mat_type": "aij"})
 A_action_calls = [0]
@@ -377,7 +377,7 @@ if debug:
 
     min_order = taylor_test(forward_ref_J, beta_sq, J_val=J.value(), ddJ=ddJ,
                             seed=1.0e-3)
-    assert min_order > 2.93
+    assert min_order > 2.98
 
     min_order = taylor_test_tlm(forward_ref_J, beta_sq,
                                 tlm_order=1, seed=1.0e-3)


### PR DESCRIPTION
Also minor changes to verification tolerances