### PR TITLE
Remove backend_interface imports

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,8 @@ master branch.
 Together with the backend libraries, tlm_adjoint requires
 
     NumPy
-    mpi4py and petsc4py (FEniCS or Firedrake backends)
+    mpi4py
+    petsc4py (FEniCS or Firedrake backends)
 
 tlm_adjoint optionally requires
 

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -599,8 +599,6 @@ Keys for the \texttt{solver\_parameters} argument are based on the
     initial guess (default true).
   \item \texttt{adjoint\_nonzero\_initial\_guess}, a logical, whether to use a
     non-zero initial guess for an adjoint solve (default true).
-  \item \texttt{report}, a logical, whether to display output during fixed
-    point iteration (default false).
 \end{itemize}
 
 \subsection{Built-in \texttt{Equation} classes: FEniCS and Firedrake}
@@ -2180,8 +2178,6 @@ allocation). Keys for \texttt{cp\_parameters} for this method are
     checkpoints to store in memory (default $0$).
   \item \texttt{snaps\_on\_disk}, non-negative integer, the number of
     checkpoints to store on disk (default $0$).
-  \item \texttt{verbose}, logical, whether to enable increased verbosity
-    (default false).
 \end{itemize}
 The method name, and the latter three keys for \texttt{cp\_parameters}, are
 based upon the configuration of multistage checkpointing in dolfin-adjoint
@@ -2380,7 +2376,7 @@ def configure_checkpointing(cp_method, cp_parameters={}, manager=None):
 Calls \texttt{EquationManager.configure\_checkpointing}. See section
 \ref{sect:configure_checkpointing}.
 \begin{lstlisting}
-def manager_info(info=info, manager=None):
+def manager_info(info=print, manager=None):
 \end{lstlisting}
 Calls \texttt{EquationManager.info}. Displays information about the currently
 active equation manager, using the function \texttt{info} to display strings.

--- a/examples/numpy/diffusion/diffusion.py
+++ b/examples/numpy/diffusion/diffusion.py
@@ -253,9 +253,9 @@ start_manager()
 J = forward(psi_0, kappa)
 stop_manager()
 
-info(f"J = {J.value():.16e}")
-info(f"Reference J = {J_ref.value():.16e}")
-info(f"Error norm = {abs(J_ref.value() - J.value()):.16e}")
+print(f"J = {J.value():.16e}")
+print(f"Reference J = {J_ref.value():.16e}")
+print(f"Error norm = {abs(J_ref.value() - J.value()):.16e}")
 assert abs(J_ref.value() - J.value()) < 1.0e-14
 
 dJ_dpsi_0, dJ_dkappa = compute_gradient(J, [psi_0, kappa])

--- a/python/tlm_adjoint/base_caches.py
+++ b/python/tlm_adjoint/base_caches.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# For tlm_adjoint copyright information see ACKNOWLEDGEMENTS in the tlm_adjoint
+# root directory
+
+# This file is part of tlm_adjoint.
+#
+# tlm_adjoint is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# tlm_adjoint is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+from .interface import function_caches, function_id
+
+from .alias import gc_disabled
+
+import weakref
+
+__all__ = \
+    [
+        "Cache",
+        "CacheException",
+        "CacheRef",
+        "clear_caches"
+    ]
+
+
+class CacheException(Exception):
+    pass
+
+
+class CacheRef:
+    def __init__(self, value=None):
+        self._value = value
+
+    def __call__(self):
+        return self._value
+
+    def _clear(self):
+        self._value = None
+
+
+@gc_disabled
+def clear_caches(*deps):
+    if len(deps) == 0:
+        for cache in tuple(Cache._caches.valuerefs()):
+            cache = cache()
+            if cache is not None:
+                cache.clear()
+    else:
+        for dep in deps:
+            function_caches(dep).clear()
+
+
+class Cache:
+    _id_counter = [0]
+    _caches = weakref.WeakValueDictionary()
+
+    def __init__(self):
+        self._cache = {}
+        self._deps_map = {}
+        self._dep_caches = {}
+
+        self._id = self._id_counter[0]
+        self._id_counter[0] += 1
+        self._caches[self._id] = self
+
+    def __del__(self):
+        for value in self._cache.values():
+            value._clear()
+
+    def __len__(self):
+        return len(self._cache)
+
+    def id(self):
+        return self._id
+
+    def clear(self, *deps):
+        if len(deps) == 0:
+            for value in self._cache.values():
+                value._clear()
+            self._cache.clear()
+            self._deps_map.clear()
+            for dep_caches in self._dep_caches.values():
+                dep_caches = dep_caches()
+                if dep_caches is not None:
+                    dep_caches.remove(self)
+            self._dep_caches.clear()
+        else:
+            for dep in deps:
+                dep_id = dep if isinstance(dep, int) else function_id(dep)
+                del dep
+                if dep_id in self._deps_map:
+                    # We keep a record of:
+                    #   - Cache entries associated with each dependency. The
+                    #     cache keys are in self._deps_map[dep_id].keys(), and
+                    #     the cache entries in self._cache[key].
+                    #   - Dependencies associated with each cache entry. The
+                    #     dependency ids are in self._deps_map[dep_id2][key]
+                    #     for *each* dependency associated with the cache
+                    #     entry.
+                    #   - The caches in which dependencies have an associated
+                    #     cache entry. A (weak) reference to the caches is in
+                    #     self._dep_caches[dep_id2].
+                    # To remove a cache item associated with a dependency with
+                    # dependency id dep_id we
+                    #   1. Clear the cache entries associated with the
+                    #      dependency. These are given by self._cache[key] for
+                    #      each key in self._deps_map[dep_id].keys().
+                    #   2. Remove the dependency ids associated with each cache
+                    #      entry. These are given by
+                    #      self._deps_map[dep_id2][key] for each dep_id2 in
+                    #      self._deps_map[dep_id][key].
+                    #  3.  Remove the (weak) reference to this cache for each
+                    #      dependency with no further associated cache entries
+                    #      in this cache.
+                    for key, dep_ids in self._deps_map[dep_id].items():
+                        # Step 1.
+                        self._cache[key]._clear()
+                        del self._cache[key]
+                        for dep_id2 in dep_ids:
+                            if dep_id2 != dep_id:
+                                # Step 2.
+                                del self._deps_map[dep_id2][key]
+                                if len(self._deps_map[dep_id2]) == 0:
+                                    del self._deps_map[dep_id2]
+                                    dep_caches = self._dep_caches[dep_id2]()
+                                    if dep_caches is not None:
+                                        # Step 3.
+                                        dep_caches.remove(self)
+                                    del self._dep_caches[dep_id2]
+                    # Step 2.
+                    del self._deps_map[dep_id]
+                    dep_caches = self._dep_caches[dep_id]()
+                    if dep_caches is not None:
+                        # Step 3.
+                        dep_caches.remove(self)
+                    del self._dep_caches[dep_id]
+
+    def add(self, key, value, deps=[]):
+        if key in self._cache:
+            value_ref = self._cache[key]
+            value = value_ref()
+            if value is None:
+                raise CacheException("Unexpected cache value state")
+            return value_ref, value
+
+        value = value()
+        value_ref = CacheRef(value)
+        dep_ids = tuple(function_id(dep) for dep in deps)
+
+        self._cache[key] = value_ref
+
+        for dep, dep_id in zip(deps, dep_ids):
+            dep_caches = function_caches(dep)
+            dep_caches.add(self)
+
+            if dep_id in self._deps_map:
+                self._deps_map[dep_id][key] = dep_ids
+                assert dep_id in self._dep_caches
+            else:
+                self._deps_map[dep_id] = {key: dep_ids}
+                self._dep_caches[dep_id] = weakref.ref(dep_caches)
+
+        return value_ref, value
+
+    def get(self, key, default=None):
+        return self._cache.get(key, default)

--- a/python/tlm_adjoint/base_equations.py
+++ b/python/tlm_adjoint/base_equations.py
@@ -24,13 +24,13 @@ from .interface import function_assign, function_axpy, function_copy, \
     function_replacement, function_set_values, function_space, function_sum, \
     function_update_caches, function_update_state, function_zero, \
     is_function, space_new
-from .backend_interface import copy_parameters_dict, \
-    finalize_adjoint_derivative_action, info, \
+from .backend_interface import finalize_adjoint_derivative_action, info, \
     subtract_adjoint_derivative_action
 
 from .alias import WeakAlias, gc_disabled
 from .manager import manager as _manager
 
+import copy
 import inspect
 import numpy as np
 import warnings
@@ -871,7 +871,7 @@ class FixedPointSolver(Equation):
                     raise EquationException("Duplicate solve")
                 X_ids.add(x_id)
 
-        solver_parameters = copy_parameters_dict(solver_parameters)
+        solver_parameters = copy.deepcopy(solver_parameters)
         if "nonzero_adjoint_initial_guess" in solver_parameters:
             warnings.warn("'nonzero_adjoint_initial_guess' parameter is "
                           "deprecated -- use 'adjoint_nonzero_initial_guess' "

--- a/python/tlm_adjoint/base_equations.py
+++ b/python/tlm_adjoint/base_equations.py
@@ -18,7 +18,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import function_assign, function_axpy, function_copy, \
+    function_get_values, function_global_size, function_id, function_inner, \
+    function_is_checkpointed, function_local_indices, function_new, \
+    function_replacement, function_set_values, function_space, function_sum, \
+    function_update_caches, function_update_state, function_zero, \
+    is_function, space_new
+from .backend_interface import copy_parameters_dict, \
+    finalize_adjoint_derivative_action, info, \
+    subtract_adjoint_derivative_action
 
 from .alias import WeakAlias, gc_disabled
 from .manager import manager as _manager

--- a/python/tlm_adjoint/base_equations.py
+++ b/python/tlm_adjoint/base_equations.py
@@ -25,13 +25,13 @@ from .interface import finalize_adjoint_derivative_action, function_assign, \
     function_set_values, function_space, function_sum, \
     function_update_caches, function_update_state, function_zero, \
     is_function, space_new, subtract_adjoint_derivative_action
-from .backend_interface import info
 
 from .alias import WeakAlias, gc_disabled
 from .manager import manager as _manager
 
 import copy
 import inspect
+import logging
 import numpy as np
 import warnings
 import weakref
@@ -859,8 +859,6 @@ class FixedPointSolver(Equation):
                 adjoint_nonzero_initial_guess
                     Whether to use a non-zero initial guess for the adjoint
                     solve. Logical, optional, default True.
-                report
-                    Whether to display output. Optional, default False.
         """
 
         X_ids = set()
@@ -887,8 +885,7 @@ class FixedPointSolver(Equation):
         # Based on KrylovSolver parameters in FEniCS 2017.2.0
         for key, default_value in [("maximum_iterations", 1000),
                                    ("nonzero_initial_guess", True),
-                                   ("adjoint_nonzero_initial_guess", True),
-                                   ("report", False)]:
+                                   ("adjoint_nonzero_initial_guess", True)]:
             if key not in solver_parameters:
                 solver_parameters[key] = default_value
 
@@ -1041,7 +1038,7 @@ class FixedPointSolver(Equation):
         maximum_iterations = self._solver_parameters["maximum_iterations"]
         nonzero_initial_guess = \
             self._solver_parameters["nonzero_initial_guess"]
-        report = self._solver_parameters["report"]
+        logger = logging.getLogger("tlm_adjoint.FixedPointSolver")
 
         eq_X = tuple(tuple(X[j] for j in self._eq_X_indices[i])
                      for i in range(len(self._eqs)))
@@ -1079,10 +1076,11 @@ class FixedPointSolver(Equation):
                     X_norm_sq += function_inner(x, x)
                 tolerance_sq = max(absolute_tolerance ** 2,
                                    X_norm_sq * (relative_tolerance ** 2))
-            if report:
-                info(f"Fixed point iteration, forward iteration {it:d}, "
-                     f"change norm {np.sqrt(R_norm_sq):.16e} "
-                     f"(tolerance {np.sqrt(tolerance_sq):.16e})")
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f"Fixed point iteration, "
+                             f"forward iteration {it:d}, "
+                             f"change norm {np.sqrt(R_norm_sq):.16e} "
+                             f"(tolerance {np.sqrt(tolerance_sq):.16e})")
             if np.isnan(R_norm_sq):
                 raise EquationException(
                     f"Fixed point iteration, forward iteration {it:d}, "
@@ -1133,7 +1131,7 @@ class FixedPointSolver(Equation):
         relative_tolerance = self._solver_parameters["relative_tolerance"]
         maximum_iterations = self._solver_parameters["maximum_iterations"]
         nonzero_initial_guess = self._solver_parameters["adjoint_nonzero_initial_guess"]  # noqa: E501
-        report = self._solver_parameters["report"]
+        logger = logging.getLogger("tlm_adjoint.FixedPointSolver")
 
         eq_adj_X = [tuple(adj_X[j] for j in self._eq_X_indices[i])
                     for i in range(len(self._eqs))]
@@ -1207,10 +1205,11 @@ class FixedPointSolver(Equation):
                     X_norm_sq += function_inner(x, x)
                 tolerance_sq = max(absolute_tolerance ** 2,
                                    X_norm_sq * (relative_tolerance ** 2))
-            if report:
-                info(f"Fixed point iteration, adjoint iteration {it:d}, "
-                     f"change norm {np.sqrt(R_norm_sq):.16e} "
-                     f"(tolerance {np.sqrt(tolerance_sq):.16e})")
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f"Fixed point iteration, "
+                             f"adjoint iteration {it:d}, "
+                             f"change norm {np.sqrt(R_norm_sq):.16e} "
+                             f"(tolerance {np.sqrt(tolerance_sq):.16e})")
             if np.isnan(R_norm_sq):
                 raise EquationException(
                     f"Fixed point iteration, adjoint iteration {it:d}, "

--- a/python/tlm_adjoint/base_equations.py
+++ b/python/tlm_adjoint/base_equations.py
@@ -18,14 +18,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import function_assign, function_axpy, function_copy, \
-    function_get_values, function_global_size, function_id, function_inner, \
-    function_is_checkpointed, function_local_indices, function_new, \
-    function_replacement, function_set_values, function_space, function_sum, \
+from .interface import finalize_adjoint_derivative_action, function_assign, \
+    function_axpy, function_copy, function_get_values, function_global_size, \
+    function_id, function_inner, function_is_checkpointed, \
+    function_local_indices, function_new, function_replacement, \
+    function_set_values, function_space, function_sum, \
     function_update_caches, function_update_state, function_zero, \
-    is_function, space_new
-from .backend_interface import finalize_adjoint_derivative_action, info, \
-    subtract_adjoint_derivative_action
+    is_function, space_new, subtract_adjoint_derivative_action
+from .backend_interface import info
 
 from .alias import WeakAlias, gc_disabled
 from .manager import manager as _manager

--- a/python/tlm_adjoint/caches.py
+++ b/python/tlm_adjoint/caches.py
@@ -18,9 +18,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .backend_code_generator_interface import *
-from .interface import *
+from .backend import TrialFunction, backend_Function
+from .interface import function_id, function_is_cached, function_space, \
+    is_function
+from .backend_code_generator_interface import assemble, assemble_arguments, \
+    assemble_matrix, linear_solver, matrix_copy, parameters_key
 
 from .alias import gc_disabled
 from .functions import eliminate_zeros, function_caches, replaced_form

--- a/python/tlm_adjoint/caches.py
+++ b/python/tlm_adjoint/caches.py
@@ -24,20 +24,16 @@ from .interface import function_id, function_is_cached, function_space, \
 from .backend_code_generator_interface import assemble, assemble_arguments, \
     assemble_matrix, linear_solver, matrix_copy, parameters_key
 
-from .alias import gc_disabled
-from .functions import eliminate_zeros, function_caches, replaced_form
+from .base_caches import Cache, CacheException
+from .functions import eliminate_zeros, replaced_form
 
 from collections import defaultdict
 import ufl
 import warnings
-import weakref
 
 __all__ = \
     [
         "AssemblyCache",
-        "Cache",
-        "CacheException",
-        "CacheRef",
         "LinearSolverCache",
         "assembly_cache",
         "form_dependencies",
@@ -49,10 +45,6 @@ __all__ = \
         "set_linear_solver_cache",
         "split_form"
     ]
-
-
-class CacheException(Exception):
-    pass
 
 
 def is_cached(e):
@@ -234,145 +226,6 @@ def split_form(form):
     non_cached_forms = ufl.classes.Form(non_cached_integrals)
 
     return cached_form, mat_forms, non_cached_forms
-
-
-class CacheRef:
-    def __init__(self, value=None):
-        self._value = value
-
-    def __call__(self):
-        return self._value
-
-    def _clear(self):
-        self._value = None
-
-
-@gc_disabled
-def clear_caches(*deps):
-    if len(deps) == 0:
-        for cache in tuple(Cache._caches.valuerefs()):
-            cache = cache()
-            if cache is not None:
-                cache.clear()
-    else:
-        for dep in deps:
-            function_caches(dep).clear()
-
-
-class Cache:
-    _id_counter = [0]
-    _caches = weakref.WeakValueDictionary()
-
-    def __init__(self):
-        self._cache = {}
-        self._deps_map = {}
-        self._dep_caches = {}
-
-        self._id = self._id_counter[0]
-        self._id_counter[0] += 1
-        self._caches[self._id] = self
-
-    def __del__(self):
-        for value in self._cache.values():
-            value._clear()
-
-    def __len__(self):
-        return len(self._cache)
-
-    def id(self):
-        return self._id
-
-    def clear(self, *deps):
-        if len(deps) == 0:
-            for value in self._cache.values():
-                value._clear()
-            self._cache.clear()
-            self._deps_map.clear()
-            for dep_caches in self._dep_caches.values():
-                dep_caches = dep_caches()
-                if dep_caches is not None:
-                    dep_caches.remove(self)
-            self._dep_caches.clear()
-        else:
-            for dep in deps:
-                dep_id = dep if isinstance(dep, int) else function_id(dep)
-                del dep
-                if dep_id in self._deps_map:
-                    # We keep a record of:
-                    #   - Cache entries associated with each dependency. The
-                    #     cache keys are in self._deps_map[dep_id].keys(), and
-                    #     the cache entries in self._cache[key].
-                    #   - Dependencies associated with each cache entry. The
-                    #     dependency ids are in self._deps_map[dep_id2][key]
-                    #     for *each* dependency associated with the cache
-                    #     entry.
-                    #   - The caches in which dependencies have an associated
-                    #     cache entry. A (weak) reference to the caches is in
-                    #     self._dep_caches[dep_id2].
-                    # To remove a cache item associated with a dependency with
-                    # dependency id dep_id we
-                    #   1. Clear the cache entries associated with the
-                    #      dependency. These are given by self._cache[key] for
-                    #      each key in self._deps_map[dep_id].keys().
-                    #   2. Remove the dependency ids associated with each cache
-                    #      entry. These are given by
-                    #      self._deps_map[dep_id2][key] for each dep_id2 in
-                    #      self._deps_map[dep_id][key].
-                    #  3.  Remove the (weak) reference to this cache for each
-                    #      dependency with no further associated cache entries
-                    #      in this cache.
-                    for key, dep_ids in self._deps_map[dep_id].items():
-                        # Step 1.
-                        self._cache[key]._clear()
-                        del self._cache[key]
-                        for dep_id2 in dep_ids:
-                            if dep_id2 != dep_id:
-                                # Step 2.
-                                del self._deps_map[dep_id2][key]
-                                if len(self._deps_map[dep_id2]) == 0:
-                                    del self._deps_map[dep_id2]
-                                    dep_caches = self._dep_caches[dep_id2]()
-                                    if dep_caches is not None:
-                                        # Step 3.
-                                        dep_caches.remove(self)
-                                    del self._dep_caches[dep_id2]
-                    # Step 2.
-                    del self._deps_map[dep_id]
-                    dep_caches = self._dep_caches[dep_id]()
-                    if dep_caches is not None:
-                        # Step 3.
-                        dep_caches.remove(self)
-                    del self._dep_caches[dep_id]
-
-    def add(self, key, value, deps=[]):
-        if key in self._cache:
-            value_ref = self._cache[key]
-            value = value_ref()
-            if value is None:
-                raise CacheException("Unexpected cache value state")
-            return value_ref, value
-
-        value = value()
-        value_ref = CacheRef(value)
-        dep_ids = tuple(function_id(dep) for dep in deps)
-
-        self._cache[key] = value_ref
-
-        for dep, dep_id in zip(deps, dep_ids):
-            dep_caches = function_caches(dep)
-            dep_caches.add(self)
-
-            if dep_id in self._deps_map:
-                self._deps_map[dep_id][key] = dep_ids
-                assert dep_id in self._dep_caches
-            else:
-                self._deps_map[dep_id] = {key: dep_ids}
-                self._dep_caches[dep_id] = weakref.ref(dep_caches)
-
-        return value_ref, value
-
-    def get(self, key, default=None):
-        return self._cache.get(key, default)
 
 
 def form_dependencies(form):

--- a/python/tlm_adjoint/eigendecomposition.py
+++ b/python/tlm_adjoint/eigendecomposition.py
@@ -55,7 +55,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .backend_interface import *
+from .interface import function_get_values, function_global_size, \
+    function_local_size, function_set_values, is_function, space_comm, \
+    space_new
 
 import numpy as np
 import petsc4py.PETSc as PETSc

--- a/python/tlm_adjoint/equations.py
+++ b/python/tlm_adjoint/equations.py
@@ -18,9 +18,19 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .backend_code_generator_interface import *
-from .backend_interface import *
+from .backend import TestFunction, TrialFunction, adjoint, \
+    backend_DirichletBC, backend_Function, backend_FunctionSpace, parameters
+from .interface import function_assign, function_comm, function_get_values, \
+    function_id, function_local_size, function_new, function_replacement, \
+    function_set_values, function_space, function_update_caches, \
+    function_update_state, function_zero, is_function
+from .backend_interface import is_real_function, real_function_value
+from .backend_code_generator_interface import assemble, \
+    assemble_linear_solver, copy_parameters_dict, \
+    form_form_compiler_parameters, function_vector, homogenize, \
+    matrix_multiply, process_adjoint_solver_parameters, \
+    process_solver_parameters, r0_space, rhs_addto, rhs_copy, solve, \
+    update_parameters_dict
 
 from .base_equations import AssignmentSolver, Equation, EquationException, \
     NullSolver, get_tangent_linear, no_replace_compatibility

--- a/python/tlm_adjoint/equations.py
+++ b/python/tlm_adjoint/equations.py
@@ -23,8 +23,8 @@ from .backend import TestFunction, TrialFunction, adjoint, \
 from .interface import function_assign, function_comm, function_get_values, \
     function_id, function_local_size, function_new, function_replacement, \
     function_set_values, function_space, function_update_caches, \
-    function_update_state, function_zero, is_function
-from .backend_interface import is_real_function, real_function_value
+    function_update_state, function_zero, is_function, is_real_function, \
+    real_function_value
 from .backend_code_generator_interface import assemble, \
     assemble_linear_solver, copy_parameters_dict, \
     form_form_compiler_parameters, function_vector, homogenize, \

--- a/python/tlm_adjoint/equations.py
+++ b/python/tlm_adjoint/equations.py
@@ -30,12 +30,12 @@ from .backend_code_generator_interface import assemble, \
     form_form_compiler_parameters, function_vector, homogenize, \
     matrix_multiply, process_adjoint_solver_parameters, \
     process_solver_parameters, r0_space, rhs_addto, rhs_copy, solve, \
-    update_parameters_dict
+    update_parameters_dict, verify_assembly
 
 from .base_equations import AssignmentSolver, Equation, EquationException, \
     NullSolver, get_tangent_linear, no_replace_compatibility
 from .caches import CacheRef, assembly_cache, form_neg, is_cached, \
-    linear_solver_cache, split_form, verify_assembly
+    linear_solver_cache, split_form
 from .functions import bcs_is_cached, bcs_is_homogeneous, bcs_is_static, \
     eliminate_zeros, extract_coefficients, is_r0_function
 

--- a/python/tlm_adjoint/equations.py
+++ b/python/tlm_adjoint/equations.py
@@ -32,10 +32,11 @@ from .backend_code_generator_interface import assemble, \
     process_solver_parameters, r0_space, rhs_addto, rhs_copy, solve, \
     update_parameters_dict, verify_assembly
 
+from .base_caches import CacheRef
 from .base_equations import AssignmentSolver, Equation, EquationException, \
     NullSolver, get_tangent_linear, no_replace_compatibility
-from .caches import CacheRef, assembly_cache, form_neg, is_cached, \
-    linear_solver_cache, split_form
+from .caches import assembly_cache, form_neg, is_cached, linear_solver_cache, \
+    split_form
 from .functions import bcs_is_cached, bcs_is_homogeneous, bcs_is_static, \
     eliminate_zeros, extract_coefficients, is_r0_function
 

--- a/python/tlm_adjoint/functional.py
+++ b/python/tlm_adjoint/functional.py
@@ -19,9 +19,8 @@
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
 from .interface import function_name, function_new, function_space, \
-    is_function, space_id, space_new
-from .backend_interface import is_real_function, new_real_function, \
-    real_function_value
+    is_function, is_real_function, real_function_value, space_id, space_new
+from .backend_interface import new_real_function
 
 from .base_equations import AssignmentSolver, AxpySolver
 try:

--- a/python/tlm_adjoint/functional.py
+++ b/python/tlm_adjoint/functional.py
@@ -19,8 +19,8 @@
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
 from .interface import function_name, function_new, function_space, \
-    is_function, is_real_function, real_function_value, space_id, space_new
-from .backend_interface import new_real_function
+    is_function, is_real_function, new_real_function, real_function_value, \
+    space_id, space_new
 
 from .base_equations import AssignmentSolver, AxpySolver
 try:

--- a/python/tlm_adjoint/functional.py
+++ b/python/tlm_adjoint/functional.py
@@ -18,7 +18,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import function_name, function_new, function_space, \
+    is_function, space_id, space_new
+from .backend_interface import is_real_function, new_real_function, \
+    real_function_value
 
 from .base_equations import AssignmentSolver, AxpySolver
 try:

--- a/python/tlm_adjoint/functions.py
+++ b/python/tlm_adjoint/functions.py
@@ -309,6 +309,9 @@ class ConstantInterface(_FunctionInterface):
                 Replacement(self, space=None)
         return self._tlm_adjoint__replacement
 
+    def _is_replacement(self):
+        return False
+
     def _is_real(self):
         return is_r0_function(self) and len(self.ufl_shape) == 0
 
@@ -617,6 +620,9 @@ class ReplacementInterface(_FunctionInterface):
 
     def _replacement(self):
         return self
+
+    def _is_replacement(self):
+        return True
 
     def _is_real(self):
         return is_r0_function(self) and len(self.ufl_shape) == 0

--- a/python/tlm_adjoint/functions.py
+++ b/python/tlm_adjoint/functions.py
@@ -18,8 +18,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .interface import *
+from .backend import backend_Constant, backend_DirichletBC, backend_Function, \
+    backend_ScalarType
+from .interface import InterfaceException, SpaceInterface, function_caches, \
+    function_comm, function_id, function_is_cached, function_is_checkpointed, \
+    function_is_static, function_name, function_new, function_replacement, \
+    function_space, function_state, add_interface, is_function, space_comm, \
+    space_new
 from .interface import FunctionInterface as _FunctionInterface
 
 from .alias import gc_disabled

--- a/python/tlm_adjoint/functions.py
+++ b/python/tlm_adjoint/functions.py
@@ -309,6 +309,9 @@ class ConstantInterface(_FunctionInterface):
                 Replacement(self, space=None)
         return self._tlm_adjoint__replacement
 
+    def _is_real(self):
+        return is_r0_function(self) and len(self.ufl_shape) == 0
+
 
 class Constant(backend_Constant):
     def __init__(self, value=None, *args, name=None, domain=None, space=None,
@@ -614,6 +617,9 @@ class ReplacementInterface(_FunctionInterface):
 
     def _replacement(self):
         return self
+
+    def _is_real(self):
+        return is_r0_function(self) and len(self.ufl_shape) == 0
 
 
 class Replacement(ufl.classes.Coefficient):

--- a/python/tlm_adjoint/hessian.py
+++ b/python/tlm_adjoint/hessian.py
@@ -21,8 +21,8 @@
 from .interface import function_copy, function_get_values, \
     function_is_cached, function_is_checkpointed, function_is_static, \
     function_name
-from .backend_interface import clear_caches
 
+from .base_caches import clear_caches
 from .manager import manager as _manager, set_manager
 
 __all__ = \

--- a/python/tlm_adjoint/hessian.py
+++ b/python/tlm_adjoint/hessian.py
@@ -18,7 +18,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import function_copy, function_get_values, \
+    function_is_cached, function_is_checkpointed, function_is_static, \
+    function_name
+from .backend_interface import clear_caches
 
 from .manager import manager as _manager, set_manager
 

--- a/python/tlm_adjoint/hessian_optimization.py
+++ b/python/tlm_adjoint/hessian_optimization.py
@@ -18,7 +18,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import function_id
+from .backend_interface import clear_caches
 
 from .hessian import Hessian, HessianException
 from .manager import manager as _manager

--- a/python/tlm_adjoint/hessian_optimization.py
+++ b/python/tlm_adjoint/hessian_optimization.py
@@ -19,8 +19,8 @@
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
 from .interface import function_id
-from .backend_interface import clear_caches
 
+from .base_caches import clear_caches
 from .hessian import Hessian, HessianException
 from .manager import manager as _manager
 from .tlm_adjoint import CheckpointStorage

--- a/python/tlm_adjoint/interface.py
+++ b/python/tlm_adjoint/interface.py
@@ -19,6 +19,8 @@
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
 import copy
+import logging
+import sys
 import types
 
 __all__ = \
@@ -415,3 +417,10 @@ def add_finalize_adjoint_derivative_action(backend, fn):
 def finalize_adjoint_derivative_action(x):
     for fn in _finalize_adjoint_derivative_action.values():
         fn(x)
+
+
+_logger = logging.getLogger("tlm_adjoint")
+_handler = logging.StreamHandler(stream=sys.stdout)
+_handler.setFormatter(logging.Formatter(fmt="%(message)s"))
+_logger.addHandler(_handler)
+_logger.setLevel(logging.INFO)

--- a/python/tlm_adjoint/interface.py
+++ b/python/tlm_adjoint/interface.py
@@ -61,7 +61,10 @@ __all__ = \
         "function_tangent_linear",
         "function_update_caches",
         "function_update_state",
-        "function_zero"
+        "function_zero",
+
+        "is_real_function",
+        "real_function_value"
     ]
 
 
@@ -126,7 +129,7 @@ class FunctionInterface:
              "_update_caches", "_zero", "_assign", "_axpy", "_inner",
              "_max_value", "_sum", "_linf_norm", "_local_size", "_global_size",
              "_local_indices", "_get_values", "_set_values", "_new", "_copy",
-             "_tangent_linear", "_replacement")
+             "_tangent_linear", "_replacement", "_is_real")
 
     def __init__(self):
         raise InterfaceException("Cannot instantiate FunctionInterface object")
@@ -210,6 +213,9 @@ class FunctionInterface:
         raise InterfaceException("Method not overridden")
 
     def _replacement(self):
+        raise InterfaceException("Method not overridden")
+
+    def _is_real(self):
         raise InterfaceException("Method not overridden")
 
 
@@ -335,3 +341,13 @@ def function_tangent_linear(x, name=None):
 
 def function_replacement(x):
     return x._tlm_adjoint__function_interface_replacement()
+
+
+def is_real_function(x):
+    return x._tlm_adjoint__function_interface_is_real()
+
+
+def real_function_value(x):
+    if not is_real_function(x):
+        raise InterfaceException("Invalid function")
+    return function_max_value(x)

--- a/python/tlm_adjoint/interface.py
+++ b/python/tlm_adjoint/interface.py
@@ -46,6 +46,7 @@ __all__ = \
         "function_inner",
         "function_is_cached",
         "function_is_checkpointed",
+        "function_is_replacement",
         "function_is_static",
         "function_linf_norm",
         "function_local_indices",
@@ -133,7 +134,7 @@ class FunctionInterface:
              "_update_caches", "_zero", "_assign", "_axpy", "_inner",
              "_max_value", "_sum", "_linf_norm", "_local_size", "_global_size",
              "_local_indices", "_get_values", "_set_values", "_new", "_copy",
-             "_tangent_linear", "_replacement", "_is_real")
+             "_tangent_linear", "_replacement", "_is_replacement", "_is_real")
 
     def __init__(self):
         raise InterfaceException("Cannot instantiate FunctionInterface object")
@@ -217,6 +218,9 @@ class FunctionInterface:
         raise InterfaceException("Method not overridden")
 
     def _replacement(self):
+        raise InterfaceException("Method not overridden")
+
+    def _is_replacement(self):
         raise InterfaceException("Method not overridden")
 
     def _is_real(self):
@@ -345,6 +349,10 @@ def function_tangent_linear(x, name=None):
 
 def function_replacement(x):
     return x._tlm_adjoint__function_interface_replacement()
+
+
+def function_is_replacement(x):
+    return x._tlm_adjoint__function_interface_is_replacement()
 
 
 def is_real_function(x):

--- a/python/tlm_adjoint/interface.py
+++ b/python/tlm_adjoint/interface.py
@@ -64,6 +64,7 @@ __all__ = \
         "function_zero",
 
         "is_real_function",
+        "new_real_function",
         "real_function_value"
     ]
 
@@ -345,6 +346,17 @@ def function_replacement(x):
 
 def is_real_function(x):
     return x._tlm_adjoint__function_interface_is_real()
+
+
+_new_real_function = [None]
+
+
+def new_real_function(name=None, comm=None, static=False, cache=None,
+                      checkpoint=None):
+    if _new_real_function[0] is None:
+        raise InterfaceException("No backend")
+    return _new_real_function[0](name=name, comm=comm, static=static,
+                                 cache=cache, checkpoint=checkpoint)
 
 
 def real_function_value(x):

--- a/python/tlm_adjoint/optimization.py
+++ b/python/tlm_adjoint/optimization.py
@@ -18,7 +18,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import function_axpy, function_copy, function_get_values, \
+    function_is_cached, function_is_checkpointed, function_is_static, \
+    function_linf_norm, function_local_size, function_new, \
+    function_set_values, is_function
+from .backend_interface import clear_caches
 
 from .manager import manager as _manager, set_manager
 

--- a/python/tlm_adjoint/optimization.py
+++ b/python/tlm_adjoint/optimization.py
@@ -22,8 +22,8 @@ from .interface import function_axpy, function_copy, function_get_values, \
     function_is_cached, function_is_checkpointed, function_is_static, \
     function_linf_norm, function_local_size, function_new, \
     function_set_values, is_function
-from .backend_interface import clear_caches
 
+from .base_caches import clear_caches
 from .manager import manager as _manager, set_manager
 
 import numpy as np

--- a/python/tlm_adjoint/timestepping.py
+++ b/python/tlm_adjoint/timestepping.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import function_id, is_function, space_new
 
 from .alias import Alias
 from .base_equations import AssignmentSolver, Equation
@@ -161,11 +161,11 @@ class TimeLevels:
 
 
 class TimeFunction:
-    def __init__(self, levels, *args, cls=Function, **kwargs):
+    def __init__(self, levels, space, name=None):
         # Note that this keeps references to the functions on each time level
         self._fns = {}
         for level in levels:
-            fn = cls(*args, **kwargs)
+            fn = space_new(space, name=name)
             fn._tlm_adjoint__tfn = self
             fn._tlm_adjoint__level = level
             self._fns[level] = fn

--- a/python/tlm_adjoint/tlm_adjoint.py
+++ b/python/tlm_adjoint/tlm_adjoint.py
@@ -22,8 +22,7 @@ from .interface import function_assign, function_copy, function_get_values, \
     function_global_size, function_id, function_is_checkpointed, \
     function_local_indices, function_name, function_new, function_set_values, \
     function_space, function_tangent_linear, is_function, space_id, space_new
-from .backend_interface import Replacement, copy_parameters_dict, \
-    default_comm, info
+from .backend_interface import Replacement, copy_parameters_dict, info
 
 from .alias import WeakAlias, gc_disabled
 from .base_equations import AdjointModelRHS, ControlsMarker, Equation, \
@@ -35,6 +34,7 @@ from .manager import manager as _manager, set_manager
 from collections import OrderedDict, defaultdict, deque
 import copy
 import gc
+import mpi4py.MPI as MPI
 import numpy as np
 import pickle
 import os
@@ -509,7 +509,7 @@ class EquationManager:
         Manager for tangent-linear and adjoint models.
 
         Arguments:
-        comm  (Optional) Communicator. Default default_comm().
+        comm  (Optional) Communicator. Default mpi4py.MPI.COMM_WORLD.
 
         cp_method  (Optional) Checkpointing method. Default "memory".
             Possible methods
@@ -567,7 +567,7 @@ class EquationManager:
         # dolfin-adjoint 2017.1.0
 
         if comm is None:
-            comm = default_comm()
+            comm = MPI.COMM_WORLD
         comm = comm.Dup()
 
         self._comm = comm

--- a/python/tlm_adjoint/tlm_adjoint.py
+++ b/python/tlm_adjoint/tlm_adjoint.py
@@ -20,9 +20,10 @@
 
 from .interface import function_assign, function_copy, function_get_values, \
     function_global_size, function_id, function_is_checkpointed, \
-    function_local_indices, function_name, function_new, function_set_values, \
-    function_space, function_tangent_linear, is_function, space_id, space_new
-from .backend_interface import Replacement, info
+    function_is_replacement, function_local_indices, function_name, \
+    function_new, function_set_values, function_space, \
+    function_tangent_linear, is_function, space_id, space_new
+from .backend_interface import info
 
 from .alias import WeakAlias, gc_disabled
 from .base_equations import AdjointModelRHS, ControlsMarker, Equation, \
@@ -534,9 +535,8 @@ class EquationManager:
         cp_parameters  (Optional) Checkpointing parameters dictionary.
             Parameters for "memory" method
                 replace        Whether to automatically replace internal
-                               functions in the provided equations with
-                               Replacement objects. Logical, optional, default
-                               False.
+                               functions in the provided equations. Logical,
+                               optional, default False.
 
             Parameters for "periodic_disk" method
                 path           Directory in which disk checkpoint data should
@@ -641,7 +641,7 @@ class EquationManager:
                 for j, dep in enumerate(eq.dependencies()):
                     info("      Dependency %i, %s (id %i)%s, %s" %
                          (j, function_name(dep), function_id(dep),
-                          ", replaced" if isinstance(dep, Replacement) else "",  # noqa: E501
+                          ", replaced" if function_is_replacement(dep) else "",
                           "non-linear" if function_id(dep) in nl_dep_ids else "linear"))  # noqa: E501
         info("Storage:")
         info(f'  Storing initial conditions: {"yes" if self._cp.store_ics() else "no":s}')  # noqa: E501

--- a/python/tlm_adjoint/tlm_adjoint.py
+++ b/python/tlm_adjoint/tlm_adjoint.py
@@ -22,7 +22,7 @@ from .interface import function_assign, function_copy, function_get_values, \
     function_global_size, function_id, function_is_checkpointed, \
     function_local_indices, function_name, function_new, function_set_values, \
     function_space, function_tangent_linear, is_function, space_id, space_new
-from .backend_interface import Replacement, copy_parameters_dict, info
+from .backend_interface import Replacement, info
 
 from .alias import WeakAlias, gc_disabled
 from .base_equations import AdjointModelRHS, ControlsMarker, Equation, \
@@ -709,7 +709,7 @@ class EquationManager:
         if self._annotation_state not in ["initial", "stopped_initial"]:
             raise ManagerException("Cannot configure checkpointing after annotation has started, or after finalization")  # noqa: E501
 
-        cp_parameters = copy_parameters_dict(cp_parameters)
+        cp_parameters = copy.deepcopy(cp_parameters)
 
         if cp_method == "memory":
             disk_storage = False

--- a/python/tlm_adjoint/tlm_adjoint.py
+++ b/python/tlm_adjoint/tlm_adjoint.py
@@ -18,7 +18,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import function_assign, function_copy, function_get_values, \
+    function_global_size, function_id, function_is_checkpointed, \
+    function_local_indices, function_name, function_new, function_set_values, \
+    function_space, function_tangent_linear, is_function, space_id, space_new
+from .backend_interface import Replacement, copy_parameters_dict, \
+    default_comm, info
 
 from .alias import WeakAlias, gc_disabled
 from .base_equations import AdjointModelRHS, ControlsMarker, Equation, \

--- a/python/tlm_adjoint/verification.py
+++ b/python/tlm_adjoint/verification.py
@@ -18,7 +18,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import function_assign, function_axpy, function_copy, \
+    function_inner, function_is_cached, function_is_checkpointed, \
+    function_is_static, function_linf_norm, function_local_size, \
+    function_name, function_new, function_set_values, is_function
+from .backend_interface import clear_caches, info
 
 from .manager import manager as _manager, set_manager
 

--- a/python/tlm_adjoint/verification.py
+++ b/python/tlm_adjoint/verification.py
@@ -22,8 +22,9 @@ from .interface import function_assign, function_axpy, function_copy, \
     function_inner, function_is_cached, function_is_checkpointed, \
     function_is_static, function_linf_norm, function_local_size, \
     function_name, function_new, function_set_values, is_function
-from .backend_interface import clear_caches, info
+from .backend_interface import info
 
+from .base_caches import clear_caches
 from .manager import manager as _manager, set_manager
 
 import numpy as np

--- a/python/tlm_adjoint/verification.py
+++ b/python/tlm_adjoint/verification.py
@@ -22,11 +22,11 @@ from .interface import function_assign, function_axpy, function_copy, \
     function_inner, function_is_cached, function_is_checkpointed, \
     function_is_static, function_linf_norm, function_local_size, \
     function_name, function_new, function_set_values, is_function
-from .backend_interface import info
 
 from .base_caches import clear_caches
 from .manager import manager as _manager, set_manager
 
+import logging
 import numpy as np
 
 __all__ = \
@@ -84,6 +84,7 @@ def taylor_test(forward, M, J_val, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
         return taylor_test(forward, [M], J_val, dJ=dJ, ddJ=ddJ, seed=seed,
                            dM=dM, M0=M0, size=size, manager=manager)
 
+    logger = logging.getLogger("tlm_adjoint.verification")
     if manager is None:
         manager = _manager()
 
@@ -127,15 +128,15 @@ def taylor_test(forward, M, J_val, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
 
     error_norms_0 = abs(J_vals - J_val)
     orders_0 = np.log(error_norms_0[1:] / error_norms_0[:-1]) / np.log(0.5)
-    info(f"Error norms, no adjoint   = {error_norms_0}")
-    info(f"Orders,      no adjoint   = {orders_0}")
+    logger.info(f"Error norms, no adjoint   = {error_norms_0}")
+    logger.info(f"Orders,      no adjoint   = {orders_0}")
 
     if ddJ is None:
         error_norms_1 = abs(J_vals - J_val
                             - eps * functions_inner(dJ, dM))
         orders_1 = np.log(error_norms_1[1:] / error_norms_1[:-1]) / np.log(0.5)
-        info(f"Error norms, with adjoint = {error_norms_1}")
-        info(f"Orders,      with adjoint = {orders_1}")
+        logger.info(f"Error norms, with adjoint = {error_norms_1}")
+        logger.info(f"Orders,      with adjoint = {orders_1}")
         return orders_1.min()
     else:
         if dJ is None:
@@ -147,8 +148,8 @@ def taylor_test(forward, M, J_val, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
                             - eps * dJ
                             - 0.5 * eps * eps * functions_inner(ddJ, dM))
         orders_2 = np.log(error_norms_2[1:] / error_norms_2[:-1]) / np.log(0.5)
-        info(f"Error norms, with adjoint = {error_norms_2}")
-        info(f"Orders,      with adjoint = {orders_2}")
+        logger.info(f"Error norms, with adjoint = {error_norms_2}")
+        logger.info(f"Orders,      with adjoint = {orders_2}")
         return orders_2.min()
 
 
@@ -160,6 +161,7 @@ def taylor_test_tlm(forward, M, tlm_order, seed=1.0e-2, dMs=None, size=5,
         return taylor_test_tlm(forward, [M], tlm_order, seed=seed, dMs=dMs,
                                size=size, manager=manager)
 
+    logger = logging.getLogger("tlm_adjoint.verification")
     if manager is None:
         manager = _manager()
     tlm_manager = manager.new("memory", {})
@@ -222,13 +224,13 @@ def taylor_test_tlm(forward, M, tlm_order, seed=1.0e-2, dMs=None, size=5,
 
     error_norms_0 = abs(J_vals - J_val)
     orders_0 = np.log(error_norms_0[1:] / error_norms_0[:-1]) / np.log(0.5)
-    info(f"Error norms, no adjoint   = {error_norms_0}")
-    info(f"Orders,      no adjoint   = {orders_0}")
+    logger.info(f"Error norms, no adjoint   = {error_norms_0}")
+    logger.info(f"Orders,      no adjoint   = {orders_0}")
 
     error_norms_1 = abs(J_vals - J_val - eps * dJ)
     orders_1 = np.log(error_norms_1[1:] / error_norms_1[:-1]) / np.log(0.5)
-    info(f"Error norms, with adjoint = {error_norms_1}")
-    info(f"Orders,      with adjoint = {orders_1}")
+    logger.info(f"Error norms, with adjoint = {error_norms_1}")
+    logger.info(f"Orders,      with adjoint = {orders_1}")
     return orders_1.min()
 
 

--- a/python/tlm_adjoint_fenics/__init__.py
+++ b/python/tlm_adjoint_fenics/__init__.py
@@ -25,6 +25,7 @@ modules = [("backend", "tlm_adjoint_fenics"),
            ("functions", "tlm_adjoint"),
            ("interface", "tlm_adjoint"),
            ("backend_code_generator_interface", "tlm_adjoint_fenics"),
+           ("base_caches", "tlm_adjoint"),
            ("caches", "tlm_adjoint"),
            ("backend_interface", "tlm_adjoint_fenics"),
            ("base_equations", "tlm_adjoint"),
@@ -68,6 +69,7 @@ from .backend import backend       # noqa: E402,F401
 from .backend_code_generator_interface import copy_parameters_dict  # noqa: E402,E501,F401
 from .backend_interface import *   # noqa: E402,F401
 from .backend_overrides import *   # noqa: E402,F401
+from .base_caches import *         # noqa: E402,F401
 from .base_equations import *      # noqa: E402,F401
 from .caches import *              # noqa: E402,F401
 from .eigendecomposition import *  # noqa: E402,F401

--- a/python/tlm_adjoint_fenics/__init__.py
+++ b/python/tlm_adjoint_fenics/__init__.py
@@ -65,6 +65,7 @@ if not tlm_adjoint_module:
 del importlib, sys, modules, tlm_adjoint_module, module_name, package
 
 from .backend import backend       # noqa: E402,F401
+from .backend_code_generator_interface import copy_parameters_dict  # noqa: E402,E501,F401
 from .backend_interface import *   # noqa: E402,F401
 from .backend_overrides import *   # noqa: E402,F401
 from .base_equations import *      # noqa: E402,F401

--- a/python/tlm_adjoint_fenics/__init__.py
+++ b/python/tlm_adjoint_fenics/__init__.py
@@ -75,6 +75,7 @@ from .fenics_equations import *    # noqa: E402,F401
 from .functions import *           # noqa: E402,F401
 from .functional import *          # noqa: E402,F401
 from .hessian import *             # noqa: E402,F401
+from .interface import *           # noqa: E402,F401
 from .manager import *             # noqa: E402,F401
 from .optimization import *        # noqa: E402,F401
 from .tlm_adjoint import *         # noqa: E402,F401

--- a/python/tlm_adjoint_fenics/backend.py
+++ b/python/tlm_adjoint_fenics/backend.py
@@ -45,7 +45,13 @@
 # Modified by Martin Sandve Alnes 2008-2014
 # Modified by Andre Massing 2009
 
-from fenics import *
+from fenics import Cell, Constant, DirichletBC, Expression, Form, Function, \
+    FunctionSpace, LocalSolver, Mesh, MeshEditor, KrylovSolver, LUSolver, \
+    LinearVariationalSolver, NonlinearVariationalProblem, \
+    NonlinearVariationalSolver, Parameters, Point, TensorFunctionSpace, \
+    TestFunction, TrialFunction, UnitIntervalMesh, adjoint, as_backend_type, \
+    assemble, assemble_system, has_lu_solver_method, info, interpolate, \
+    parameters, project, solve
 import fenics
 import petsc4py.PETSc as PETSc
 

--- a/python/tlm_adjoint_fenics/backend_code_generator_interface.py
+++ b/python/tlm_adjoint_fenics/backend_code_generator_interface.py
@@ -30,6 +30,8 @@ from .interface import InterfaceException, add_interface
 from .functions import ConstantInterface, ConstantSpaceInterface, \
     eliminate_zeros, new_count
 
+from collections.abc import Iterable
+import copy
 import ffc
 import mpi4py.MPI as MPI
 import numpy as np
@@ -94,15 +96,16 @@ del _parameters
 
 
 def copy_parameters_dict(parameters):
+    if isinstance(parameters, Parameters):
+        parameters = parameters.copy()
     new_parameters = {}
     for key in parameters:
         value = parameters[key]
         if isinstance(value, (Parameters, dict)):
-            new_parameters[key] = copy_parameters_dict(value)
-        elif isinstance(value, list):
-            new_parameters[key] = list(value)
-        else:
-            new_parameters[key] = value
+            value = copy_parameters_dict(value)
+        elif isinstance(value, Iterable):
+            value = copy.copy(value)  # shallow copy only
+        new_parameters[key] = value
     return new_parameters
 
 

--- a/python/tlm_adjoint_fenics/backend_code_generator_interface.py
+++ b/python/tlm_adjoint_fenics/backend_code_generator_interface.py
@@ -18,10 +18,17 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
+from .backend import Form, FunctionSpace, Parameters, TensorFunctionSpace, \
+    TestFunction, TrialFunction, as_backend_type, backend_Constant, \
+    backend_DirichletBC, backend_KrylovSolver, backend_LUSolver, \
+    backend_LinearVariationalSolver, backend_NonlinearVariationalSolver, \
+    backend_assemble, backend_assemble_system, backend_solve, \
+    cpp_LinearVariationalProblem, cpp_NonlinearVariationalProblem, \
+    extract_args, has_lu_solver_method, parameters
+from .interface import InterfaceException, add_interface
+
 from .functions import ConstantInterface, ConstantSpaceInterface, \
     eliminate_zeros, new_count
-from .interface import InterfaceException, add_interface
 
 import ffc
 import mpi4py.MPI as MPI

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -26,8 +26,7 @@ from .interface import _new_real_function, InterfaceException, \
     function_copy, function_is_cached, function_is_checkpointed, \
     function_is_static, function_new, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
-from .backend_code_generator_interface import assemble, copy_parameters_dict, \
-    r0_space
+from .backend_code_generator_interface import assemble, r0_space
 
 from .caches import clear_caches, form_neg
 from .functions import Caches, Constant, Function, Replacement, Zero, \
@@ -41,7 +40,6 @@ import warnings
 __all__ = \
     [
         "clear_caches",
-        "copy_parameters_dict",
         "finalize_adjoint_derivative_action",
         "info",
         "subtract_adjoint_derivative_action",
@@ -283,9 +281,6 @@ if _new_real_function[0] is None:
 
 
 # def info(message):
-
-
-# def copy_parameters_dict(parameters):
 
 
 def subtract_adjoint_derivative_action(x, y):

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -30,7 +30,7 @@ from .interface import InterfaceException, SpaceInterface, \
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, r0_space
 
-from .caches import clear_caches, form_neg
+from .caches import form_neg
 from .functions import Caches, Constant, Function, Replacement, Zero, \
     is_r0_function
 
@@ -41,7 +41,6 @@ import warnings
 
 __all__ = \
     [
-        "clear_caches",
         "info",
 
         "Constant",
@@ -274,9 +273,6 @@ def _new_real_function(name=None, comm=None, static=False, cache=None,
 
 
 add_new_real_function(backend, _new_real_function)
-
-
-# def clear_caches(*deps):
 
 
 # def info(message):

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -18,11 +18,22 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .backend_code_generator_interface import assemble, \
-    copy_parameters_dict, r0_space
-from .interface import *
+from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
+    backend_Function, backend_FunctionSpace, backend_ScalarType, \
+    backend_Vector, info
+from .interface import InterfaceException, SpaceInterface, function_assign, \
+    function_axpy, function_caches, function_comm, function_copy, \
+    function_id, function_is_cached, function_is_checkpointed, \
+    function_is_static, function_get_values, function_global_size, \
+    function_inner, function_local_indices, function_linf_norm, \
+    function_local_size, function_max_value, function_name, function_new, \
+    function_replacement, function_set_values, function_space, \
+    function_state, function_sum, function_tangent_linear, \
+    function_update_caches, function_update_state, function_zero, \
+    add_interface, is_function, is_space, space_comm, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
+from .backend_code_generator_interface import assemble, copy_parameters_dict, \
+    r0_space
 
 from .caches import clear_caches, form_neg
 from .functions import Caches, Constant, Function, Replacement, Zero, \

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -21,10 +21,10 @@
 from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
     backend_Function, backend_FunctionSpace, backend_ScalarType, \
     backend_Vector, info
-from .interface import InterfaceException, SpaceInterface, add_interface, \
-    function_axpy, function_caches, function_copy, function_is_cached, \
-    function_is_checkpointed, function_is_static, function_new, space_id, \
-    space_new
+from .interface import _new_real_function, InterfaceException, \
+    SpaceInterface, add_interface, function_axpy, function_caches, \
+    function_copy, function_is_cached, function_is_checkpointed, \
+    function_is_static, function_new, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, copy_parameters_dict, \
     r0_space
@@ -40,8 +40,6 @@ import warnings
 
 __all__ = \
     [
-        "new_real_function",
-
         "clear_caches",
         "copy_parameters_dict",
         "finalize_adjoint_derivative_action",
@@ -271,10 +269,14 @@ backend_Function._tlm_adjoint__orig___init__ = backend_Function.__init__
 backend_Function.__init__ = _Function__init__
 
 
-def new_real_function(name=None, domain=None, comm=None, static=False,
-                      cache=None, checkpoint=None):
-    return Constant(0.0, name=name, domain=domain, comm=comm, static=static,
-                    cache=cache, checkpoint=checkpoint)
+def new_real_function(name=None, comm=None, static=False, cache=None,
+                      checkpoint=None):
+    return Constant(0.0, name=name, comm=comm, static=static, cache=cache,
+                    checkpoint=checkpoint)
+
+
+if _new_real_function[0] is None:
+    _new_real_function[0] = new_real_function
 
 
 # def clear_caches(*deps):

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -23,8 +23,8 @@ from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
     backend_Vector, info
 from .interface import InterfaceException, SpaceInterface, add_interface, \
     function_axpy, function_caches, function_copy, function_is_cached, \
-    function_is_checkpointed, function_is_static, function_max_value, \
-    function_new, space_id, space_new
+    function_is_checkpointed, function_is_static, function_new, space_id, \
+    space_new
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, copy_parameters_dict, \
     r0_space
@@ -40,9 +40,7 @@ import warnings
 
 __all__ = \
     [
-        "is_real_function",
         "new_real_function",
-        "real_function_value",
 
         "clear_caches",
         "copy_parameters_dict",
@@ -264,6 +262,9 @@ class FunctionInterface(_FunctionInterface):
             self._tlm_adjoint__replacement = Replacement(self)
         return self._tlm_adjoint__replacement
 
+    def _is_real(self):
+        return is_r0_function(self) and len(self.ufl_shape) == 0
+
 
 def _Function__init__(self, *args, **kwargs):
     backend_Function._tlm_adjoint__orig___init__(self, *args, **kwargs)
@@ -274,19 +275,10 @@ backend_Function._tlm_adjoint__orig___init__ = backend_Function.__init__
 backend_Function.__init__ = _Function__init__
 
 
-def is_real_function(x):
-    return is_r0_function(x) and len(x.ufl_shape) == 0
-
-
 def new_real_function(name=None, domain=None, comm=None, static=False,
                       cache=None, checkpoint=None):
     return Constant(0.0, name=name, domain=domain, comm=comm, static=static,
                     cache=cache, checkpoint=checkpoint)
-
-
-def real_function_value(x):
-    assert is_real_function(x)
-    return function_max_value(x)
 
 
 # def clear_caches(*deps):

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -41,12 +41,11 @@ import warnings
 
 __all__ = \
     [
-        "info",
-
         "RealFunctionSpace",
         "default_comm",
         "function_space_id",
         "function_space_new",
+        "info",
         "warning"
     ]
 
@@ -274,9 +273,6 @@ def _new_real_function(name=None, comm=None, static=False, cache=None,
 add_new_real_function(backend, _new_real_function)
 
 
-# def info(message):
-
-
 def _subtract_adjoint_derivative_action(x, y):
     if isinstance(y, backend_Vector):
         y = (1.0, y)
@@ -369,7 +365,10 @@ def function_space_new(*args, **kwargs):
     return space_new(*args, **kwargs)
 
 
+# def info(message):
+
+
 def warning(message):
-    warnings.warn("warning is deprecated -- use warnings.warn instead",
+    warnings.warn("warning is deprecated -- use logging.warning instead",
                   DeprecationWarning, stacklevel=2)
     warnings.warn(message, RuntimeWarning)

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -21,16 +21,10 @@
 from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
     backend_Function, backend_FunctionSpace, backend_ScalarType, \
     backend_Vector, info
-from .interface import InterfaceException, SpaceInterface, function_assign, \
-    function_axpy, function_caches, function_comm, function_copy, \
-    function_id, function_is_cached, function_is_checkpointed, \
-    function_is_static, function_get_values, function_global_size, \
-    function_inner, function_local_indices, function_linf_norm, \
-    function_local_size, function_max_value, function_name, function_new, \
-    function_replacement, function_set_values, function_space, \
-    function_state, function_sum, function_tangent_linear, \
-    function_update_caches, function_update_state, function_zero, \
-    add_interface, is_function, is_space, space_comm, space_id, space_new
+from .interface import InterfaceException, SpaceInterface, add_interface, \
+    function_axpy, function_caches, function_copy, function_is_cached, \
+    function_is_checkpointed, function_is_static, function_max_value, \
+    function_new, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, copy_parameters_dict, \
     r0_space
@@ -46,42 +40,6 @@ import warnings
 
 __all__ = \
     [
-        "InterfaceException",
-
-        "is_space",
-        "space_comm",
-        "space_id",
-        "space_new",
-
-        "is_function",
-        "function_assign",
-        "function_axpy",
-        "function_caches",
-        "function_comm",
-        "function_copy",
-        "function_get_values",
-        "function_global_size",
-        "function_id",
-        "function_inner",
-        "function_is_cached",
-        "function_is_checkpointed",
-        "function_is_static",
-        "function_linf_norm",
-        "function_local_indices",
-        "function_local_size",
-        "function_max_value",
-        "function_name",
-        "function_new",
-        "function_replacement",
-        "function_set_values",
-        "function_space",
-        "function_state",
-        "function_sum",
-        "function_tangent_linear",
-        "function_update_caches",
-        "function_update_state",
-        "function_zero",
-
         "is_real_function",
         "new_real_function",
         "real_function_value",

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -44,7 +44,6 @@ __all__ = \
 
         "clear_caches",
         "copy_parameters_dict",
-        "default_comm",
         "finalize_adjoint_derivative_action",
         "info",
         "subtract_adjoint_derivative_action",
@@ -54,14 +53,11 @@ __all__ = \
         "Replacement",
 
         "RealFunctionSpace",
+        "default_comm",
         "function_space_id",
         "function_space_new",
         "warning"
     ]
-
-
-def default_comm():
-    return MPI.COMM_WORLD
 
 
 class FunctionSpaceInterface(SpaceInterface):
@@ -344,6 +340,13 @@ def finalize_adjoint_derivative_action(x):
             assemble(x._tlm_adjoint__adj_b, tensor=x.vector(),
                      add_values=True)
         delattr(x, "_tlm_adjoint__adj_b")
+
+
+def default_comm():
+    warnings.warn("default_comm is deprecated -- "
+                  "use mpi4py.MPI.COMM_WORLD instead",
+                  DeprecationWarning, stacklevel=2)
+    return MPI.COMM_WORLD
 
 
 def RealFunctionSpace(comm=MPI.COMM_WORLD):

--- a/python/tlm_adjoint_fenics/backend_interface.py
+++ b/python/tlm_adjoint_fenics/backend_interface.py
@@ -43,10 +43,6 @@ __all__ = \
     [
         "info",
 
-        "Constant",
-        "Function",
-        "Replacement",
-
         "RealFunctionSpace",
         "default_comm",
         "function_space_id",
@@ -252,6 +248,9 @@ class FunctionInterface(_FunctionInterface):
         if not hasattr(self, "_tlm_adjoint__replacement"):
             self._tlm_adjoint__replacement = Replacement(self)
         return self._tlm_adjoint__replacement
+
+    def _is_replacement(self):
+        return False
 
     def _is_real(self):
         return is_r0_function(self) and len(self.ufl_shape) == 0

--- a/python/tlm_adjoint_fenics/backend_overrides.py
+++ b/python/tlm_adjoint_fenics/backend_overrides.py
@@ -18,8 +18,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .backend_interface import *
+from .backend import Parameters, backend_DirichletBC, backend_Function, \
+    backend_KrylovSolver, backend_LUSolver, backend_LinearVariationalSolver, \
+    backend_Matrix, backend_NonlinearVariationalProblem, \
+    backend_NonlinearVariationalSolver, backend_assemble, \
+    backend_assemble_system, backend_project, backend_solve, extract_args, \
+    parameters
+from .interface import function_new, function_update_state, space_new
+from .backend_interface import copy_parameters_dict
 from .backend_code_generator_interface import update_parameters_dict
 
 from .equations import AssignmentSolver, EquationSolver, ProjectionSolver, \

--- a/python/tlm_adjoint_fenics/backend_overrides.py
+++ b/python/tlm_adjoint_fenics/backend_overrides.py
@@ -25,8 +25,8 @@ from .backend import Parameters, backend_DirichletBC, backend_Function, \
     backend_assemble_system, backend_project, backend_solve, extract_args, \
     parameters
 from .interface import function_new, function_update_state, space_new
-from .backend_interface import copy_parameters_dict
-from .backend_code_generator_interface import update_parameters_dict
+from .backend_code_generator_interface import copy_parameters_dict, \
+    update_parameters_dict
 
 from .equations import AssignmentSolver, EquationSolver, ProjectionSolver, \
     linear_equation_new_x

--- a/python/tlm_adjoint_fenics/fenics_equations.py
+++ b/python/tlm_adjoint_fenics/fenics_equations.py
@@ -25,9 +25,10 @@ from .interface import function_assign, function_comm, function_get_values, \
     is_function, is_real_function, real_function_value
 from .backend_code_generator_interface import assemble
 
+from .base_caches import Cache
 from .base_equations import Equation, EquationException, LinearEquation, \
     Matrix, MatrixActionRHS, NullSolver, get_tangent_linear
-from .caches import Cache, form_dependencies, form_key
+from .caches import form_dependencies, form_key
 from .equations import EquationSolver, bind_form, derivative, unbind_form, \
     unbound_form
 from .functions import eliminate_zeros

--- a/python/tlm_adjoint_fenics/fenics_equations.py
+++ b/python/tlm_adjoint_fenics/fenics_equations.py
@@ -22,8 +22,7 @@ from .backend import Cell, Expression, LocalSolver, Mesh, MeshEditor, Point, \
     TestFunction, TrialFunction, backend_Function, interpolate, parameters
 from .interface import function_assign, function_comm, function_get_values, \
     function_local_size, function_new, function_set_values, function_space, \
-    is_function
-from .backend_interface import is_real_function, real_function_value
+    is_function, is_real_function, real_function_value
 from .backend_code_generator_interface import assemble
 
 from .base_equations import Equation, EquationException, LinearEquation, \

--- a/python/tlm_adjoint_fenics/fenics_equations.py
+++ b/python/tlm_adjoint_fenics/fenics_equations.py
@@ -18,9 +18,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .backend_code_generator_interface import *
-from .backend_interface import *
+from .backend import Cell, Expression, LocalSolver, Mesh, MeshEditor, Point, \
+    TestFunction, TrialFunction, backend_Function, interpolate, parameters
+from .interface import function_assign, function_comm, function_get_values, \
+    function_local_size, function_new, function_set_values, function_space, \
+    is_function
+from .backend_interface import is_real_function, real_function_value
+from .backend_code_generator_interface import assemble
 
 from .base_equations import Equation, EquationException, LinearEquation, \
     Matrix, MatrixActionRHS, NullSolver, get_tangent_linear

--- a/python/tlm_adjoint_firedrake/__init__.py
+++ b/python/tlm_adjoint_firedrake/__init__.py
@@ -65,6 +65,7 @@ if not tlm_adjoint_module:
 del importlib, sys, modules, tlm_adjoint_module, module_name, package
 
 from .backend import backend        # noqa: E402,F401
+from .backend_code_generator_interface import copy_parameters_dict  # noqa: E402,E501,F401
 from .backend_interface import *    # noqa: E402,F401
 from .backend_overrides import *    # noqa: E402,F401
 from .base_equations import *       # noqa: E402,F401

--- a/python/tlm_adjoint_firedrake/__init__.py
+++ b/python/tlm_adjoint_firedrake/__init__.py
@@ -75,6 +75,7 @@ from .firedrake_equations import *  # noqa: E402,F401
 from .functions import *            # noqa: E402,F401
 from .functional import *           # noqa: E402,F401
 from .hessian import *              # noqa: E402,F401
+from .interface import *           # noqa: E402,F401
 from .manager import *              # noqa: E402,F401
 from .optimization import *         # noqa: E402,F401
 from .tlm_adjoint import *          # noqa: E402,F401

--- a/python/tlm_adjoint_firedrake/__init__.py
+++ b/python/tlm_adjoint_firedrake/__init__.py
@@ -25,6 +25,7 @@ modules = [("backend", "tlm_adjoint_firedrake"),
            ("functions", "tlm_adjoint"),
            ("interface", "tlm_adjoint"),
            ("backend_code_generator_interface", "tlm_adjoint_firedrake"),
+           ("base_caches", "tlm_adjoint"),
            ("caches", "tlm_adjoint"),
            ("backend_interface", "tlm_adjoint_firedrake"),
            ("base_equations", "tlm_adjoint"),
@@ -68,6 +69,7 @@ from .backend import backend        # noqa: E402,F401
 from .backend_code_generator_interface import copy_parameters_dict  # noqa: E402,E501,F401
 from .backend_interface import *    # noqa: E402,F401
 from .backend_overrides import *    # noqa: E402,F401
+from .base_caches import *          # noqa: E402,F401
 from .base_equations import *       # noqa: E402,F401
 from .caches import *               # noqa: E402,F401
 from .eigendecomposition import *   # noqa: E402,F401
@@ -76,7 +78,7 @@ from .firedrake_equations import *  # noqa: E402,F401
 from .functions import *            # noqa: E402,F401
 from .functional import *           # noqa: E402,F401
 from .hessian import *              # noqa: E402,F401
-from .interface import *           # noqa: E402,F401
+from .interface import *            # noqa: E402,F401
 from .manager import *              # noqa: E402,F401
 from .optimization import *         # noqa: E402,F401
 from .tlm_adjoint import *          # noqa: E402,F401

--- a/python/tlm_adjoint_firedrake/backend.py
+++ b/python/tlm_adjoint_firedrake/backend.py
@@ -22,7 +22,7 @@ from firedrake import Constant, DirichletBC, Function, FunctionSpace, \
     LinearSolver, LinearVariationalProblem, LinearVariationalSolver, \
     NonlinearVariationalSolver, Parameters, Projector, Tensor, TestFunction, \
     TrialFunction, UnitIntervalMesh, Vector, adjoint, assemble, homogenize, \
-    parameters, project, solve
+    info, parameters, project, solve
 import firedrake
 
 backend = "Firedrake"
@@ -74,5 +74,6 @@ __all__ = \
         "UnitIntervalMesh",
         "adjoint",
         "homogenize",
+        "info",
         "parameters"
     ]

--- a/python/tlm_adjoint_firedrake/backend.py
+++ b/python/tlm_adjoint_firedrake/backend.py
@@ -18,7 +18,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from firedrake import *
+from firedrake import Constant, DirichletBC, Function, FunctionSpace, \
+    LinearSolver, LinearVariationalProblem, LinearVariationalSolver, \
+    NonlinearVariationalSolver, Parameters, Projector, Tensor, TestFunction, \
+    TrialFunction, UnitIntervalMesh, Vector, adjoint, assemble, homogenize, \
+    parameters, project, solve
 import firedrake
 
 backend = "Firedrake"

--- a/python/tlm_adjoint_firedrake/backend_code_generator_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_code_generator_interface.py
@@ -18,11 +18,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .functions import ConstantInterface, ConstantSpaceInterface, \
-    eliminate_zeros, new_count
+from .backend import FunctionSpace, Parameters, backend_Constant, \
+    backend_DirichletBC, backend_Function, backend_LinearSolver, \
+    backend_Matrix, backend_ScalarType, backend_assemble, backend_solve, \
+    extract_args, homogenize, parameters
 from .interface import InterfaceException, add_interface, function_axpy, \
     function_copy
+
+from .functions import ConstantInterface, ConstantSpaceInterface, \
+    eliminate_zeros, new_count
 
 import copy
 import mpi4py.MPI as MPI

--- a/python/tlm_adjoint_firedrake/backend_code_generator_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_code_generator_interface.py
@@ -28,6 +28,7 @@ from .interface import InterfaceException, add_interface, function_axpy, \
 from .functions import ConstantInterface, ConstantSpaceInterface, \
     eliminate_zeros, new_count
 
+from collections.abc import Iterable
 import copy
 import mpi4py.MPI as MPI
 import numpy as np
@@ -90,13 +91,14 @@ del _parameters
 
 
 def copy_parameters_dict(parameters):
-    parameters_copy = parameters.copy()
+    new_parameters = parameters.copy()
     for key, value in parameters.items():
         if isinstance(value, (Parameters, dict)):
-            parameters_copy[key] = copy_parameters_dict(value)
-        elif isinstance(value, list):
-            parameters_copy[key] = list(value)
-    return parameters_copy
+            value = copy_parameters_dict(value)
+        elif isinstance(value, Iterable):
+            value = copy.copy(value)  # shallow copy only
+        new_parameters[key] = value
+    return new_parameters
 
 
 def update_parameters_dict(parameters, new_parameters):

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -309,6 +309,24 @@ def _subtract_adjoint_derivative_action(x, y):
             x._tlm_adjoint__firedrake_adj_b += form_neg(y)
         else:
             x._tlm_adjoint__firedrake_adj_b = form_neg(y)
+    elif isinstance(x, backend_Constant):
+        if isinstance(y, backend_Function):
+            alpha = 1.0
+        elif isinstance(y, tuple) \
+                and len(y) == 2 \
+                and isinstance(y[0], (int, float)) \
+                and isinstance(y[1], backend_Function):
+            alpha, y = y
+            alpha = float(alpha)
+        else:
+            return NotImplemented
+        if len(x.ufl_shape) == 0:
+            y_value, = y.dat.data
+            # annotate=False, tlm=False
+            x.assign(float(x) - alpha * y_value)
+        else:
+            # See Firedrake issue #1456
+            raise InterfaceException("Rank >= 1 Constant not implemented")
     else:
         return NotImplemented
 

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -18,10 +18,20 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .backend_code_generator_interface import assemble, copy_parameters_dict
-from .interface import *
+from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
+    backend_Function, backend_FunctionSpace, backend_ScalarType
+from .interface import InterfaceException, SpaceInterface, function_assign, \
+    function_axpy, function_caches, function_comm, function_copy, \
+    function_id, function_is_cached, function_is_checkpointed, \
+    function_is_static, function_get_values, function_global_size, \
+    function_inner, function_local_indices, function_linf_norm, \
+    function_local_size, function_max_value, function_name, function_new, \
+    function_replacement, function_set_values, function_space, \
+    function_state, function_sum, function_tangent_linear, \
+    function_update_caches, function_update_state, function_zero, \
+    add_interface, is_function, is_space, space_comm, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
+from .backend_code_generator_interface import assemble, copy_parameters_dict
 
 from .caches import clear_caches, form_neg
 from .functions import Caches, Constant, Function, Replacement, Zero, \

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -45,10 +45,6 @@ __all__ = \
     [
         "info",
 
-        "Constant",
-        "Function",
-        "Replacement",
-
         "RealFunctionSpace",
         "default_comm",
         "function_space_id",
@@ -283,6 +279,9 @@ class FunctionInterface(_FunctionInterface):
         if not hasattr(self, "_tlm_adjoint__replacement"):
             self._tlm_adjoint__replacement = Replacement(self)
         return self._tlm_adjoint__replacement
+
+    def _is_replacement(self):
+        return False
 
     def _is_real(self):
         return is_r0_function(self) and len(self.ufl_shape) == 0

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -44,7 +44,6 @@ __all__ = \
 
         "clear_caches",
         "copy_parameters_dict",
-        "default_comm",
         "finalize_adjoint_derivative_action",
         "info",
         "subtract_adjoint_derivative_action",
@@ -54,14 +53,11 @@ __all__ = \
         "Replacement",
 
         "RealFunctionSpace",
+        "default_comm",
         "function_space_id",
         "function_space_new",
         "warning"
     ]
-
-
-def default_comm():
-    return MPI.COMM_WORLD
 
 
 class FunctionSpaceInterface(SpaceInterface):
@@ -353,12 +349,19 @@ def finalize_adjoint_derivative_action(x):
         delattr(x, "_tlm_adjoint__adj_b")
 
 
+def default_comm():
+    warnings.warn("default_comm is deprecated -- "
+                  "use mpi4py.MPI.COMM_WORLD instead",
+                  DeprecationWarning, stacklevel=2)
+    return MPI.COMM_WORLD
+
+
 def RealFunctionSpace(comm=None):
     warnings.warn("RealFunctionSpace is deprecated -- "
                   "use new_real_function instead",
                   DeprecationWarning, stacklevel=2)
     if comm is None:
-        comm = default_comm()
+        comm = MPI.COMM_WORLD
     return FunctionSpace(UnitIntervalMesh(comm.size, comm=comm), "R", 0)
 
 

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -25,7 +25,7 @@ from .interface import _new_real_function, InterfaceException, \
     function_caches, function_is_cached, function_is_checkpointed, \
     function_is_static, function_new, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
-from .backend_code_generator_interface import assemble, copy_parameters_dict
+from .backend_code_generator_interface import assemble
 
 from .caches import clear_caches, form_neg
 from .functions import Caches, Constant, Function, Replacement, Zero, \
@@ -41,7 +41,6 @@ import warnings
 __all__ = \
     [
         "clear_caches",
-        "copy_parameters_dict",
         "finalize_adjoint_derivative_action",
         "info",
         "subtract_adjoint_derivative_action",
@@ -314,9 +313,6 @@ if _new_real_function[0] is None:
 def info(message):
     sys.stdout.write(f"{message:s}\n")
     sys.stdout.flush()
-
-
-# def copy_parameters_dict(parameters):
 
 
 def subtract_adjoint_derivative_action(x, y):

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -22,8 +22,8 @@ from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
     backend_Function, backend_FunctionSpace, backend_ScalarType
 from .interface import InterfaceException, SpaceInterface, add_interface, \
     function_assign, function_axpy, function_caches, function_is_cached, \
-    function_is_checkpointed, function_is_static, function_max_value, \
-    function_new, space_id, space_new
+    function_is_checkpointed, function_is_static, function_new, space_id, \
+    space_new
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, copy_parameters_dict
 
@@ -40,9 +40,7 @@ import warnings
 
 __all__ = \
     [
-        "is_real_function",
         "new_real_function",
-        "real_function_value",
 
         "clear_caches",
         "copy_parameters_dict",
@@ -293,6 +291,9 @@ class FunctionInterface(_FunctionInterface):
             self._tlm_adjoint__replacement = Replacement(self)
         return self._tlm_adjoint__replacement
 
+    def _is_real(self):
+        return is_r0_function(self) and len(self.ufl_shape) == 0
+
 
 def _Function__init__(self, *args, **kwargs):
     backend_Function._tlm_adjoint__orig___init__(self, *args, **kwargs)
@@ -303,19 +304,10 @@ backend_Function._tlm_adjoint__orig___init__ = backend_Function.__init__
 backend_Function.__init__ = _Function__init__
 
 
-def is_real_function(x):
-    return is_r0_function(x) and len(x.ufl_shape) == 0
-
-
 def new_real_function(name=None, domain=None, comm=None, static=False,
                       cache=None, checkpoint=None):
     return Constant(0.0, name=name, domain=domain, comm=comm, static=static,
                     cache=cache, checkpoint=checkpoint)
-
-
-def real_function_value(x):
-    assert is_real_function(x)
-    return function_max_value(x)
 
 
 # def clear_caches(*deps):

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -20,16 +20,10 @@
 
 from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
     backend_Function, backend_FunctionSpace, backend_ScalarType
-from .interface import InterfaceException, SpaceInterface, function_assign, \
-    function_axpy, function_caches, function_comm, function_copy, \
-    function_id, function_is_cached, function_is_checkpointed, \
-    function_is_static, function_get_values, function_global_size, \
-    function_inner, function_local_indices, function_linf_norm, \
-    function_local_size, function_max_value, function_name, function_new, \
-    function_replacement, function_set_values, function_space, \
-    function_state, function_sum, function_tangent_linear, \
-    function_update_caches, function_update_state, function_zero, \
-    add_interface, is_function, is_space, space_comm, space_id, space_new
+from .interface import InterfaceException, SpaceInterface, add_interface, \
+    function_assign, function_axpy, function_caches, function_is_cached, \
+    function_is_checkpointed, function_is_static, function_max_value, \
+    function_new, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, copy_parameters_dict
 
@@ -46,42 +40,6 @@ import warnings
 
 __all__ = \
     [
-        "InterfaceException",
-
-        "is_space",
-        "space_comm",
-        "space_id",
-        "space_new",
-
-        "is_function",
-        "function_assign",
-        "function_axpy",
-        "function_caches",
-        "function_comm",
-        "function_copy",
-        "function_get_values",
-        "function_global_size",
-        "function_id",
-        "function_inner",
-        "function_is_cached",
-        "function_is_checkpointed",
-        "function_is_static",
-        "function_linf_norm",
-        "function_local_indices",
-        "function_local_size",
-        "function_max_value",
-        "function_name",
-        "function_new",
-        "function_replacement",
-        "function_set_values",
-        "function_space",
-        "function_state",
-        "function_sum",
-        "function_tangent_linear",
-        "function_update_caches",
-        "function_update_state",
-        "function_zero",
-
         "is_real_function",
         "new_real_function",
         "real_function_value",

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -20,10 +20,10 @@
 
 from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
     backend_Function, backend_FunctionSpace, backend_ScalarType
-from .interface import InterfaceException, SpaceInterface, add_interface, \
-    function_assign, function_axpy, function_caches, function_is_cached, \
-    function_is_checkpointed, function_is_static, function_new, space_id, \
-    space_new
+from .interface import _new_real_function, InterfaceException, \
+    SpaceInterface, add_interface, function_assign, function_axpy, \
+    function_caches, function_is_cached, function_is_checkpointed, \
+    function_is_static, function_new, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, copy_parameters_dict
 
@@ -40,8 +40,6 @@ import warnings
 
 __all__ = \
     [
-        "new_real_function",
-
         "clear_caches",
         "copy_parameters_dict",
         "finalize_adjoint_derivative_action",
@@ -300,10 +298,14 @@ backend_Function._tlm_adjoint__orig___init__ = backend_Function.__init__
 backend_Function.__init__ = _Function__init__
 
 
-def new_real_function(name=None, domain=None, comm=None, static=False,
-                      cache=None, checkpoint=None):
-    return Constant(0.0, name=name, domain=domain, comm=comm, static=static,
-                    cache=cache, checkpoint=checkpoint)
+def new_real_function(name=None, comm=None, static=False, cache=None,
+                      checkpoint=None):
+    return Constant(0.0, name=name, comm=comm, static=static, cache=cache,
+                    checkpoint=checkpoint)
+
+
+if _new_real_function[0] is None:
+    _new_real_function[0] = new_real_function
 
 
 # def clear_caches(*deps):

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -30,7 +30,7 @@ from .interface import InterfaceException, SpaceInterface, \
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble
 
-from .caches import clear_caches, form_neg
+from .caches import form_neg
 from .functions import Caches, Constant, Function, Replacement, Zero, \
     is_r0_function
 
@@ -43,7 +43,6 @@ import warnings
 
 __all__ = \
     [
-        "clear_caches",
         "info",
 
         "Constant",
@@ -305,9 +304,6 @@ def _new_real_function(name=None, comm=None, static=False, cache=None,
 
 
 add_new_real_function(backend, _new_real_function)
-
-
-# def clear_caches(*deps):
 
 
 def info(message):

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -20,7 +20,7 @@
 
 from .backend import FunctionSpace, UnitIntervalMesh, backend, \
     backend_Constant, backend_Function, backend_FunctionSpace, \
-    backend_ScalarType
+    backend_ScalarType, info
 from .interface import InterfaceException, SpaceInterface, \
     add_finalize_adjoint_derivative_action, add_interface, \
     add_new_real_function, add_subtract_adjoint_derivative_action, \
@@ -38,17 +38,15 @@ import mpi4py.MPI as MPI
 import numpy as np
 import petsc4py.PETSc as PETSc
 import ufl
-import sys
 import warnings
 
 __all__ = \
     [
-        "info",
-
         "RealFunctionSpace",
         "default_comm",
         "function_space_id",
         "function_space_new",
+        "info",
         "warning"
     ]
 
@@ -305,11 +303,6 @@ def _new_real_function(name=None, comm=None, static=False, cache=None,
 add_new_real_function(backend, _new_real_function)
 
 
-def info(message):
-    sys.stdout.write(f"{message:s}\n")
-    sys.stdout.flush()
-
-
 def _subtract_adjoint_derivative_action(x, y):
     if isinstance(y, ufl.classes.Form):
         if hasattr(x, "_tlm_adjoint__firedrake_adj_b"):
@@ -363,7 +356,10 @@ def function_space_new(*args, **kwargs):
     return space_new(*args, **kwargs)
 
 
+# def info(message):
+
+
 def warning(message):
-    warnings.warn("warning is deprecated -- use warnings.warn instead",
+    warnings.warn("warning is deprecated -- use logging.warning instead",
                   DeprecationWarning, stacklevel=2)
     warnings.warn(message, RuntimeWarning)

--- a/python/tlm_adjoint_firedrake/backend_interface.py
+++ b/python/tlm_adjoint_firedrake/backend_interface.py
@@ -18,12 +18,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import FunctionSpace, UnitIntervalMesh, backend_Constant, \
-    backend_Function, backend_FunctionSpace, backend_ScalarType
-from .interface import _new_real_function, InterfaceException, \
-    SpaceInterface, add_interface, function_assign, function_axpy, \
-    function_caches, function_is_cached, function_is_checkpointed, \
-    function_is_static, function_new, space_id, space_new
+from .backend import FunctionSpace, UnitIntervalMesh, backend, \
+    backend_Constant, backend_Function, backend_FunctionSpace, \
+    backend_ScalarType
+from .interface import InterfaceException, SpaceInterface, \
+    add_finalize_adjoint_derivative_action, add_interface, \
+    add_new_real_function, add_subtract_adjoint_derivative_action, \
+    function_assign, function_caches, function_is_cached, \
+    function_is_checkpointed, function_is_static, function_new, space_id, \
+    space_new, subtract_adjoint_derivative_action
 from .interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble
 
@@ -41,9 +44,7 @@ import warnings
 __all__ = \
     [
         "clear_caches",
-        "finalize_adjoint_derivative_action",
         "info",
-        "subtract_adjoint_derivative_action",
 
         "Constant",
         "Function",
@@ -297,14 +298,13 @@ backend_Function._tlm_adjoint__orig___init__ = backend_Function.__init__
 backend_Function.__init__ = _Function__init__
 
 
-def new_real_function(name=None, comm=None, static=False, cache=None,
-                      checkpoint=None):
+def _new_real_function(name=None, comm=None, static=False, cache=None,
+                       checkpoint=None):
     return Constant(0.0, name=name, comm=comm, static=static, cache=cache,
                     checkpoint=checkpoint)
 
 
-if _new_real_function[0] is None:
-    _new_real_function[0] = new_real_function
+add_new_real_function(backend, _new_real_function)
 
 
 # def clear_caches(*deps):
@@ -315,36 +315,29 @@ def info(message):
     sys.stdout.flush()
 
 
-def subtract_adjoint_derivative_action(x, y):
-    if y is None:
-        pass
-    elif isinstance(y, ufl.classes.Form):
-        if hasattr(x, "_tlm_adjoint__adj_b"):
-            x._tlm_adjoint__adj_b += form_neg(y)
+def _subtract_adjoint_derivative_action(x, y):
+    if isinstance(y, ufl.classes.Form):
+        if hasattr(x, "_tlm_adjoint__firedrake_adj_b"):
+            x._tlm_adjoint__firedrake_adj_b += form_neg(y)
         else:
-            x._tlm_adjoint__adj_b = form_neg(y)
+            x._tlm_adjoint__firedrake_adj_b = form_neg(y)
     else:
-        if isinstance(y, tuple):
-            alpha, y = y
-        else:
-            alpha = 1.0
-        if isinstance(x, backend_Constant):
-            if len(x.ufl_shape) == 0:
-                y_value, = y.dat.data
-                # annotate=False, tlm=False
-                x.assign(float(x) - alpha * y_value)
-            else:
-                # See Firedrake issue #1456
-                raise InterfaceException("Rank >= 1 Constant not implemented")
-        else:
-            function_axpy(x, -alpha, y)
+        return NotImplemented
 
 
-def finalize_adjoint_derivative_action(x):
-    if hasattr(x, "_tlm_adjoint__adj_b"):
-        y = assemble(x._tlm_adjoint__adj_b)
+add_subtract_adjoint_derivative_action(backend,
+                                       _subtract_adjoint_derivative_action)
+
+
+def _finalize_adjoint_derivative_action(x):
+    if hasattr(x, "_tlm_adjoint__firedrake_adj_b"):
+        y = assemble(x._tlm_adjoint__firedrake_adj_b)
         subtract_adjoint_derivative_action(x, (-1.0, y))
-        delattr(x, "_tlm_adjoint__adj_b")
+        delattr(x, "_tlm_adjoint__firedrake_adj_b")
+
+
+add_finalize_adjoint_derivative_action(backend,
+                                       _finalize_adjoint_derivative_action)
 
 
 def default_comm():

--- a/python/tlm_adjoint_firedrake/backend_overrides.py
+++ b/python/tlm_adjoint_firedrake/backend_overrides.py
@@ -18,8 +18,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .backend_interface import *
+from .backend import Parameters, Projector, backend_DirichletBC, \
+    backend_Function, backend_LinearSolver, backend_LinearVariationalProblem, \
+    backend_LinearVariationalSolver, backend_NonlinearVariationalSolver, \
+    backend_Vector, backend_assemble, backend_project, backend_solve, \
+    extract_args, parameters
+from .interface import InterfaceException, function_new, \
+    function_update_state, space_new
 from .backend_code_generator_interface import copy_parameters_dict, \
     update_parameters_dict
 

--- a/python/tlm_adjoint_firedrake/firedrake_equations.py
+++ b/python/tlm_adjoint_firedrake/firedrake_equations.py
@@ -22,8 +22,7 @@ from .backend import Tensor, TestFunction, TrialFunction, backend_Function, \
     backend_assemble
 from .interface import function_assign, function_comm, function_get_values, \
     function_local_size, function_new, function_set_values, function_space, \
-    is_function
-from .backend_interface import is_real_function, real_function_value
+    is_function, is_real_function, real_function_value
 from .backend_code_generator_interface import assemble, matrix_multiply
 
 from .base_equations import Equation, EquationException, NullSolver, \

--- a/python/tlm_adjoint_firedrake/firedrake_equations.py
+++ b/python/tlm_adjoint_firedrake/firedrake_equations.py
@@ -25,9 +25,10 @@ from .interface import function_assign, function_comm, function_get_values, \
     is_function, is_real_function, real_function_value
 from .backend_code_generator_interface import assemble, matrix_multiply
 
+from .base_caches import Cache
 from .base_equations import Equation, EquationException, NullSolver, \
     get_tangent_linear
-from .caches import Cache, form_dependencies, form_key, parameters_key
+from .caches import form_dependencies, form_key, parameters_key
 from .equations import EquationSolver, bind_form, derivative, unbind_form, \
     unbound_form
 from .functions import eliminate_zeros

--- a/python/tlm_adjoint_firedrake/firedrake_equations.py
+++ b/python/tlm_adjoint_firedrake/firedrake_equations.py
@@ -18,9 +18,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend import *
-from .backend_code_generator_interface import *
-from .backend_interface import *
+from .backend import Tensor, TestFunction, TrialFunction, backend_Function, \
+    backend_assemble
+from .interface import function_assign, function_comm, function_get_values, \
+    function_local_size, function_new, function_set_values, function_space, \
+    is_function
+from .backend_interface import is_real_function, real_function_value
+from .backend_code_generator_interface import assemble, matrix_multiply
 
 from .base_equations import Equation, EquationException, NullSolver, \
     get_tangent_linear

--- a/python/tlm_adjoint_numpy/__init__.py
+++ b/python/tlm_adjoint_numpy/__init__.py
@@ -27,6 +27,7 @@ modules = [("backend", "tlm_adjoint_numpy"),
            ("base_equations", "tlm_adjoint"),
            ("numpy_equations", "tlm_adjoint_numpy"),
            ("alias", "tlm_adjoint"),
+           ("base_caches", "tlm_adjoint"),
            ("binomial_checkpointing", "tlm_adjoint"),
            ("functional", "tlm_adjoint"),
            ("hessian", "tlm_adjoint"),
@@ -59,10 +60,11 @@ del importlib, sys, modules, tlm_adjoint_module, module_name, package
 
 from .backend import backend      # noqa: E402,F401
 from .backend_interface import *  # noqa: E402,F401
+from .base_caches import *        # noqa: E402,F401
 from .base_equations import *     # noqa: E402,F401
 from .functional import *         # noqa: E402,F401
 from .hessian import *            # noqa: E402,F401
-from .interface import *           # noqa: E402,F401
+from .interface import *          # noqa: E402,F401
 from .manager import *            # noqa: E402,F401
 from .numpy_equations import *    # noqa: E402,F401
 from .optimization import *       # noqa: E402,F401

--- a/python/tlm_adjoint_numpy/__init__.py
+++ b/python/tlm_adjoint_numpy/__init__.py
@@ -62,6 +62,7 @@ from .backend_interface import *  # noqa: E402,F401
 from .base_equations import *     # noqa: E402,F401
 from .functional import *         # noqa: E402,F401
 from .hessian import *            # noqa: E402,F401
+from .interface import *           # noqa: E402,F401
 from .manager import *            # noqa: E402,F401
 from .numpy_equations import *    # noqa: E402,F401
 from .optimization import *       # noqa: E402,F401

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -18,7 +18,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import *
+from .interface import InterfaceException, SpaceInterface, function_assign, \
+    function_axpy, function_caches, function_comm, function_copy, \
+    function_id, function_is_cached, function_is_checkpointed, \
+    function_is_static, function_get_values, function_global_size, \
+    function_inner, function_local_indices, function_linf_norm, \
+    function_local_size, function_max_value, function_name, function_new, \
+    function_replacement, function_set_values, function_space, \
+    function_state, function_sum, function_tangent_linear, \
+    function_update_caches, function_update_state, function_zero, \
+    add_interface, is_function, is_space, space_comm, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 
 import copy

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -18,8 +18,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import InterfaceException, SpaceInterface, add_interface, \
-    space_id, space_new
+from .interface import _new_real_function, InterfaceException, \
+    SpaceInterface, add_interface, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 
 import copy
@@ -313,6 +313,10 @@ def new_real_function(name=None, comm=None, static=False, cache=None,
                       checkpoint=None):
     return Function(FunctionSpace(1), name=name, static=static, cache=cache,
                     checkpoint=checkpoint)
+
+
+if _new_real_function[0] is None:
+    _new_real_function[0] = new_real_function
 
 
 def clear_caches(*deps):

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -18,8 +18,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import _new_real_function, InterfaceException, \
-    SpaceInterface, add_interface, space_id, space_new
+from .backend import backend
+from .interface import InterfaceException, SpaceInterface, add_interface, \
+    add_new_real_function, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 
 import copy
@@ -31,9 +32,7 @@ import warnings
 __all__ = \
     [
         "clear_caches",
-        "finalize_adjoint_derivative_action",
         "info",
-        "subtract_adjoint_derivative_action",
 
         "Function",
         "FunctionSpace",
@@ -309,14 +308,13 @@ class Replacement:
         return self._checkpoint
 
 
-def new_real_function(name=None, comm=None, static=False, cache=None,
-                      checkpoint=None):
+def _new_real_function(name=None, comm=None, static=False, cache=None,
+                       checkpoint=None):
     return Function(FunctionSpace(1), name=name, static=static, cache=cache,
                     checkpoint=checkpoint)
 
 
-if _new_real_function[0] is None:
-    _new_real_function[0] = new_real_function
+add_new_real_function(backend, _new_real_function)
 
 
 def clear_caches(*deps):
@@ -326,27 +324,6 @@ def clear_caches(*deps):
 def info(message):
     sys.stdout.write(f"{message:s}\n")
     sys.stdout.flush()
-
-
-def subtract_adjoint_derivative_action(x, y):
-    if y is None:
-        pass
-    elif isinstance(y, tuple):
-        alpha, y = y
-        if isinstance(y, Function):
-            y = y.vector()
-        if alpha == 1.0:
-            x.vector()[:] -= y
-        else:
-            x.vector()[:] -= alpha * y
-    else:
-        if isinstance(y, Function):
-            y = y.vector()
-        x.vector()[:] -= y
-
-
-def finalize_adjoint_derivative_action(x):
-    pass
 
 
 def default_comm():

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -31,7 +31,6 @@ import warnings
 __all__ = \
     [
         "clear_caches",
-        "copy_parameters_dict",
         "finalize_adjoint_derivative_action",
         "info",
         "subtract_adjoint_derivative_action",
@@ -41,6 +40,7 @@ __all__ = \
         "Replacement",
 
         "RealFunctionSpace",
+        "copy_parameters_dict",
         "default_comm",
         "function_space_id",
         "function_space_new",
@@ -328,10 +328,6 @@ def info(message):
     sys.stdout.flush()
 
 
-def copy_parameters_dict(parameters):
-    return copy.deepcopy(parameters)
-
-
 def subtract_adjoint_derivative_action(x, y):
     if y is None:
         pass
@@ -383,3 +379,10 @@ def warning(message):
     warnings.warn("warning is deprecated -- use warnings.warn instead",
                   DeprecationWarning, stacklevel=2)
     warnings.warn(message, RuntimeWarning)
+
+
+def copy_parameters_dict(parameters):
+    warnings.warn("copy_parameters_dict is deprecated -- "
+                  "use copy.deepcopy instead",
+                  DeprecationWarning, stacklevel=2)
+    return copy.deepcopy(parameters)

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -18,16 +18,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import InterfaceException, SpaceInterface, function_assign, \
-    function_axpy, function_caches, function_comm, function_copy, \
-    function_id, function_is_cached, function_is_checkpointed, \
-    function_is_static, function_get_values, function_global_size, \
-    function_inner, function_local_indices, function_linf_norm, \
-    function_local_size, function_max_value, function_name, function_new, \
-    function_replacement, function_set_values, function_space, \
-    function_state, function_sum, function_tangent_linear, \
-    function_update_caches, function_update_state, function_zero, \
-    add_interface, is_function, is_space, space_comm, space_id, space_new
+from .interface import InterfaceException, SpaceInterface, add_interface, \
+    is_function, space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 
 import copy
@@ -37,46 +29,6 @@ import warnings
 
 __all__ = \
     [
-        "InterfaceException",
-
-        "is_space",
-        "space_comm",
-        "space_id",
-        "space_new",
-
-        "is_function",
-        "function_assign",
-        "function_axpy",
-        "function_caches",
-        "function_comm",
-        "function_copy",
-        "function_get_values",
-        "function_global_size",
-        "function_id",
-        "function_inner",
-        "function_is_cached",
-        "function_is_checkpointed",
-        "function_is_static",
-        "function_linf_norm",
-        "function_local_indices",
-        "function_local_size",
-        "function_max_value",
-        "function_name",
-        "function_new",
-        "function_replacement",
-        "function_set_values",
-        "function_space",
-        "function_state",
-        "function_sum",
-        "function_tangent_linear",
-        "function_update_caches",
-        "function_update_state",
-        "function_zero",
-
-        "is_real_function",
-        "new_real_function",
-        "real_function_value",
-
         "clear_caches",
         "copy_parameters_dict",
         "default_comm",

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -165,6 +165,9 @@ class FunctionInterface(_FunctionInterface):
     def _replacement(self):
         return self.replacement()
 
+    def _is_replacement(self):
+        return False
+
     def _is_real(self):
         return self.space().dim() == 1
 
@@ -273,6 +276,9 @@ class ReplacementInterface(_FunctionInterface):
 
     def _replacement(self):
         return self
+
+    def _is_replacement(self):
+        return True
 
     def _is_real(self):
         return self.space().dim() == 1

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -26,13 +26,10 @@ from .interface import FunctionInterface as _FunctionInterface
 import copy
 import mpi4py.MPI as MPI
 import numpy as np
-import sys
 import warnings
 
 __all__ = \
     [
-        "info",
-
         "Function",
         "FunctionSpace",
         "Replacement",
@@ -42,6 +39,7 @@ __all__ = \
         "default_comm",
         "function_space_id",
         "function_space_new",
+        "info",
         "warning"
     ]
 
@@ -322,11 +320,6 @@ def _new_real_function(name=None, comm=None, static=False, cache=None,
 add_new_real_function(backend, _new_real_function)
 
 
-def info(message):
-    sys.stdout.write(f"{message:s}\n")
-    sys.stdout.flush()
-
-
 def default_comm():
     warnings.warn("default_comm is deprecated -- "
                   "use mpi4py.MPI.COMM_WORLD instead",
@@ -353,8 +346,14 @@ def function_space_new(*args, **kwargs):
     return space_new(*args, **kwargs)
 
 
+def info(message):
+    warnings.warn("info is deprecated -- use print instead",
+                  DeprecationWarning, stacklevel=2)
+    print(message)
+
+
 def warning(message):
-    warnings.warn("warning is deprecated -- use warnings.warn instead",
+    warnings.warn("warning is deprecated -- use logging.warning instead",
                   DeprecationWarning, stacklevel=2)
     warnings.warn(message, RuntimeWarning)
 

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -31,7 +31,6 @@ import warnings
 
 __all__ = \
     [
-        "clear_caches",
         "info",
 
         "Function",
@@ -315,10 +314,6 @@ def _new_real_function(name=None, comm=None, static=False, cache=None,
 
 
 add_new_real_function(backend, _new_real_function)
-
-
-def clear_caches(*deps):
-    pass
 
 
 def info(message):

--- a/python/tlm_adjoint_numpy/backend_interface.py
+++ b/python/tlm_adjoint_numpy/backend_interface.py
@@ -19,7 +19,7 @@
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
 from .interface import InterfaceException, SpaceInterface, add_interface, \
-    is_function, space_id, space_new
+    space_id, space_new
 from .interface import FunctionInterface as _FunctionInterface
 
 import copy
@@ -200,6 +200,9 @@ class FunctionInterface(_FunctionInterface):
     def _replacement(self):
         return self.replacement()
 
+    def _is_real(self):
+        return self.space().dim() == 1
+
 
 class Function:
     _id_counter = [0]
@@ -306,6 +309,9 @@ class ReplacementInterface(_FunctionInterface):
     def _replacement(self):
         return self
 
+    def _is_real(self):
+        return self.space().dim() == 1
+
 
 class Replacement:
     def __init__(self, x):
@@ -336,20 +342,10 @@ class Replacement:
         return self._checkpoint
 
 
-def is_real_function(x):
-    return is_function(x) and x.space().dim() == 1
-
-
 def new_real_function(name=None, comm=None, static=False, cache=None,
                       checkpoint=None):
     return Function(FunctionSpace(1), name=name, static=static, cache=cache,
                     checkpoint=checkpoint)
-
-
-def real_function_value(x):
-    assert is_real_function(x)
-    value, = x.vector()
-    return value
 
 
 def clear_caches(*deps):

--- a/python/tlm_adjoint_numpy/numpy_equations.py
+++ b/python/tlm_adjoint_numpy/numpy_equations.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .backend_interface import *
+from .interface import space_new
 
 from .base_equations import EquationException, LinearEquation, Matrix, RHS
 

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -25,6 +25,7 @@ from tlm_adjoint_fenics.backend import backend_Constant, backend_Function
 
 import copy
 import gc
+import logging
 import mpi4py.MPI as MPI
 import numpy as np
 import os
@@ -67,6 +68,8 @@ def setup_test():
     reset_manager("memory", {"drop_references": True})
     clear_caches()
     stop_manager()
+
+    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
 
     np.random.seed(14012313 + MPI.COMM_WORLD.rank)
 

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -34,7 +34,7 @@ def test_long_range(setup_test, test_leaks):
     n_steps = 200
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 0,
-                             "snaps_in_ram": 2, "verbose": True})
+                             "snaps_in_ram": 2})
 
     mesh = UnitIntervalMesh(20)
     X = SpatialCoordinate(mesh)
@@ -417,8 +417,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
         fp_eq = FixedPointSolver(
             [eq0, eq1],
             solver_parameters={"absolute_tolerance": 0.0,
-                               "relative_tolerance": 1.0e-14,
-                               "report": False})
+                               "relative_tolerance": 1.0e-14})
         fp_eq.solve()
 
         if forward_run:
@@ -556,7 +555,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
 
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 0,
-                             "snaps_in_ram": snaps_in_ram, "verbose": False})
+                             "snaps_in_ram": snaps_in_ram})
 
     def forward(m):
         for n in range(n_steps):

--- a/tests/fenics/test_models.py
+++ b/tests/fenics/test_models.py
@@ -94,10 +94,10 @@ def diffusion_ref():
     [("memory", {"drop_references": True}),
      ("periodic_disk", {"period": 3, "format": "pickle"}),
      ("periodic_disk", {"period": 3, "format": "hdf5"}),
-     ("multistage", {"format": "pickle", "snaps_on_disk": 1, "snaps_in_ram": 2,
-                     "verbose": True}),
-     ("multistage", {"format": "hdf5", "snaps_on_disk": 1, "snaps_in_ram": 2,
-                     "verbose": True})])
+     ("multistage", {"format": "pickle", "snaps_on_disk": 1,
+                     "snaps_in_ram": 2}),
+     ("multistage", {"format": "hdf5", "snaps_on_disk": 1,
+                     "snaps_in_ram": 2})])
 def test_oscillator(setup_test, test_leaks,
                     cp_method, cp_parameters):
     n_steps = 20
@@ -179,7 +179,7 @@ def test_diffusion_1d_timestepping(setup_test, test_leaks,
                                    n_steps):
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 2,
-                             "snaps_in_ram": 3, "verbose": True})
+                             "snaps_in_ram": 3})
 
     mesh = UnitIntervalMesh(100)
     X = SpatialCoordinate(mesh)
@@ -263,7 +263,7 @@ def test_diffusion_2d(setup_test, test_leaks):
     n_steps = 20
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 2,
-                             "snaps_in_ram": 3, "verbose": True})
+                             "snaps_in_ram": 3})
 
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -25,6 +25,7 @@ from tlm_adjoint_firedrake.backend import backend_Constant, backend_Function
 
 import copy
 import gc
+import logging
 import mpi4py.MPI as MPI
 import numpy as np
 import os
@@ -63,6 +64,8 @@ def setup_test():
     reset_manager("memory", {"drop_references": True})
     clear_caches()
     stop_manager()
+
+    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
 
     np.random.seed(14012313 + MPI.COMM_WORLD.rank)
 

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -35,7 +35,7 @@ def test_long_range(setup_test, test_leaks):
     n_steps = 200
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 0,
-                             "snaps_in_ram": 2, "verbose": True})
+                             "snaps_in_ram": 2})
 
     mesh = UnitIntervalMesh(20)
     X = SpatialCoordinate(mesh)
@@ -420,8 +420,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
         fp_eq = FixedPointSolver(
             [eq0, eq1],
             solver_parameters={"absolute_tolerance": 0.0,
-                               "relative_tolerance": 1.0e-14,
-                               "report": False})
+                               "relative_tolerance": 1.0e-14})
         fp_eq.solve()
 
         if forward_run:
@@ -559,7 +558,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
 
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 0,
-                             "snaps_in_ram": snaps_in_ram, "verbose": False})
+                             "snaps_in_ram": snaps_in_ram})
 
     def forward(m):
         for n in range(n_steps):

--- a/tests/firedrake/test_models.py
+++ b/tests/firedrake/test_models.py
@@ -93,10 +93,10 @@ def diffusion_ref():
     [("memory", {"drop_references": True}),
      ("periodic_disk", {"period": 3, "format": "pickle"}),
      ("periodic_disk", {"period": 3, "format": "hdf5"}),
-     ("multistage", {"format": "pickle", "snaps_on_disk": 1, "snaps_in_ram": 2,
-                     "verbose": True}),
-     ("multistage", {"format": "hdf5", "snaps_on_disk": 1, "snaps_in_ram": 2,
-                     "verbose": True})])
+     ("multistage", {"format": "pickle", "snaps_on_disk": 1,
+                     "snaps_in_ram": 2}),
+     ("multistage", {"format": "hdf5", "snaps_on_disk": 1,
+                     "snaps_in_ram": 2})])
 def test_oscillator(setup_test, test_leaks,
                     cp_method, cp_parameters):
     n_steps = 20
@@ -176,7 +176,7 @@ def test_diffusion_1d_timestepping(setup_test, test_leaks,
                                    n_steps):
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 2,
-                             "snaps_in_ram": 3, "verbose": True})
+                             "snaps_in_ram": 3})
 
     mesh = UnitIntervalMesh(100)
     X = SpatialCoordinate(mesh)
@@ -260,7 +260,7 @@ def test_diffusion_2d(setup_test, test_leaks):
     n_steps = 20
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 2,
-                             "snaps_in_ram": 3, "verbose": True})
+                             "snaps_in_ram": 3})
 
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -22,6 +22,7 @@ from tlm_adjoint_numpy import *
 from tlm_adjoint_numpy import manager as _manager
 
 import gc
+import logging
 import numpy as np
 import os
 import pytest
@@ -31,6 +32,7 @@ import weakref
 __all__ = \
     [
         "Constant",
+        "info",
 
         "run_example",
         "setup_test",
@@ -43,6 +45,8 @@ def setup_test():
     reset_manager("memory", {"drop_references": True})
     clear_caches()
     stop_manager()
+
+    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
 
     np.random.seed(14012313)
 
@@ -102,6 +106,10 @@ def run_example(example, clear_forward_globals=True):
         # Clear objects created by the script. Requires the script to define a
         # 'forward' function.
         gl["forward"].__globals__.clear()
+
+
+def info(message):
+    print(message)
 
 
 class Constant(Function):

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -286,8 +286,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
         fp_eq = FixedPointSolver(
             [eq0, eq1],
             solver_parameters={"absolute_tolerance": 0.0,
-                               "relative_tolerance": 1.0e-14,
-                               "report": False})
+                               "relative_tolerance": 1.0e-14})
         fp_eq.solve()
 
         if forward_run:
@@ -425,7 +424,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
 
     configure_checkpointing("multistage",
                             {"blocks": n_steps, "snaps_on_disk": 0,
-                             "snaps_in_ram": snaps_in_ram, "verbose": False})
+                             "snaps_in_ram": snaps_in_ram})
 
     def forward(m):
         for n in range(n_steps):


### PR DESCRIPTION
Remove all cases of `from .backend_interface import [...]`, except for use in `__init__.py` files.