### PR TITLE
FEniCS backend: Fix to InteriorAssignmentSolver.adjoint_derivative_action

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -160,7 +160,7 @@ def forward(psi_0, psi_n_file=None):
 
         def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
             if dep_index == 0:
-                return b
+                return adj_x
             elif dep_index == 1:
                 b = function_copy(adj_x)
                 self._bc.apply(b.vector())
@@ -295,7 +295,7 @@ def forward(psi_0, psi_n_file=None):
 
         def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
             if dep_index == 0:
-                return b
+                return adj_x
             elif dep_index == 1:
                 b = function_copy(adj_x)
                 self._bc.apply(b.vector())
@@ -2523,7 +2523,7 @@ def forward(psi_0, psi_n_file=None):
 
         def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
             if dep_index == 0:
-                return b
+                return adj_x
             elif dep_index == 1:
                 b = function_copy(adj_x)
                 self._bc.apply(b.vector())

--- a/examples/fenics/manual/diffusion_adjoint.py
+++ b/examples/fenics/manual/diffusion_adjoint.py
@@ -41,7 +41,7 @@ def forward(psi_0, psi_n_file=None):
 
         def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
             if dep_index == 0:
-                return b
+                return adj_x
             elif dep_index == 1:
                 b = function_copy(adj_x)
                 self._bc.apply(b.vector())

--- a/examples/fenics/manual/diffusion_adjoint_timestepping.py
+++ b/examples/fenics/manual/diffusion_adjoint_timestepping.py
@@ -43,7 +43,7 @@ def forward(psi_0, psi_n_file=None):
 
         def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
             if dep_index == 0:
-                return b
+                return adj_x
             elif dep_index == 1:
                 b = function_copy(adj_x)
                 self._bc.apply(b.vector())

--- a/examples/fenics/manual/diffusion_hessian.py
+++ b/examples/fenics/manual/diffusion_hessian.py
@@ -41,7 +41,7 @@ def forward(psi_0, psi_n_file=None):
 
         def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
             if dep_index == 0:
-                return b
+                return adj_x
             elif dep_index == 1:
                 b = function_copy(adj_x)
                 self._bc.apply(b.vector())


### PR DESCRIPTION
For the (unused) case where dep_index=0