### PR TITLE
Add ReplacementConstant and ReplacementFunction classes

### DIFF
--- a/tests/fenics/test_caches.py
+++ b/tests/fenics/test_caches.py
@@ -73,7 +73,7 @@ def test_clear_caches(setup_test, test_leaks):
     function_update_caches(F, value=Function(space))
     test_cleared(F, cached_form)
 
-    # Clear on cache update, Replacement with new Function
+    # Clear on cache update, replacement with new Function
     cached_form = cache_item(F)
     test_not_cleared(F, cached_form)
     function_update_caches(function_replacement(F), value=Function(space))

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -20,6 +20,7 @@
 
 from fenics import *
 from tlm_adjoint.fenics import *
+from tlm_adjoint.fenics.backend_code_generator_interface import function_vector
 
 from test_base import *
 
@@ -909,3 +910,54 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
 
     min_order = taylor_test_tlm_adjoint(forward, m, adjoint_order=2)
     assert min_order > 2.00
+
+
+@pytest.mark.fenics
+@pytest.mark.parametrize("dim", [1, 2, 3, 4])
+def test_form_binding(setup_test, test_leaks,
+                      dim):
+    from tlm_adjoint.fenics.backend_code_generator_interface import \
+        assemble as bind_assemble
+    from tlm_adjoint.fenics.equations import bind_form, unbind_form, \
+        unbound_form
+
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    if dim > 1:
+        space = FunctionSpace(
+            mesh, MixedElement(*[space.ufl_element() for i in range(dim)]))
+    test = TestFunction(space)
+
+    if dim == 1:
+        u = project(sin(pi * X[0])
+                    * exp(2 * pi * X[1]),
+                    space, solver_parameters=ls_parameters_cg)
+    else:
+        u = project(as_vector([sin((2 * i + 1) * pi * X[0])
+                               * exp((2 * i + 2) * pi * X[1])
+                               for i in range(dim)]),
+                    space, solver_parameters=ls_parameters_cg)
+
+    form = inner(dot(u, u) * u, test) * dx
+    assembled_form_ref = Function(space)
+    assemble(form, tensor=function_vector(assembled_form_ref))
+
+    for c in form.coefficients():
+        assert not function_is_replacement(c)
+    form = unbound_form(form, [u])
+    for c in form.coefficients():
+        assert function_is_replacement(c)
+    u = function_copy(u)
+
+    assert "_tlm_adjoint__bindings" not in form._cache
+    bind_form(form, [u])
+    assert "_tlm_adjoint__bindings" in form._cache
+    assembled_form = Function(space)
+    bind_assemble(form, tensor=function_vector(assembled_form))
+    unbind_form(form)
+    assert "_tlm_adjoint__bindings" not in form._cache
+
+    error = function_copy(assembled_form_ref)
+    function_axpy(error, -1.0, assembled_form)
+    assert function_linf_norm(error) == 0.0

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -929,35 +929,53 @@ def test_form_binding(setup_test, test_leaks,
             mesh, MixedElement(*[space.ufl_element() for i in range(dim)]))
     test = TestFunction(space)
 
-    if dim == 1:
-        u = project(sin(pi * X[0])
-                    * exp(2 * pi * X[1]),
-                    space, solver_parameters=ls_parameters_cg)
-    else:
-        u = project(as_vector([sin((2 * i + 1) * pi * X[0])
-                               * exp((2 * i + 2) * pi * X[1])
-                               for i in range(dim)]),
-                    space, solver_parameters=ls_parameters_cg)
+    def test_form(u, u_split, test):
+        if dim == 1:
+            # With FEniCS u.split() is empty for dim=1
+            v = u
+        else:
+            v = as_vector(u_split)
+        return inner(dot(u, v) * u, test) * dx
 
-    form = inner(dot(u, u) * u, test) * dx
-    assembled_form_ref = Function(space)
-    assemble(form, tensor=function_vector(assembled_form_ref))
+    def test_form_deps(u, u_split):
+        if dim == 1:
+            return [u]
+        else:
+            return [u] + list(u_split)
 
+    u = Function(space)
+    # With FEniCS u.split() creates new Coefficient objects
+    u_split = u.split()
+    form = test_form(u, u_split, test)
     for c in form.coefficients():
         assert not function_is_replacement(c)
-    form = unbound_form(form, [u])
+    form = unbound_form(form, test_form_deps(u, u_split))
     for c in form.coefficients():
         assert function_is_replacement(c)
-    u = function_copy(u)
+    del u, u_split
 
-    assert "_tlm_adjoint__bindings" not in form._cache
-    bind_form(form, [u])
-    assert "_tlm_adjoint__bindings" in form._cache
-    assembled_form = Function(space)
-    bind_assemble(form, tensor=function_vector(assembled_form))
-    unbind_form(form)
-    assert "_tlm_adjoint__bindings" not in form._cache
+    for i in range(5):
+        if dim == 1:
+            u = project((i + 1) * sin(pi * X[0]) * exp(2 * pi * X[1]),
+                        space, solver_parameters=ls_parameters_cg)
+        else:
+            u = project((i + 1) * as_vector([sin((2 * j + 1) * pi * X[0])
+                                             * exp((2 * j + 2) * pi * X[1])
+                                            for j in range(dim)]),
+                        space, solver_parameters=ls_parameters_cg)
+        u_split = u.split()
+        assembled_form_ref = Function(space)
+        assemble(test_form(u, u_split, test),
+                 tensor=function_vector(assembled_form_ref))
 
-    error = function_copy(assembled_form_ref)
-    function_axpy(error, -1.0, assembled_form)
-    assert function_linf_norm(error) == 0.0
+        assert "_tlm_adjoint__bindings" not in form._cache
+        bind_form(form, test_form_deps(u, u_split))
+        assert "_tlm_adjoint__bindings" in form._cache
+        assembled_form = Function(space)
+        bind_assemble(form, tensor=function_vector(assembled_form))
+        unbind_form(form)
+        assert "_tlm_adjoint__bindings" not in form._cache
+
+        error = function_copy(assembled_form_ref)
+        function_axpy(error, -1.0, assembled_form)
+        assert function_linf_norm(error) == 0.0

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -921,7 +921,7 @@ def test_form_binding(setup_test, test_leaks,
     from tlm_adjoint.fenics.equations import bind_form, unbind_form, \
         unbound_form
 
-    mesh = UnitSquareMesh(10, 10)
+    mesh = UnitSquareMesh(30, 30)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
     if dim > 1:
@@ -956,11 +956,11 @@ def test_form_binding(setup_test, test_leaks,
 
     for i in range(5):
         if dim == 1:
-            u = project((i + 1) * sin(pi * X[0]) * exp(2 * pi * X[1]),
+            u = project((i + 1) * sin(pi * X[0]) * cos(2 * pi * X[1]),
                         space, solver_parameters=ls_parameters_cg)
         else:
             u = project((i + 1) * as_vector([sin((2 * j + 1) * pi * X[0])
-                                             * exp((2 * j + 2) * pi * X[1])
+                                             * cos((2 * j + 2) * pi * X[1])
                                             for j in range(dim)]),
                         space, solver_parameters=ls_parameters_cg)
         u_split = u.split()
@@ -978,4 +978,4 @@ def test_form_binding(setup_test, test_leaks,
 
         error = function_copy(assembled_form_ref)
         function_axpy(error, -1.0, assembled_form)
-        assert function_linf_norm(error) == 0.0
+        assert function_linf_norm(error) < 1.0e-16

--- a/tests/fenics/test_gauss_newton.py
+++ b/tests/fenics/test_gauss_newton.py
@@ -30,9 +30,8 @@ import pytest
 
 
 @pytest.mark.fenics
+@seed_test
 def test_GaussNewton(setup_test, test_leaks):
-    np.random.seed(50167378 + MPI.COMM_WORLD.rank)
-
     mesh = UnitSquareMesh(10, 10)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -271,9 +271,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             linear_eq = WeakAlias(linear_eq)
 
@@ -282,9 +282,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             manager.drop_references()
 
@@ -293,9 +293,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
         y = Constant(0.0, name="y")
         LinearEquation(b, y, A=M).solve()
@@ -310,7 +310,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             M = WeakAlias(M)
             b = WeakAlias(b)
@@ -319,7 +319,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             manager.drop_references()
 
@@ -327,7 +327,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert b._references_dropped
             assert M._references_dropped
             for dep in b.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
 
         J = Functional(name="J")
         NormSqSolver(z, J.fn()).solve()
@@ -427,7 +427,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [fp_eq, eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             fp_eq = WeakAlias(fp_eq)
@@ -436,7 +436,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [fp_eq, eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             manager.drop_references()
@@ -444,11 +444,11 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             assert len(manager._to_drop_references) == 0
             assert fp_eq._references_dropped
             for dep in fp_eq.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
         eq0.solve()
@@ -459,7 +459,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             eq0 = WeakAlias(eq0)
@@ -469,7 +469,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             manager.drop_references()
@@ -478,7 +478,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert eq._references_dropped
                 for dep in eq.dependencies():
-                    assert isinstance(dep, Replacement)
+                    assert function_is_replacement(dep)
             del eq
 
         J = Functional(name="J")

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -24,7 +24,9 @@ from tlm_adjoint.firedrake import manager as _manager
 from tlm_adjoint.firedrake.backend import backend_Constant, backend_Function
 
 import copy
+import functools
 import gc
+import hashlib
 import logging
 import mpi4py.MPI as MPI
 import numpy as np
@@ -40,6 +42,7 @@ __all__ = \
 
         "run_example",
         "setup_test",
+        "seed_test",
         "test_configurations",
         "test_leaks",
 
@@ -87,6 +90,20 @@ def setup_test():
     if MPI.COMM_WORLD.size > 1:
         if gc_enabled:
             gc.enable()
+
+
+def seed_test(fn):
+    @functools.wraps(fn)
+    def wrapped_fn(*args, **kwargs):
+        h = hashlib.sha256()
+        h.update(fn.__name__.encode("utf-8"))
+        h.update(str(args).encode("utf-8"))
+        h.update(str(sorted(kwargs.items(), key=lambda e: e[0])).encode("utf-8"))  # noqa: E501
+        seed = int(h.hexdigest(), 16) + MPI.COMM_WORLD.rank
+        seed %= 2 ** 32
+        np.random.seed(seed)
+        return fn(*args, **kwargs)
+    return wrapped_fn
 
 
 def params_set(names, *values):

--- a/tests/firedrake/test_caches.py
+++ b/tests/firedrake/test_caches.py
@@ -73,7 +73,7 @@ def test_clear_caches(setup_test, test_leaks):
     function_update_caches(F, value=Function(space))
     test_cleared(F, cached_form)
 
-    # Clear on cache update, Replacement with new Function
+    # Clear on cache update, replacement with new Function
     cached_form = cache_item(F)
     test_not_cleared(F, cached_form)
     function_update_caches(function_replacement(F), value=Function(space))

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -910,7 +910,7 @@ def test_form_binding(setup_test, test_leaks,
     from tlm_adjoint.firedrake.equations import bind_form, unbind_form, \
         unbound_form
 
-    mesh = UnitSquareMesh(10, 10)
+    mesh = UnitSquareMesh(30, 30)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
     if dim > 1:
@@ -945,11 +945,11 @@ def test_form_binding(setup_test, test_leaks,
 
     for i in range(5):
         if dim == 1:
-            u = project((i + 1) * sin(pi * X[0]) * exp(2 * pi * X[1]),
+            u = project((i + 1) * sin(pi * X[0]) * cos(2 * pi * X[1]),
                         space, solver_parameters=ls_parameters_cg)
         else:
             u = project((i + 1) * as_vector([sin((2 * j + 1) * pi * X[0])
-                                             * exp((2 * j + 2) * pi * X[1])
+                                             * cos((2 * j + 2) * pi * X[1])
                                             for j in range(dim)]),
                         space, solver_parameters=ls_parameters_cg)
         u_split = u.split()

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -918,35 +918,53 @@ def test_form_binding(setup_test, test_leaks,
             mesh, MixedElement(*[space.ufl_element() for i in range(dim)]))
     test = TestFunction(space)
 
-    if dim == 1:
-        u = project(sin(pi * X[0])
-                    * exp(2 * pi * X[1]),
-                    space, solver_parameters=ls_parameters_cg)
-    else:
-        u = project(as_vector([sin((2 * i + 1) * pi * X[0])
-                               * exp((2 * i + 2) * pi * X[1])
-                               for i in range(dim)]),
-                    space, solver_parameters=ls_parameters_cg)
+    def test_form(u, u_split, test):
+        if dim == 1:
+            # With FEniCS u.split() is empty for dim=1
+            v = u
+        else:
+            v = as_vector(u_split)
+        return inner(dot(u, v) * u, test) * dx
 
-    form = inner(dot(u, u) * u, test) * dx
-    assembled_form_ref = Function(space)
-    assemble(form, tensor=function_vector(assembled_form_ref))
+    def test_form_deps(u, u_split):
+        if dim == 1:
+            return [u]
+        else:
+            return [u] + list(u_split)
 
+    u = Function(space)
+    # With FEniCS u.split() creates new Coefficient objects
+    u_split = u.split()
+    form = test_form(u, u_split, test)
     for c in form.coefficients():
         assert not function_is_replacement(c)
-    form = unbound_form(form, [u])
+    form = unbound_form(form, test_form_deps(u, u_split))
     for c in form.coefficients():
         assert function_is_replacement(c)
-    u = function_copy(u)
+    del u, u_split
 
-    assert "_tlm_adjoint__bindings" not in form._cache
-    bind_form(form, [u])
-    assert "_tlm_adjoint__bindings" in form._cache
-    assembled_form = Function(space)
-    bind_assemble(form, tensor=function_vector(assembled_form))
-    unbind_form(form)
-    assert "_tlm_adjoint__bindings" not in form._cache
+    for i in range(5):
+        if dim == 1:
+            u = project((i + 1) * sin(pi * X[0]) * exp(2 * pi * X[1]),
+                        space, solver_parameters=ls_parameters_cg)
+        else:
+            u = project((i + 1) * as_vector([sin((2 * j + 1) * pi * X[0])
+                                             * exp((2 * j + 2) * pi * X[1])
+                                            for j in range(dim)]),
+                        space, solver_parameters=ls_parameters_cg)
+        u_split = u.split()
+        assembled_form_ref = Function(space)
+        assemble(test_form(u, u_split, test),
+                 tensor=function_vector(assembled_form_ref))
 
-    error = function_copy(assembled_form_ref)
-    function_axpy(error, -1.0, assembled_form)
-    assert function_linf_norm(error) == 0.0
+        assert "_tlm_adjoint__bindings" not in form._cache
+        bind_form(form, test_form_deps(u, u_split))
+        assert "_tlm_adjoint__bindings" in form._cache
+        assembled_form = Function(space)
+        bind_assemble(form, tensor=function_vector(assembled_form))
+        unbind_form(form)
+        assert "_tlm_adjoint__bindings" not in form._cache
+
+        error = function_copy(assembled_form_ref)
+        function_axpy(error, -1.0, assembled_form)
+        assert function_linf_norm(error) == 0.0

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -799,6 +799,75 @@ def test_initial_guess(setup_test, test_leaks):
 
 
 @pytest.mark.firedrake
+@pytest.mark.parametrize("dim", [1, 2, 3, 4])
+def test_form_binding(setup_test, test_leaks,
+                      dim):
+    from tlm_adjoint.firedrake.backend_code_generator_interface import \
+        assemble as bind_assemble
+    from tlm_adjoint.firedrake.equations import bind_form, unbind_form, \
+        unbound_form
+
+    mesh = UnitSquareMesh(30, 30)
+    X = SpatialCoordinate(mesh)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    if dim > 1:
+        space = FunctionSpace(
+            mesh, MixedElement(*[space.ufl_element() for i in range(dim)]))
+    test = TestFunction(space)
+
+    def test_form(u, u_split, test):
+        if dim == 1:
+            # With FEniCS u.split() is empty for dim=1
+            v = u
+        else:
+            v = as_vector(u_split)
+        return inner(dot(u, v) * u, test) * dx
+
+    def test_form_deps(u, u_split):
+        if dim == 1:
+            return [u]
+        else:
+            return [u] + list(u_split)
+
+    u = Function(space)
+    # With FEniCS u.split() creates new Coefficient objects
+    u_split = u.split()
+    form = test_form(u, u_split, test)
+    for c in form.coefficients():
+        assert not function_is_replacement(c)
+    form = unbound_form(form, test_form_deps(u, u_split))
+    for c in form.coefficients():
+        assert function_is_replacement(c)
+    del u, u_split
+
+    for i in range(5):
+        if dim == 1:
+            u = project((i + 1) * sin(pi * X[0]) * cos(2 * pi * X[1]),
+                        space, solver_parameters=ls_parameters_cg)
+        else:
+            u = project((i + 1) * as_vector([sin((2 * j + 1) * pi * X[0])
+                                             * cos((2 * j + 2) * pi * X[1])
+                                            for j in range(dim)]),
+                        space, solver_parameters=ls_parameters_cg)
+        u_split = u.split()
+        assembled_form_ref = Function(space)
+        assemble(test_form(u, u_split, test),
+                 tensor=function_vector(assembled_form_ref))
+
+        assert "_tlm_adjoint__bindings" not in form._cache
+        bind_form(form, test_form_deps(u, u_split))
+        assert "_tlm_adjoint__bindings" in form._cache
+        assembled_form = Function(space)
+        bind_assemble(form, tensor=function_vector(assembled_form))
+        unbind_form(form)
+        assert "_tlm_adjoint__bindings" not in form._cache
+
+        error = function_copy(assembled_form_ref)
+        function_axpy(error, -1.0, assembled_form)
+        assert function_linf_norm(error) == 0.0
+
+
+@pytest.mark.firedrake
 @pytest.mark.parametrize("cache_rhs_assembly", [True, False])
 def test_EquationSolver_form_binding_bc(setup_test, test_leaks,
                                         cache_rhs_assembly):
@@ -899,72 +968,3 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
 
     min_order = taylor_test_tlm_adjoint(forward, m, adjoint_order=2)
     assert min_order > 2.00
-
-
-@pytest.mark.firedrake
-@pytest.mark.parametrize("dim", [1, 2, 3, 4])
-def test_form_binding(setup_test, test_leaks,
-                      dim):
-    from tlm_adjoint.firedrake.backend_code_generator_interface import \
-        assemble as bind_assemble
-    from tlm_adjoint.firedrake.equations import bind_form, unbind_form, \
-        unbound_form
-
-    mesh = UnitSquareMesh(30, 30)
-    X = SpatialCoordinate(mesh)
-    space = FunctionSpace(mesh, "Lagrange", 1)
-    if dim > 1:
-        space = FunctionSpace(
-            mesh, MixedElement(*[space.ufl_element() for i in range(dim)]))
-    test = TestFunction(space)
-
-    def test_form(u, u_split, test):
-        if dim == 1:
-            # With FEniCS u.split() is empty for dim=1
-            v = u
-        else:
-            v = as_vector(u_split)
-        return inner(dot(u, v) * u, test) * dx
-
-    def test_form_deps(u, u_split):
-        if dim == 1:
-            return [u]
-        else:
-            return [u] + list(u_split)
-
-    u = Function(space)
-    # With FEniCS u.split() creates new Coefficient objects
-    u_split = u.split()
-    form = test_form(u, u_split, test)
-    for c in form.coefficients():
-        assert not function_is_replacement(c)
-    form = unbound_form(form, test_form_deps(u, u_split))
-    for c in form.coefficients():
-        assert function_is_replacement(c)
-    del u, u_split
-
-    for i in range(5):
-        if dim == 1:
-            u = project((i + 1) * sin(pi * X[0]) * cos(2 * pi * X[1]),
-                        space, solver_parameters=ls_parameters_cg)
-        else:
-            u = project((i + 1) * as_vector([sin((2 * j + 1) * pi * X[0])
-                                             * cos((2 * j + 2) * pi * X[1])
-                                            for j in range(dim)]),
-                        space, solver_parameters=ls_parameters_cg)
-        u_split = u.split()
-        assembled_form_ref = Function(space)
-        assemble(test_form(u, u_split, test),
-                 tensor=function_vector(assembled_form_ref))
-
-        assert "_tlm_adjoint__bindings" not in form._cache
-        bind_form(form, test_form_deps(u, u_split))
-        assert "_tlm_adjoint__bindings" in form._cache
-        assembled_form = Function(space)
-        bind_assemble(form, tensor=function_vector(assembled_form))
-        unbind_form(form)
-        assert "_tlm_adjoint__bindings" not in form._cache
-
-        error = function_copy(assembled_form_ref)
-        function_axpy(error, -1.0, assembled_form)
-        assert function_linf_norm(error) == 0.0

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -800,6 +800,7 @@ def test_initial_guess(setup_test, test_leaks):
 
 @pytest.mark.firedrake
 @pytest.mark.parametrize("dim", [1, 2, 3, 4])
+@seed_test
 def test_form_binding(setup_test, test_leaks,
                       dim):
     from tlm_adjoint.firedrake.backend_code_generator_interface import \
@@ -869,6 +870,7 @@ def test_form_binding(setup_test, test_leaks,
 
 @pytest.mark.firedrake
 @pytest.mark.parametrize("cache_rhs_assembly", [True, False])
+@seed_test
 def test_EquationSolver_form_binding_bc(setup_test, test_leaks,
                                         cache_rhs_assembly):
     mesh = UnitSquareMesh(20, 20)
@@ -883,14 +885,14 @@ def test_EquationSolver_form_binding_bc(setup_test, test_leaks,
 
         x = Function(space, name="x")
         CustomEquationSolver(
-            inner(test, m * trial) * dx == inner(test, Constant(0.0)) * dx,
+            inner(m * trial, test) * dx == inner(Constant(2.0), test) * dx,
             x, DirichletBC(space, 1.0, "on_boundary"),
             solver_parameters=ls_parameters_cg,
             cache_jacobian=False,
             cache_rhs_assembly=cache_rhs_assembly).solve()
 
         J = Functional(name="J")
-        J.assign(inner(dot(x, x), dot(x, x)) * dx)
+        J.assign(((1 + x) ** 3) * dx)
         return J
 
     # m should not be static for this test
@@ -916,7 +918,7 @@ def test_EquationSolver_form_binding_bc(setup_test, test_leaks,
     assert min_order > 1.99
 
     min_order = taylor_test_tlm_adjoint(forward, m, adjoint_order=1)
-    assert min_order > 1.98
+    assert min_order > 1.99
 
     min_order = taylor_test_tlm_adjoint(forward, m, adjoint_order=2)
     assert min_order > 1.99

--- a/tests/firedrake/test_gauss_newton.py
+++ b/tests/firedrake/test_gauss_newton.py
@@ -31,9 +31,8 @@ import pytest
 
 
 @pytest.mark.firedrake
+@seed_test
 def test_GaussNewton(setup_test, test_leaks):
-    np.random.seed(50167378 + MPI.COMM_WORLD.rank)
-
     mesh = UnitSquareMesh(10, 10)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -274,9 +274,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             linear_eq = WeakAlias(linear_eq)
 
@@ -285,9 +285,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             manager.drop_references()
 
@@ -296,9 +296,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
         y = Constant(0.0, name="y")
         LinearEquation(b, y, A=M).solve()
@@ -313,7 +313,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             M = WeakAlias(M)
             b = WeakAlias(b)
@@ -322,7 +322,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             manager.drop_references()
 
@@ -330,7 +330,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert b._references_dropped
             assert M._references_dropped
             for dep in b.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
 
         J = Functional(name="J")
         NormSqSolver(z, J.fn()).solve()
@@ -430,7 +430,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [fp_eq, eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             fp_eq = WeakAlias(fp_eq)
@@ -439,7 +439,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [fp_eq, eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             manager.drop_references()
@@ -447,11 +447,11 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             assert len(manager._to_drop_references) == 0
             assert fp_eq._references_dropped
             for dep in fp_eq.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
         eq0.solve()
@@ -462,7 +462,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             eq0 = WeakAlias(eq0)
@@ -472,7 +472,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             manager.drop_references()
@@ -481,7 +481,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert eq._references_dropped
                 for dep in eq.dependencies():
-                    assert isinstance(dep, Replacement)
+                    assert function_is_replacement(dep)
             del eq
 
         J = Functional(name="J")

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -142,9 +142,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             linear_eq = WeakAlias(linear_eq)
 
@@ -153,9 +153,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             manager.drop_references()
 
@@ -164,9 +164,9 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in linear_eq.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
         y = Constant(0.0, name="y")
         LinearEquation(b, y, A=M).solve()
@@ -181,7 +181,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             M = WeakAlias(M)
             b = WeakAlias(b)
@@ -190,7 +190,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert not b._references_dropped
             assert not M._references_dropped
             for dep in b.dependencies():
-                assert not isinstance(dep, Replacement)
+                assert not function_is_replacement(dep)
 
             manager.drop_references()
 
@@ -198,7 +198,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             assert b._references_dropped
             assert M._references_dropped
             for dep in b.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
 
         J = Functional(name="J")
         NormSqSolver(z, J.fn()).solve()
@@ -298,7 +298,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [fp_eq, eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             fp_eq = WeakAlias(fp_eq)
@@ -307,7 +307,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [fp_eq, eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             manager.drop_references()
@@ -315,11 +315,11 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             assert len(manager._to_drop_references) == 0
             assert fp_eq._references_dropped
             for dep in fp_eq.dependencies():
-                assert isinstance(dep, Replacement)
+                assert function_is_replacement(dep)
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
         eq0.solve()
@@ -330,7 +330,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             eq0 = WeakAlias(eq0)
@@ -340,7 +340,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert not eq._references_dropped
                 for dep in eq.dependencies():
-                    assert not isinstance(dep, Replacement)
+                    assert not function_is_replacement(dep)
             del eq
 
             manager.drop_references()
@@ -349,7 +349,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             for eq in [eq0, eq1]:
                 assert eq._references_dropped
                 for dep in eq.dependencies():
-                    assert isinstance(dep, Replacement)
+                    assert function_is_replacement(dep)
             del eq
 
         J = Functional(name="J")

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -582,9 +582,8 @@ class Replacement(ufl.classes.Coefficient):
             domain, = x_domains
 
         super().__init__(x_space, count=new_count())
-        self.__domain = domain
         self.__space = space
-        self.__name = function_name(x)
+        self.__domain = domain
         add_interface(self, ReplacementInterface,
                       {"id": function_id(x), "name": function_name(x),
                        "space": x_space, "static": function_is_static(x),
@@ -594,42 +593,6 @@ class Replacement(ufl.classes.Coefficient):
 
     def function_space(self):
         return self.__space
-
-    def id(self):
-        warnings.warn("Replacement.id method is deprecated -- "
-                      "use function_id instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_id(self)
-
-    def name(self):
-        warnings.warn("Replacement.name is deprecated -- "
-                      "use function_name instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_name(self)
-
-    def is_static(self):
-        warnings.warn("Replacement.is_static is deprecated -- "
-                      "use function_is_static instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_static(self)
-
-    def is_cached(self):
-        warnings.warn("Replacement.is_cached is deprecated -- "
-                      "use function_is_cached instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_cached(self)
-
-    def is_checkpointed(self):
-        warnings.warn("Replacement.is_checkpointed is deprecated -- "
-                      "use function_is_checkpointed instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_checkpointed(self)
-
-    def caches(self):
-        warnings.warn("Replacement.caches is deprecated -- "
-                      "use function_caches instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_caches(self)
 
     def ufl_domain(self):
         return self.__domain

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -40,7 +40,6 @@ __all__ = \
         "DirichletBC",
         "Function",
         "HomogeneousDirichletBC",
-        "Replacement",
         "ReplacementConstant",
         "ReplacementFunction",
         "ZeroConstant",

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -41,6 +41,8 @@ __all__ = \
         "Function",
         "HomogeneousDirichletBC",
         "Replacement",
+        "ReplacementConstant",
+        "ReplacementFunction",
         "ZeroConstant",
         "ZeroFunction",
         "bcs_is_cached",
@@ -242,7 +244,7 @@ class ConstantInterface(_FunctionInterface):
 
     def _replacement(self):
         if not hasattr(self, "_tlm_adjoint__replacement"):
-            self._tlm_adjoint__replacement = Replacement(self)
+            self._tlm_adjoint__replacement = ReplacementConstant(self)
         return self._tlm_adjoint__replacement
 
     def _is_replacement(self):
@@ -589,6 +591,16 @@ class Replacement(ufl.classes.Coefficient):
             return ()
         else:
             return (self.__domain,)
+
+
+class ReplacementConstant(backend_Constant, Replacement):
+    def __init__(self, x):
+        Replacement.__init__(self, x)
+
+
+class ReplacementFunction(backend_Function, Replacement):
+    def __init__(self, x):
+        Replacement.__init__(self, x)
 
 
 def replaced_expr(expr):

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -242,9 +242,7 @@ class ConstantInterface(_FunctionInterface):
 
     def _replacement(self):
         if not hasattr(self, "_tlm_adjoint__replacement"):
-            # Firedrake requires Constant.function_space() to return None
-            self._tlm_adjoint__replacement = \
-                Replacement(self, space=None)
+            self._tlm_adjoint__replacement = Replacement(self)
         return self._tlm_adjoint__replacement
 
     def _is_replacement(self):
@@ -565,15 +563,8 @@ class ReplacementInterface(_FunctionInterface):
 
 
 class Replacement(ufl.classes.Coefficient):
-    def __init__(self, x, *args, **kwargs):
-        if len(args) > 0 or len(kwargs) > 0:
-            def extract_args(x, space):
-                return x, space
-            x, space = extract_args(x, *args, **kwargs)
-            x_space = function_space(x)
-        else:
-            space = function_space(x)
-            x_space = space
+    def __init__(self, x):
+        space = function_space(x)
 
         x_domains = x.ufl_domains()
         if len(x_domains) == 0:
@@ -581,18 +572,14 @@ class Replacement(ufl.classes.Coefficient):
         else:
             domain, = x_domains
 
-        super().__init__(x_space, count=new_count())
-        self.__space = space
+        super().__init__(space, count=new_count())
         self.__domain = domain
         add_interface(self, ReplacementInterface,
                       {"id": function_id(x), "name": function_name(x),
-                       "space": x_space, "static": function_is_static(x),
+                       "space": space, "static": function_is_static(x),
                        "cache": function_is_cached(x),
                        "checkpoint": function_is_checkpointed(x),
                        "caches": function_caches(x)})
-
-    def function_space(self):
-        return self.__space
 
     def ufl_domain(self):
         return self.__domain

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -34,7 +34,7 @@ from .backend_code_generator_interface import assemble, is_valid_r0_space, \
 from .caches import form_neg
 from .equations import AssembleSolver, EquationSolver
 from .functions import Caches, Constant, ConstantInterface, \
-    ConstantSpaceInterface, Function, Replacement, Zero
+    ConstantSpaceInterface, Function, ReplacementFunction, Zero
 
 import mpi4py.MPI as MPI
 import numpy as np
@@ -276,7 +276,7 @@ class FunctionInterface(_FunctionInterface):
 
     def _replacement(self):
         if not hasattr(self, "_tlm_adjoint__replacement"):
-            self._tlm_adjoint__replacement = Replacement(self)
+            self._tlm_adjoint__replacement = ReplacementFunction(self)
         return self._tlm_adjoint__replacement
 
     def _is_replacement(self):

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -184,7 +184,9 @@ def form_bindings(*forms):
 def bind_forms(*forms):
     for dep, binding in form_bindings(*forms):
         for name in _form_binding_names:
-            assert not hasattr(dep, name)
+            if hasattr(dep, name):
+                old_name = f"_tlm_adjoint__bindings_old_{name:s}"
+                setattr(dep, old_name, getattr(dep, name))
             setattr(dep, name, getattr(binding, name))
 
 
@@ -192,6 +194,10 @@ def unbind_forms(*forms):
     for dep, binding in form_bindings(*forms):
         for name in _form_binding_names:
             delattr(dep, name)
+            old_name = f"_tlm_adjoint__bindings_old_{name:s}"
+            if hasattr(dep, old_name):
+                setattr(dep, name, getattr(dep, old_name))
+                delattr(dep, old_name)
 
 
 def _assemble(form, tensor=None, form_compiler_parameters=None,

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -34,7 +34,7 @@ from .backend_code_generator_interface import assemble, is_valid_r0_space
 from .caches import form_neg
 from .equations import AssembleSolver, EquationSolver
 from .functions import Caches, Constant, ConstantInterface, \
-    ConstantSpaceInterface, Function, Replacement, Zero
+    ConstantSpaceInterface, Function, ReplacementFunction, Zero
 
 import mpi4py.MPI as MPI
 import numpy as np
@@ -286,7 +286,7 @@ class FunctionInterface(_FunctionInterface):
 
     def _replacement(self):
         if not hasattr(self, "_tlm_adjoint__replacement"):
-            self._tlm_adjoint__replacement = Replacement(self)
+            self._tlm_adjoint__replacement = ReplacementFunction(self)
         return self._tlm_adjoint__replacement
 
     def _is_replacement(self):
@@ -313,6 +313,17 @@ def _Function__init__(self, *args, **kwargs):
 assert not hasattr(backend_Function, "_tlm_adjoint__orig___init__")
 backend_Function._tlm_adjoint__orig___init__ = backend_Function.__init__
 backend_Function.__init__ = _Function__init__
+
+
+def _Function__getattr__(self, key):
+    if "_data" not in self.__dict__:
+        raise AttributeError(f"No attribute '{key:s}'")
+    return backend_Function._tlm_adjoint__orig__getattr__(self, key)
+
+
+assert not hasattr(backend_Function, "_tlm_adjoint__orig__getattr__")
+backend_Function._tlm_adjoint__orig__getattr__ = backend_Function.__getattr__
+backend_Function.__getattr__ = _Function__getattr__
 
 
 def _new_scalar_function(name=None, comm=None, static=False, cache=None,

--- a/tlm_adjoint/numpy/backend_interface.py
+++ b/tlm_adjoint/numpy/backend_interface.py
@@ -37,7 +37,6 @@ __all__ = \
 
         "Function",
         "FunctionSpace",
-        "Replacement",
 
         "RealFunctionSpace",
         "copy_parameters_dict",


### PR DESCRIPTION
These inherit from Constant and Function, as needed by Firedrake assembly. Also remove deprecated Replacement methods, and remove Replacement from `__all__`.