### PR TITLE
Update tests

### DIFF
--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -239,9 +239,9 @@ def test_FixedPointSolver(setup_test, test_leaks):
     J = forward(a, b)
     stop_manager()
 
-    x_val = complex(x)
-    a_val = complex(a)
-    b_val = complex(b)
+    x_val = function_scalar_value(x)
+    a_val = function_scalar_value(a)
+    b_val = function_scalar_value(b)
     assert abs(x_val * np.sqrt(x_val + b_val) - a_val) < 1.0e-14
 
     J_val = J.value()

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -169,7 +169,7 @@ def test_empty(setup_test, test_leaks):
     stop_manager()
 
     dJ = compute_gradient(J, m)
-    assert complex(dJ) == 0.0
+    assert function_scalar_value(dJ) == 0.0
 
 
 @pytest.mark.fenics

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -241,9 +241,9 @@ def test_FixedPointSolver(setup_test, test_leaks):
     J = forward(a, b)
     stop_manager()
 
-    x_val = complex(x)
-    a_val = complex(a)
-    b_val = complex(b)
+    x_val = function_scalar_value(x)
+    a_val = function_scalar_value(a)
+    b_val = function_scalar_value(b)
     assert abs(x_val * np.sqrt(x_val + b_val) - a_val) < 1.0e-14
 
     J_val = J.value()

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -171,7 +171,7 @@ def test_empty(setup_test, test_leaks):
     stop_manager()
 
     dJ = compute_gradient(J, m)
-    assert complex(dJ) == 0.0
+    assert function_scalar_value(dJ) == 0.0
 
 
 @pytest.mark.firedrake

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -52,8 +52,6 @@ def setup_test():
 
     logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
 
-    np.random.seed(14012313)
-
     set_default_dtype(np.float64)
 
 

--- a/tests/numpy/test_equations.py
+++ b/tests/numpy/test_equations.py
@@ -27,7 +27,8 @@ import pytest
 
 
 @pytest.mark.numpy
-def test_AssignmentSolver(setup_test, test_leaks):
+@seed_test
+def test_AssignmentSolver(setup_test, test_leaks, test_default_dtypes):
     x = Constant(16.0, name="x", static=True)
 
     def forward(x):
@@ -37,20 +38,21 @@ def test_AssignmentSolver(setup_test, test_leaks):
         AssignmentSolver(x, y[0]).solve()
         for i in range(len(y) - 1):
             AssignmentSolver(y[i], y[i + 1]).solve()
-        NormSqSolver(y[-1], z).solve()  # Should have no effect on sensitivity
-        NormSqSolver(y[-1], z).solve()
+        # Following line should have no effect on sensitivity
+        DotProductSolver(y[-1], y[-1], z).solve()
+        DotProductSolver(y[-1], y[-1], z).solve()
 
-        x_norm_sq = Constant(name="x_norm_sq")
-        NormSqSolver(x, x_norm_sq).solve()
+        x_dot_x = Constant(name="x_dot_x")
+        DotProductSolver(x, x, x_dot_x).solve()
 
-        z_norm_sq = Constant(name="z_norm_sq")
-        NormSqSolver(z, z_norm_sq).solve()
+        z_dot_z = Constant(name="z_dot_z")
+        DotProductSolver(z, z, z_dot_z).solve()
 
         J = Functional(name="J")
-        AxpySolver(z_norm_sq, 2.0, x_norm_sq, J.fn()).solve()
+        AxpySolver(z_dot_z, 2.0, x_dot_x, J.fn()).solve()
 
         K = Functional(name="K")
-        AssignmentSolver(z_norm_sq, K.fn()).solve()
+        AssignmentSolver(z_dot_z, K.fn()).solve()
 
         return J, K
 
@@ -87,7 +89,8 @@ def test_AssignmentSolver(setup_test, test_leaks):
 
 
 @pytest.mark.numpy
-def test_AxpySolver(setup_test, test_leaks):
+@seed_test
+def test_AxpySolver(setup_test, test_leaks, test_default_dtypes):
     x = Constant(1.0, name="x", static=True)
 
     def forward(x):
@@ -98,10 +101,10 @@ def test_AxpySolver(setup_test, test_leaks):
         AssignmentSolver(x, y[0]).solve()
         for i in range(len(y) - 1):
             AxpySolver(y[i], i + 1, z[0], y[i + 1]).solve()
-        NormSqSolver(y[-1], z[1]).solve()
+        DotProductSolver(y[-1], y[-1], z[1]).solve()
 
         J = Functional(name="J")
-        NormSqSolver(z[1], J.fn()).solve()
+        DotProductSolver(z[1], z[1], J.fn()).solve()
         return J
 
     start_manager()
@@ -135,7 +138,8 @@ def test_AxpySolver(setup_test, test_leaks):
 
 
 @pytest.mark.numpy
-def test_SumSolver(setup_test, test_leaks):
+@seed_test
+def test_SumSolver(setup_test, test_leaks, test_default_dtypes):
     space = FunctionSpace(10)
 
     def forward(F):
@@ -147,7 +151,11 @@ def test_SumSolver(setup_test, test_leaks):
         return J
 
     F = Function(space, name="F", static=True)
-    function_set_values(F, np.random.random(function_local_size(F)))
+    F_arr = np.random.random(function_local_size(F))
+    if issubclass(function_dtype(F), (complex, np.complexfloating)):
+        F_arr = F_arr + 1.0j * np.random.random(function_local_size(F))
+    function_set_values(F, F_arr)
+    del F_arr
 
     start_manager()
     J = forward(F)
@@ -160,6 +168,7 @@ def test_SumSolver(setup_test, test_leaks):
 
 
 @pytest.mark.numpy
+@seed_test
 def test_InnerProductSolver(setup_test, test_leaks):
     space = FunctionSpace(10)
 
@@ -172,7 +181,11 @@ def test_InnerProductSolver(setup_test, test_leaks):
         return J
 
     F = Function(space, name="F", static=True)
-    function_set_values(F, np.random.random(function_local_size(F)))
+    F_arr = np.random.random(function_local_size(F))
+    if issubclass(function_dtype(F), (complex, np.complexfloating)):
+        F_arr = F_arr + 1.0j * np.random.random(function_local_size(F))
+    function_set_values(F, F_arr)
+    del F_arr
 
     start_manager()
     J = forward(F)
@@ -184,27 +197,38 @@ def test_InnerProductSolver(setup_test, test_leaks):
 
 
 @pytest.mark.numpy
-def test_ContractionSolver(setup_test, test_leaks):
+@seed_test
+def test_ContractionSolver(setup_test, test_leaks, test_default_dtypes):
     dtype = default_dtype()
 
-    space_0 = FunctionSpace(1)
     space = FunctionSpace(3)
-    A = np.array([[1.0, 2.0, 3.0], [0.0, 4.0, 5.0], [0.0, 0.0, 6.0]],
-                 dtype=dtype)
+    if issubclass(dtype, (complex, np.complexfloating)):
+        A = np.array([[1.0 + 10.0j, 2.0 + 11.0j, 3.0 + 12.0j],
+                      [0.0, 4.0 + 13.0j, 5.0 + 14.0j],
+                      [0.0, 0.0, 6.0 + 15.0j]],
+                     dtype=dtype)
+    else:
+        A = np.array([[1.0, 2.0, 3.0], [0.0, 4.0, 5.0], [0.0, 0.0, 6.0]],
+                     dtype=dtype)
 
     def forward(m):
         x = Function(space, name="x")
         ContractionSolver(A, (1,), (m,), x).solve()
 
-        norm_sq = Function(space_0, name="norm_sq")
-        NormSqSolver(x, norm_sq).solve()
+        x_dot_x = Constant(name="x_dot_x")
+        DotProductSolver(x, x, x_dot_x).solve()
 
         J = Functional(name="J")
-        NormSqSolver(norm_sq, J.fn()).solve()
+        DotProductSolver(x_dot_x, x_dot_x, J.fn()).solve()
         return x, J
 
     m = Function(space, name="m", static=True)
-    function_set_values(m, np.array([7.0, 8.0, 9.0], dtype=dtype))
+    if issubclass(dtype, (complex, np.complexfloating)):
+        function_set_values(
+            m, np.array([7.0 + 16.0j, 8.0 + 17.0j, 9.0 + 18.0j], dtype=dtype))
+    else:
+        function_set_values(
+            m, np.array([7.0, 8.0, 9.0], dtype=dtype))
 
     start_manager()
     x, J = forward(m)
@@ -212,7 +236,7 @@ def test_ContractionSolver(setup_test, test_leaks):
 
     A_action = A.dot(m.vector())
     assert abs(A_action - x.vector()).max() == 0.0
-    assert abs(A_action.conjugate().dot(A_action)) ** 2 - J.value() == 0.0
+    assert abs(A_action.dot(A_action) ** 2 - J.value()) == 0.0
 
     J_val = J.value()
 
@@ -236,50 +260,3 @@ def test_ContractionSolver(setup_test, test_leaks):
 
     min_order = taylor_test_tlm_adjoint(forward_J, m, adjoint_order=2)
     assert min_order > 2.00
-
-
-@pytest.mark.numpy
-def test_ContractionSolver_complex(setup_test, test_leaks):
-    set_default_dtype(np.complex128)
-    dtype = default_dtype()
-
-    space = FunctionSpace(3)
-    A = np.array([[1.0 + 10.0j, 2.0 + 11.0j, 3.0 + 12.0j],
-                  [0.0, 4.0 + 13.0j, 5.0 + 14.0j],
-                  [0.0, 0.0, 6.0 + 15.0j]],
-                 dtype=dtype)
-
-    def forward(m):
-        x = Function(space, name="x")
-        ContractionSolver(A, (1,), (m,), x).solve()
-
-        J = Functional(name="J")
-        SumSolver(x, J.fn()).solve()
-        return x, J
-
-    m = Function(space, name="m", static=True)
-    function_set_values(m, np.array([7.0 + 16.0j, 8.0 + 17.0j, 9.0 + 18.0j],
-                                    dtype=dtype))
-
-    start_manager()
-    x, J = forward(m)
-    stop_manager()
-
-    A_action = A.dot(m.vector())
-    assert abs(A_action - x.vector()).max() == 0.0
-    assert A_action.sum() - J.value() == 0.0
-
-    dJ = compute_gradient(J, m)
-
-    def forward_m_val(m_val):
-        m = Function(space)
-        function_set_values(m, m_val)
-        return forward(m)[1].value()
-
-    dJ_ref = np.full(3, np.NAN, dtype=dtype)
-    for i in range(3):
-        m_val = np.zeros(3, dtype=dtype)
-        m_val[i] = 1.0
-        dJ_ref[i] = forward_m_val(m_val)
-
-    assert abs(dJ.vector().conjugate() - dJ_ref).max() == 0.0

--- a/tests/numpy/test_examples.py
+++ b/tests/numpy/test_examples.py
@@ -28,5 +28,6 @@ import pytest
 
 @pytest.mark.numpy
 @pytest.mark.example
+@seed_test
 def test_diffusion(setup_test, test_leaks):
     run_example(os.path.join("diffusion", "diffusion.py"))


### PR DESCRIPTION
- Add further complex NumPy tests
- Use `seed_test` decorator with NumPy tests
- Update the NumPy diffusion example
- Replace use of `complex` with `function_scalar_value` in FEniCS and Firedrake tests