### PR TITLE
Add missing complex conjugation in Hessian.action_fn and GaussNewton.action_fn

### DIFF
--- a/tlm_adjoint/hessian.py
+++ b/tlm_adjoint/hessian.py
@@ -66,7 +66,7 @@ class Hessian:
 
         def action(dm):
             _, _, ddJ = self.action(m, dm, M0=m0)
-            return function_get_values(ddJ)
+            return function_get_values(ddJ).conjugate()
 
         return action
 
@@ -244,7 +244,7 @@ class GaussNewton:
     def action_fn(self, m, m0=None):
         def action(dm):
             ddJ = self.action(m, dm, M0=m0)
-            return function_get_values(ddJ)
+            return function_get_values(ddJ).conjugate()
 
         return action
 


### PR DESCRIPTION
`compute_gradient` returns the complex conjugate of the linear sensitivity, so that evaluation of a linear sensitivity functional is equivalent to a \mathbb{C}^N inner product. Similarly `Hessian.action` and `GaussNewton.action` return the complex conjugate of the Hessian action. Hence an extra complex conjugation is needed in `Hessian.action_fn` and `GaussNewton.action_fn`.