### PR TITLE
Primal/dual spaces

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -952,7 +952,7 @@ the form
 def __init__(self, x, deps, nl_deps=None,
              *, ic_deps=None, ic=None,
              adj_ic_deps=None, adj_ic=None,
-             adj_type="dual"):
+             adj_type="conjugate_dual"):
 \end{lstlisting}
 with constructor arguments
 \begin{itemize}
@@ -974,9 +974,9 @@ with constructor arguments
   \item \texttt{adj\_ic}, if true sets \texttt{adj\_ic\_deps} to be the
     solution to the equation. Defaults to true if \texttt{adj\_ic\_deps} is
     \texttt{None}, and false otherwise.
-  \item \texttt{adj\_type}, ``primal'' or ``dual'', defining whether the
-    adjoint is in the dual space associated with the solution to the equation,
-    \texttt{x}.
+  \item \texttt{adj\_type}, ``primal'' or ``conjugate\_dual'', defining whether
+    the adjoint is in the primal or conjugate dual space associated with the
+    solution to the equation, \texttt{x}.
 \end{itemize}
 
 \subsection{Forward}
@@ -1176,7 +1176,7 @@ arguments \texttt{x}, \texttt{adj\_x}, and \texttt{b} in the above should be
 capitalized \texttt{X}, \texttt{adj\_X}, and \texttt{B}, and should each be a
 sequence of functions. The return value of \texttt{adjoint\_jacobian\_solve}
 should also be a sequence of functions. \texttt{adj\_type} may be a sequence
-with elements equal to ``primal'' or ``dual''.
+with elements equal to ``primal'' or ``conjugate\_dual''.
 
 \subsection{Dropping references}\label{sect:drop_references}
 
@@ -1201,7 +1201,7 @@ where $A$ is a matrix and the $b_i$ are independent of $x$.
 
 The \texttt{LinearEquation} constructor has the form
 \begin{lstlisting}
-def __init__(self, B, X, *, A=None, adj_type="dual"):
+def __init__(self, B, X, *, A=None, adj_type="conjugate_dual"):
 \end{lstlisting}
 with constructor arguments
 \begin{itemize}
@@ -1794,11 +1794,8 @@ controls can be computed via for example
 Note that the \texttt{compute\_gradient} method finalizes the internal
 \texttt{EquationManager} (see section \ref{sect:EquationManager_state}).
 
-\texttt{tlm\_adjoint} uses the convention that the values stored for linear
-sensitivity functionals are the complex conjugate of the coefficients
-appearing in their expansion using the dual basis. Hence the degrees of freedom
-associated with functions returned by \texttt{compute\_gradient} are the
-complex conjugate of linear sensitivities.
+The degrees of freedom associated with functions returned by
+\texttt{compute\_gradient} are the complex conjugate of linear sensitivities.
 
 \section{Tangent-linear and higher order adjoint}\label{sect:higher_order}
 
@@ -2649,9 +2646,9 @@ and associated eigenvectors $v$ where
 This has the interface
 \begin{lstlisting}
 def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
-                   action_type="dual", N_eigenvalues=None, solver_type=None,
-                   problem_type=None, which=None, tolerance=1.0e-12,
-                   configure=None):
+                   action_type="conjugate_dual", N_eigenvalues=None,
+                   solver_type=None, problem_type=None, which=None,
+                   tolerance=1.0e-12, configure=None):
 \end{lstlisting}
 with arguments
 \begin{itemize}
@@ -2663,8 +2660,8 @@ with arguments
     and computes the action of the matrix $B$. The result must be returned as a
     function or a NumPy array. If not provided then $B$ is considered an
     identity matrix.
-  \item \texttt{space\_type}, ``primal'' or ``dual'', whether eigenvectors
-    are in the primal or dual space.
+  \item \texttt{space\_type}, ``primal'', ``conjugate\_primal'', ``dual'', or
+    ``conjugate\_dual'', defining the space type for eigenvectors.
   \item \texttt{action\_type}, whether the action is in the same space as the
     eigenvectors, or the associated dual space. If ``dual'' then
     \texttt{A\_action} and \texttt{B\_action} return the complex conjugate of

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -951,7 +951,8 @@ the form
 \begin{lstlisting}
 def __init__(self, x, deps, nl_deps=None,
              *, ic_deps=None, ic=None,
-             adj_ic_deps=None, adj_ic=None):
+             adj_ic_deps=None, adj_ic=None,
+             adj_type="dual"):
 \end{lstlisting}
 with constructor arguments
 \begin{itemize}
@@ -973,6 +974,9 @@ with constructor arguments
   \item \texttt{adj\_ic}, if true sets \texttt{adj\_ic\_deps} to be the
     solution to the equation. Defaults to true if \texttt{adj\_ic\_deps} is
     \texttt{None}, and false otherwise.
+  \item \texttt{adj\_type}, ``primal'' or ``dual'', defining whether the
+    adjoint is in the dual space associated with the solution to the equation,
+    \texttt{x}.
 \end{itemize}
 
 \subsection{Forward}
@@ -1171,7 +1175,8 @@ An \texttt{Equation} may solve for two or more functions. In this case the
 arguments \texttt{x}, \texttt{adj\_x}, and \texttt{b} in the above should be
 capitalized \texttt{X}, \texttt{adj\_X}, and \texttt{B}, and should each be a
 sequence of functions. The return value of \texttt{adjoint\_jacobian\_solve}
-should also be a sequence of functions.
+should also be a sequence of functions. \texttt{adj\_type} may be a sequence
+with elements equal to ``primal'' or ``dual''.
 
 \subsection{Dropping references}\label{sect:drop_references}
 

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1223,7 +1223,8 @@ matrices as used by a \texttt{LinearEquation}.
 A subclass of \texttt{Matrix} must call the \texttt{Matrix} constructor to
 define dependencies. The \texttt{Matrix} constructor has the form
 \begin{lstlisting}
-def __init__(self, nl_deps=None, *, ic=True, adj_ic=True):
+def __init__(self, nl_deps=None, *, ic=True, adj_ic=True,
+             col_space_type="conjugate_dual"):
 \end{lstlisting}
 with constructor arguments
 \begin{itemize}
@@ -1235,6 +1236,9 @@ with constructor arguments
   \item \texttt{adj\_ic}. If true then in solving an adjoint equation
     involving the matrix the solution variable is an adjoint initial
     condition dependency of the equation.
+  \item \texttt{col\_space\_type}, ``primal'', ``conjugate\_primal'',
+    ``dual'', or ``conjugate\_dual''. The space type for the result of a
+    matrix action, $A x$.
 \end{itemize}
 
 \subsubsection{Matrix action}

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -2642,20 +2642,27 @@ and associated eigenvectors $v$ where
 \end{equation*}
 This has the interface
 \begin{lstlisting}
-def eigendecompose(space, A_action, *, B_action=None, N_eigenvalues=None,
-                   solver_type=None, problem_type=None, which=None,
-                   tolerance=1.0e-12, configure=None):
+def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
+                   action_type="dual", N_eigenvalues=None, solver_type=None,
+                   problem_type=None, which=None, tolerance=1.0e-12,
+                   configure=None):
 \end{lstlisting}
 with arguments
 \begin{itemize}
   \item \texttt{space}, a function space. Eigenvector discrete function space.
   \item \texttt{A\_action}, a callable which accepts a single input function,
-    and computes the complex conjugate of the action of the matrix $A$. The
-    result must be returned as a function or a NumPy array.
+    and computes the action of the matrix $A$. The result must be returned as a
+    function or a NumPy array.
   \item \texttt{B\_action}, a callable which accepts a single input function,
-    and computes the complex conjugate of the action of the matrix $B$. The
-    result must be returned as a function or a NumPy array. If not provided
-    then $B$ is considered an identity matrix.
+    and computes the action of the matrix $B$. The result must be returned as a
+    function or a NumPy array. If not provided then $B$ is considered an
+    identity matrix.
+  \item \texttt{space\_type}, ``primal'' or ``dual'', whether eigenvectors
+    are in the primal or dual space.
+  \item \texttt{action\_type}, whether the action is in the same space as the
+    eigenvectors, or the associated dual space. If ``dual'' then
+    \texttt{A\_action} and \texttt{B\_action} return the complex conjugate of
+    the matrix actions.
   \item \texttt{N\_eigenvalues}, requested number of eigenvalues to find,
     passed as the \texttt{nev} argument to \texttt{slepc4py.EPS.setDimensions}.
     If not provided then performs a full spectrum eigendecomposition.

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1201,7 +1201,7 @@ where $A$ is a matrix and the $b_i$ are independent of $x$.
 
 The \texttt{LinearEquation} constructor has the form
 \begin{lstlisting}
-def __init__(self, B, X, A=None):
+def __init__(self, B, X, *, A=None, adj_type="dual"):
 \end{lstlisting}
 with constructor arguments
 \begin{itemize}
@@ -1210,6 +1210,7 @@ with constructor arguments
   \item \texttt{X}, a function, or a sequence of functions, defining $x$.
   \item \texttt{A}, a \texttt{Matrix}. If not provided $A$ is an identity
     matrix.
+  \item \texttt{adj\_type}, as for the \texttt{Equation} constructor.
 \end{itemize}
 
 \subsection{\texttt{Matrix}}

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -764,16 +764,16 @@ directly to the \texttt{DirichletBC} constructor.
 
 \subsubsection{\texttt{AssembleSolver}}\label{sect:AssembleSolver}
 
-An \texttt{AssembleSolver} represents the assembly of a rank zero or rank one
-form. The \texttt{AssembleSolver} constructor has the form
+An \texttt{AssembleSolver} represents the assembly of a rank zero form. The
+\texttt{AssembleSolver} constructor has the form
 \begin{lstlisting}
 def __init__(self, rhs, x, form_compiler_parameters=None,
              match_quadrature=None):
 \end{lstlisting}
 with constructor arguments
 \begin{itemize}
-  \item \texttt{rhs}, a \texttt{ufl.classes.Form}, defining a form of rank zero
-    or rank one.
+  \item \texttt{rhs}, a \texttt{ufl.classes.Form}, defining a form of rank
+    zero.
   \item \texttt{x}, a function, the solution to the equation.
   \item \texttt{form\_compiler\_parameters}, a dictionary of parameters passed
     to the form compiler.
@@ -784,8 +784,8 @@ with constructor arguments
     which by default is false.
 \end{itemize}
 
-If the form is rank zero then the solution \texttt{x} must be a scalar, for
-example as returned by the \texttt{new\_scalar\_function} function
+The solution \texttt{x} must be a scalar, for example as returned by the
+\texttt{new\_scalar\_function} function
 \begin{lstlisting}
 x = new_scalar_function(comm=comm)
 \end{lstlisting}

--- a/examples/numpy/diffusion/diffusion.py
+++ b/examples/numpy/diffusion/diffusion.py
@@ -155,6 +155,8 @@ def forward(psi_0, kappa):
             self._A_kappa = None
 
         def forward_action(self, nl_deps, x, b, method="assign"):
+            check_space_type(b, self.b_space_type())
+
             kappa, = nl_deps
             self._assemble_A(kappa)
             sb = self._A.dot(x.vector())
@@ -174,6 +176,8 @@ def forward(psi_0, kappa):
             self.forward_action(nl_deps, adj_x, b, method=method)
 
         def forward_solve(self, x, nl_deps, b):
+            check_space_type(b, self.b_space_type())
+
             kappa, = nl_deps
             self._assemble_A(kappa)
             x.vector()[:], fail = cg(self._A, b.vector(), x0=x.vector())

--- a/tests/fenics/test_eigendecomposition.py
+++ b/tests/fenics/test_eigendecomposition.py
@@ -36,6 +36,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.fenics
+@no_space_type_checking
 @seed_test
 def test_HEP(setup_test, test_leaks):
     mesh = UnitIntervalMesh(20)
@@ -45,7 +46,7 @@ def test_HEP(setup_test, test_leaks):
     M = assemble(inner(trial, test) * dx)
 
     def M_action(x):
-        y = function_new(x)
+        y = function_new_conjugate_dual(x)
         assemble(inner(x, test) * dx, tensor=function_vector(y))
         return function_get_values(y).conjugate()
 
@@ -55,7 +56,7 @@ def test_HEP(setup_test, test_leaks):
 
     assert (lam > 0.0).all()
 
-    diff = Function(space)
+    diff = Function(space, space_type="conjugate_dual")
     assert len(lam) == len(V)
     for lam_val, v in zip(lam, V):
         matrix_multiply(M, function_vector(v),
@@ -65,6 +66,7 @@ def test_HEP(setup_test, test_leaks):
 
 
 @pytest.mark.fenics
+@no_space_type_checking
 @seed_test
 def test_NHEP(setup_test, test_leaks):
     mesh = UnitIntervalMesh(20)
@@ -74,7 +76,7 @@ def test_NHEP(setup_test, test_leaks):
     N = assemble(inner(trial.dx(0), test) * dx)
 
     def N_action(x):
-        y = function_new(x)
+        y = function_new_conjugate_dual(x)
         assemble(inner(x.dx(0), test) * dx, tensor=function_vector(y))
         return function_get_values(y).conjugate()
 
@@ -82,7 +84,7 @@ def test_NHEP(setup_test, test_leaks):
 
     assert abs(lam.real).max() < 1.0e-15
 
-    diff = Function(space)
+    diff = Function(space, space_type="conjugate_dual")
     if issubclass(PETSc.ScalarType, (complex, np.complexfloating)):
         assert len(lam) == len(V)
         for lam_val, v in zip(lam, V):

--- a/tests/fenics/test_eigendecomposition.py
+++ b/tests/fenics/test_eigendecomposition.py
@@ -156,8 +156,7 @@ def test_CachedHessian(setup_test):
         zero.assign(0.0)
         _, _, ddJ = H.action(F, zeta)
 
-        error = Function(space, name="error")
-        function_assign(error, ddJ)
+        error = function_copy(ddJ)
         function_axpy(error, -1.0, ddJ_opt)
         assert function_linf_norm(error) == 0.0
 

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -842,7 +842,7 @@ def test_initial_guess(setup_test, test_leaks):
                 == 4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,
                 adj_x_0, solver_parameters=ls_parameters_cg,
                 annotate=False, tlm=False)
-            NullSolver(x).solve()
+            NullSolver(x, adj_type="primal").solve()
             J_term = space_new(J.space())
             InnerProductSolver(x, adj_x_0, J_term).solve()
             J.addto(J_term)

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -37,6 +37,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.fenics
+@no_space_type_checking
 @seed_test
 def test_AssignmentSolver(setup_test, test_leaks):
     x = Constant(16.0, name="x", static=True)
@@ -99,6 +100,7 @@ def test_AssignmentSolver(setup_test, test_leaks):
 
 
 @pytest.mark.fenics
+@no_space_type_checking
 @seed_test
 def test_AxpySolver(setup_test, test_leaks):
     x = Constant(1.0, name="x", static=True)
@@ -599,6 +601,7 @@ def test_AssembleSolver(setup_test, test_leaks):
 
 
 @pytest.mark.fenics
+@no_space_type_checking
 @seed_test
 def test_Storage(setup_test, test_leaks):
     comm = manager().comm()
@@ -727,6 +730,7 @@ def test_SumSolver(setup_test, test_leaks):
 @pytest.mark.skipif(issubclass(PETSc.ScalarType,
                                (complex, np.complexfloating)),
                     reason="real only")
+@no_space_type_checking
 @seed_test
 def test_InnerProductSolver(setup_test, test_leaks):
     mesh = UnitIntervalMesh(10)
@@ -836,14 +840,15 @@ def test_initial_guess(setup_test, test_leaks):
 
         # test_adj_ic defined in test scope below
         if test_adj_ic:
-            adj_x_0 = Function(space_1, name="adj_x_0", static=True)
+            adj_x_0 = Function(space_1, name="adj_x_0", space_type="dual",
+                               static=True)
             solve(
                 inner(trial_1, test_1) * dx
                 == 4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,
                 adj_x_0, solver_parameters=ls_parameters_cg,
                 annotate=False, tlm=False)
             NullSolver(x, adj_type="primal").solve()
-            J_term = space_new(J.space())
+            J_term = function_new(J.fn())
             InnerProductSolver(x, adj_x_0, J_term).solve()
             J.addto(J_term)
         else:

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -970,14 +970,14 @@ def test_form_binding(setup_test, test_leaks,
                                             for j in range(dim)]),
                         space, solver_parameters=ls_parameters_cg)
         u_split = u.split()
-        assembled_form_ref = Function(space)
+        assembled_form_ref = Function(space, space_type="conjugate_dual")
         assemble(test_form(u, u_split, test),
                  tensor=function_vector(assembled_form_ref))
 
         assert "_tlm_adjoint__bindings" not in form._cache
         bind_form(form, test_form_deps(u, u_split))
         assert "_tlm_adjoint__bindings" in form._cache
-        assembled_form = Function(space)
+        assembled_form = Function(space, space_type="conjugate_dual")
         bind_assemble(form, tensor=function_vector(assembled_form))
         unbind_form(form)
         assert "_tlm_adjoint__bindings" not in form._cache

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -558,7 +558,6 @@ def test_AssembleSolver(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
-    test = TestFunction(space)
 
     def forward(F):
         x = Constant(name="x")

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -838,8 +838,8 @@ def test_initial_guess(setup_test, test_leaks):
 
         # test_adj_ic defined in test scope below
         if test_adj_ic:
-            adj_x_0 = Function(space_1, name="adj_x_0", space_type="dual",
-                               static=True)
+            adj_x_0 = Function(space_1, name="adj_x_0",
+                               space_type="conjugate_dual", static=True)
             solve(
                 inner(trial_1, test_1) * dx
                 == 4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -561,15 +561,12 @@ def test_AssembleSolver(setup_test, test_leaks):
     test = TestFunction(space)
 
     def forward(F):
-        x = Function(space, name="x")
-        y = Constant(name="y")
+        x = Constant(name="x")
 
-        AssembleSolver(inner(F * F, test) * dx
-                       + inner(F, test) * dx, x).solve()
-        AssembleSolver(dot(F, x) * dx, y).solve()
+        AssembleSolver((dot(F, F) ** 2) * dx, x).solve()
 
         J = Functional(name="J")
-        J.assign(y)
+        J.assign(x)
         return J
 
     F = Function(space, name="F", static=True)
@@ -580,6 +577,7 @@ def test_AssembleSolver(setup_test, test_leaks):
     stop_manager()
 
     J_val = J.value()
+    assert abs(J_val - assemble((dot(F, F) ** 2) * dx)) == 0.0
 
     dJ = compute_gradient(J, F)
 
@@ -588,7 +586,7 @@ def test_AssembleSolver(setup_test, test_leaks):
 
     ddJ = Hessian(forward)
     min_order = taylor_test(forward, F, J_val=J_val, ddJ=ddJ)
-    assert min_order > 2.99
+    assert min_order > 3.00
 
     min_order = taylor_test_tlm(forward, F, tlm_order=1)
     assert min_order > 2.00
@@ -597,7 +595,7 @@ def test_AssembleSolver(setup_test, test_leaks):
     assert min_order > 2.00
 
     min_order = taylor_test_tlm_adjoint(forward, F, adjoint_order=2)
-    assert min_order > 1.99
+    assert min_order > 2.00
 
 
 @pytest.mark.fenics

--- a/tests/fenics/test_gauss_newton.py
+++ b/tests/fenics/test_gauss_newton.py
@@ -62,13 +62,13 @@ def test_GaussNewton(setup_test, test_leaks):
         return J
 
     def R_inv_action(x):
-        y = function_new(x)
+        y = function_new_dual(x)
         assemble(inner(grad(ufl.conj(x)), grad(test)) * dx,
                  tensor=function_vector(y))
         return y
 
     def B_inv_action(x):
-        y = function_new(x)
+        y = function_new_dual(x)
         assemble(eps * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y
@@ -125,13 +125,13 @@ def test_CachedGaussNewton(setup_test):
         return J
 
     def R_inv_action(x):
-        y = function_new(x)
+        y = function_new_dual(x)
         assemble(inner(grad(ufl.conj(x)), grad(test)) * dx,
                  tensor=function_vector(y))
         return y
 
     def B_inv_action(x):
-        y = function_new(x)
+        y = function_new_dual(x)
         assemble(eps * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y

--- a/tests/fenics/test_gauss_newton.py
+++ b/tests/fenics/test_gauss_newton.py
@@ -62,13 +62,13 @@ def test_GaussNewton(setup_test, test_leaks):
         return J
 
     def R_inv_action(x):
-        y = function_new_dual(x)
+        y = function_new_conjugate_dual(x)
         assemble(inner(grad(ufl.conj(x)), grad(test)) * dx,
                  tensor=function_vector(y))
         return y
 
     def B_inv_action(x):
-        y = function_new_dual(x)
+        y = function_new_conjugate_dual(x)
         assemble(eps * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y
@@ -125,13 +125,13 @@ def test_CachedGaussNewton(setup_test):
         return J
 
     def R_inv_action(x):
-        y = function_new_dual(x)
+        y = function_new_conjugate_dual(x)
         assemble(inner(grad(ufl.conj(x)), grad(test)) * dx,
                  tensor=function_vector(y))
         return y
 
     def B_inv_action(x):
-        y = function_new_dual(x)
+        y = function_new_conjugate_dual(x)
         assemble(eps * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -277,12 +277,12 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                 function_assign(x, b)
 
             def adjoint_solve(self, adj_x, nl_deps, b):
-                return function_copy_dual(b)
+                return function_copy_conjugate_dual(b)
 
             def tangent_linear_rhs(self, M, dM, tlm_map, x):
                 return None
 
-        x = Constant(0.0, name="x", space_type="dual")
+        x = Constant(0.0, name="x", space_type="conjugate_dual")
 
         M = IdentityMatrix()
         b = NormSqRHS(m, M=M)
@@ -323,10 +323,10 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert not function_is_replacement(dep)
 
-        y = Constant(0.0, name="y", space_type="dual")
+        y = Constant(0.0, name="y", space_type="conjugate_dual")
         LinearEquation(b, y, A=M, adj_type="primal").solve()
 
-        z = Constant(0.0, name="z", space_type="dual")
+        z = Constant(0.0, name="z", space_type="conjugate_dual")
         AxpySolver(x, 1.0, y, z).solve()
 
         if forward_run:
@@ -419,7 +419,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
                 if dep_index == 1:
                     x0, m = nl_deps
-                    F = function_new_dual(x0)
+                    F = function_new_conjugate_dual(x0)
                     function_set_values(
                         F,
                         0.5 * function_get_values(adj_x)
@@ -428,7 +428,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
                     return F
                 elif dep_index == 2:
                     x0, m = nl_deps
-                    F = function_new_dual(x0)
+                    F = function_new_conjugate_dual(x0)
                     function_set_values(
                         F,
                         -0.5 * function_get_values(adj_x)

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -102,6 +102,7 @@ def test_long_range(setup_test, test_leaks):
 
 
 @pytest.mark.fenics
+@no_space_type_checking
 @seed_test
 def test_EmptySolver(setup_test, test_leaks):
     class EmptySolver(Equation):
@@ -255,12 +256,14 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             def __init__(self):
                 super().__init__(nl_deps=[], ic=False, adj_ic=False)
 
+            @no_space_type_checking
             def forward_action(self, nl_deps, x, b, method="assign"):
                 if method == "assign":
                     function_assign(b, x)
                 else:
                     raise EquationException(f"Unexpected method '{method:s}'")
 
+            @no_space_type_checking
             def adjoint_action(self, nl_deps, adj_x, b, b_index=0,
                                method="assign"):
                 if b_index != 0:
@@ -274,16 +277,16 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                 function_assign(x, b)
 
             def adjoint_solve(self, adj_x, nl_deps, b):
-                return b
+                return function_copy_dual(b)
 
             def tangent_linear_rhs(self, M, dM, tlm_map, x):
                 return None
 
-        x = Constant(0.0, name="x")
+        x = Constant(0.0, name="x", space_type="dual")
 
         M = IdentityMatrix()
         b = NormSqRHS(m, M=M)
-        linear_eq = LinearEquation([b, b], x, A=M)
+        linear_eq = LinearEquation([b, b], x, A=M, adj_type="primal")
         linear_eq.solve()
 
         if forward_run:
@@ -320,10 +323,10 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert not function_is_replacement(dep)
 
-        y = Constant(0.0, name="y")
-        LinearEquation(b, y, A=M).solve()
+        y = Constant(0.0, name="y", space_type="dual")
+        LinearEquation(b, y, A=M, adj_type="primal").solve()
 
-        z = Constant(0.0, name="z")
+        z = Constant(0.0, name="z", space_type="dual")
         AxpySolver(x, 1.0, y, z).solve()
 
         if forward_run:
@@ -352,8 +355,10 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert function_is_replacement(dep)
 
+        M = IdentityMatrix()
+
         J = Functional(name="J")
-        NormSqSolver(z, J.fn()).solve()
+        NormSqSolver(z, J.fn(), M=M).solve()
         return J
 
     m = Constant(np.sqrt(2.0), name="m")
@@ -540,6 +545,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
                                                    (200, 20),
                                                    (200, 50),
                                                    (1000, 50)])
+@no_space_type_checking
 @seed_test
 def test_binomial_checkpointing(setup_test, test_leaks,
                                 n_steps, snaps_in_ram):
@@ -612,6 +618,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
 
 @pytest.mark.fenics
 @pytest.mark.parametrize("max_depth", [1, 2, 3, 4, 5])
+@no_space_type_checking
 @seed_test
 def test_TangentLinearMap_finalizes(setup_test, test_leaks,
                                     max_depth):

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -414,7 +414,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
                 if dep_index == 1:
                     x0, m = nl_deps
-                    F = function_new(x0)
+                    F = function_new_dual(x0)
                     function_set_values(
                         F,
                         0.5 * function_get_values(adj_x)
@@ -423,7 +423,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
                     return F
                 elif dep_index == 2:
                     x0, m = nl_deps
-                    F = function_new(x0)
+                    F = function_new_dual(x0)
                     function_set_values(
                         F,
                         -0.5 * function_get_values(adj_x)

--- a/tests/firedrake/test_eigendecomposition.py
+++ b/tests/firedrake/test_eigendecomposition.py
@@ -36,6 +36,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.firedrake
+@no_space_type_checking
 @seed_test
 def test_HEP(setup_test, test_leaks):
     mesh = UnitIntervalMesh(20)
@@ -45,7 +46,7 @@ def test_HEP(setup_test, test_leaks):
     M = assemble(inner(trial, test) * dx)
 
     def M_action(x):
-        y = function_new(x)
+        y = function_new_conjugate_dual(x)
         assemble(inner(x, test) * dx, tensor=function_vector(y))
         return function_get_values(y).conjugate()
 
@@ -55,7 +56,7 @@ def test_HEP(setup_test, test_leaks):
 
     assert (lam > 0.0).all()
 
-    diff = Function(space)
+    diff = Function(space, space_type="conjugate_dual")
     assert len(lam) == len(V)
     for lam_val, v in zip(lam, V):
         matrix_multiply(M, function_vector(v),
@@ -65,6 +66,7 @@ def test_HEP(setup_test, test_leaks):
 
 
 @pytest.mark.firedrake
+@no_space_type_checking
 @seed_test
 def test_NHEP(setup_test, test_leaks):
     mesh = UnitIntervalMesh(20)
@@ -74,7 +76,7 @@ def test_NHEP(setup_test, test_leaks):
     N = assemble(inner(trial.dx(0), test) * dx)
 
     def N_action(x):
-        y = function_new(x)
+        y = function_new_conjugate_dual(x)
         assemble(inner(x.dx(0), test) * dx, tensor=function_vector(y))
         return function_get_values(y).conjugate()
 
@@ -82,7 +84,7 @@ def test_NHEP(setup_test, test_leaks):
 
     assert abs(lam.real).max() < 1.0e-15
 
-    diff = Function(space)
+    diff = Function(space, space_type="conjugate_dual")
     if issubclass(PETSc.ScalarType, (complex, np.complexfloating)):
         assert len(lam) == len(V)
         for lam_val, v in zip(lam, V):

--- a/tests/firedrake/test_eigendecomposition.py
+++ b/tests/firedrake/test_eigendecomposition.py
@@ -156,8 +156,7 @@ def test_CachedHessian(setup_test):
         zero.assign(0.0)
         _, _, ddJ = H.action(F, zeta)
 
-        error = Function(space, name="error")
-        function_assign(error, ddJ)
+        error = function_copy(ddJ)
         function_axpy(error, -1.0, ddJ_opt)
         assert function_linf_norm(error) == 0.0
 

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -492,7 +492,6 @@ def test_AssembleSolver(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
-    test = TestFunction(space)
 
     def forward(F):
         x = Constant(name="x")

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -775,8 +775,8 @@ def test_initial_guess(setup_test, test_leaks):
 
         # test_adj_ic defined in test scope below
         if test_adj_ic:
-            adj_x_0 = Function(space_1, name="adj_x_0", space_type="dual",
-                               static=True)
+            adj_x_0 = Function(space_1, name="adj_x_0",
+                               space_type="conjugate_dual", static=True)
             solve(
                 inner(trial_1, test_1) * dx
                 == 4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -779,7 +779,7 @@ def test_initial_guess(setup_test, test_leaks):
                 == 4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,
                 adj_x_0, solver_parameters=ls_parameters_cg,
                 annotate=False, tlm=False)
-            NullSolver(x).solve()
+            NullSolver(x, adj_type="primal").solve()
             J_term = space_new(J.space())
             InnerProductSolver(x, adj_x_0, J_term).solve()
             J.addto(J_term)

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -39,6 +39,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.firedrake
+@no_space_type_checking
 @seed_test
 def test_AssignmentSolver(setup_test, test_leaks):
     x = Constant(16.0, name="x", static=True)
@@ -101,6 +102,7 @@ def test_AssignmentSolver(setup_test, test_leaks):
 
 
 @pytest.mark.firedrake
+@no_space_type_checking
 @seed_test
 def test_AxpySolver(setup_test, test_leaks):
     x = Constant(1.0, name="x", static=True)
@@ -533,6 +535,7 @@ def test_AssembleSolver(setup_test, test_leaks):
 
 
 @pytest.mark.firedrake
+@no_space_type_checking
 @seed_test
 def test_Storage(setup_test, test_leaks):
     comm = manager().comm()
@@ -661,6 +664,7 @@ def test_SumSolver(setup_test, test_leaks):
 @pytest.mark.skipif(issubclass(PETSc.ScalarType,
                                (complex, np.complexfloating)),
                     reason="real only")
+@no_space_type_checking
 @seed_test
 def test_InnerProductSolver(setup_test, test_leaks):
     mesh = UnitIntervalMesh(10)
@@ -773,14 +777,15 @@ def test_initial_guess(setup_test, test_leaks):
 
         # test_adj_ic defined in test scope below
         if test_adj_ic:
-            adj_x_0 = Function(space_1, name="adj_x_0", static=True)
+            adj_x_0 = Function(space_1, name="adj_x_0", space_type="dual",
+                               static=True)
             solve(
                 inner(trial_1, test_1) * dx
                 == 4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,
                 adj_x_0, solver_parameters=ls_parameters_cg,
                 annotate=False, tlm=False)
             NullSolver(x, adj_type="primal").solve()
-            J_term = space_new(J.space())
+            J_term = function_new(J.fn())
             InnerProductSolver(x, adj_x_0, J_term).solve()
             J.addto(J_term)
         else:

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -907,14 +907,14 @@ def test_form_binding(setup_test, test_leaks,
                                             for j in range(dim)]),
                         space, solver_parameters=ls_parameters_cg)
         u_split = u.split()
-        assembled_form_ref = Function(space)
+        assembled_form_ref = Function(space, space_type="conjugate_dual")
         assemble(test_form(u, u_split, test),
                  tensor=function_vector(assembled_form_ref))
 
         assert "_tlm_adjoint__bindings" not in form._cache
         bind_form(form, test_form_deps(u, u_split))
         assert "_tlm_adjoint__bindings" in form._cache
-        assembled_form = Function(space)
+        assembled_form = Function(space, space_type="conjugate_dual")
         bind_assemble(form, tensor=function_vector(assembled_form))
         unbind_form(form)
         assert "_tlm_adjoint__bindings" not in form._cache

--- a/tests/firedrake/test_gauss_newton.py
+++ b/tests/firedrake/test_gauss_newton.py
@@ -63,13 +63,13 @@ def test_GaussNewton(setup_test, test_leaks):
         return J
 
     def R_inv_action(x):
-        y = function_new(x)
+        y = function_new_dual(x)
         assemble(inner(grad(ufl.conj(x)), grad(test)) * dx,
                  tensor=function_vector(y))
         return y
 
     def B_inv_action(x):
-        y = function_new(x)
+        y = function_new_dual(x)
         assemble(eps * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y
@@ -126,13 +126,13 @@ def test_CachedGaussNewton(setup_test):
         return J
 
     def R_inv_action(x):
-        y = function_new(x)
+        y = function_new_dual(x)
         assemble(inner(grad(ufl.conj(x)), grad(test)) * dx,
                  tensor=function_vector(y))
         return y
 
     def B_inv_action(x):
-        y = function_new(x)
+        y = function_new_dual(x)
         assemble(eps * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y

--- a/tests/firedrake/test_gauss_newton.py
+++ b/tests/firedrake/test_gauss_newton.py
@@ -63,13 +63,13 @@ def test_GaussNewton(setup_test, test_leaks):
         return J
 
     def R_inv_action(x):
-        y = function_new_dual(x)
+        y = function_new_conjugate_dual(x)
         assemble(inner(grad(ufl.conj(x)), grad(test)) * dx,
                  tensor=function_vector(y))
         return y
 
     def B_inv_action(x):
-        y = function_new_dual(x)
+        y = function_new_conjugate_dual(x)
         assemble(eps * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y
@@ -126,13 +126,13 @@ def test_CachedGaussNewton(setup_test):
         return J
 
     def R_inv_action(x):
-        y = function_new_dual(x)
+        y = function_new_conjugate_dual(x)
         assemble(inner(grad(ufl.conj(x)), grad(test)) * dx,
                  tensor=function_vector(y))
         return y
 
     def B_inv_action(x):
-        y = function_new_dual(x)
+        y = function_new_conjugate_dual(x)
         assemble(eps * inner(ufl.conj(x), test) * dx,
                  tensor=function_vector(y))
         return y

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -255,8 +255,9 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
 def test_Referrers_LinearEquation(setup_test, test_leaks):
     def forward(m, forward_run=False):
         class IdentityMatrix(Matrix):
-            def __init__(self):
-                super().__init__(nl_deps=[], ic=False, adj_ic=False)
+            def __init__(self, col_space_type="conjugate_dual"):
+                super().__init__(nl_deps=[], ic=False, adj_ic=False,
+                                 col_space_type=col_space_type)
 
             @no_space_type_checking
             def forward_action(self, nl_deps, x, b, method="assign"):
@@ -276,6 +277,8 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                     raise EquationException(f"Unexpected method '{method:s}'")
 
             def forward_solve(self, x, nl_deps, b):
+                check_space_type(b, self.b_space_type())
+
                 function_assign(x, b)
 
             def adjoint_solve(self, adj_x, nl_deps, b):
@@ -357,7 +360,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert function_is_replacement(dep)
 
-        M = IdentityMatrix()
+        M = IdentityMatrix(col_space_type="primal")
 
         J = Functional(name="J")
         NormSqSolver(z, J.fn(), M=M).solve()

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -416,7 +416,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
                 if dep_index == 1:
                     x0, m = nl_deps
-                    F = function_new(x0)
+                    F = function_new_dual(x0)
                     function_set_values(
                         F,
                         0.5 * function_get_values(adj_x)
@@ -425,7 +425,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
                     return F
                 elif dep_index == 2:
                     x0, m = nl_deps
-                    F = function_new(x0)
+                    F = function_new_dual(x0)
                     function_set_values(
                         F,
                         -0.5 * function_get_values(adj_x)

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -279,12 +279,12 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                 function_assign(x, b)
 
             def adjoint_solve(self, adj_x, nl_deps, b):
-                return function_copy_dual(b)
+                return function_copy_conjugate_dual(b)
 
             def tangent_linear_rhs(self, M, dM, tlm_map, x):
                 return None
 
-        x = Constant(0.0, name="x", space_type="dual")
+        x = Constant(0.0, name="x", space_type="conjugate_dual")
 
         M = IdentityMatrix()
         b = NormSqRHS(m, M=M)
@@ -325,10 +325,10 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert not function_is_replacement(dep)
 
-        y = Constant(0.0, name="y", space_type="dual")
+        y = Constant(0.0, name="y", space_type="conjugate_dual")
         LinearEquation(b, y, A=M, adj_type="primal").solve()
 
-        z = Constant(0.0, name="z", space_type="dual")
+        z = Constant(0.0, name="z", space_type="conjugate_dual")
         AxpySolver(x, 1.0, y, z).solve()
 
         if forward_run:
@@ -421,7 +421,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
             def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
                 if dep_index == 1:
                     x0, m = nl_deps
-                    F = function_new_dual(x0)
+                    F = function_new_conjugate_dual(x0)
                     function_set_values(
                         F,
                         0.5 * function_get_values(adj_x)
@@ -430,7 +430,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
                     return F
                 elif dep_index == 2:
                     x0, m = nl_deps
-                    F = function_new_dual(x0)
+                    F = function_new_conjugate_dual(x0)
                     function_set_values(
                         F,
                         -0.5 * function_get_values(adj_x)

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -137,11 +137,11 @@ def info(message):
 
 
 class Constant(Function):
-    def __init__(self, value=0.0, *, name=None, static=False, cache=None,
-                 checkpoint=None):
+    def __init__(self, value=0.0, *, name=None, space_type="primal",
+                 static=False, cache=None, checkpoint=None):
         space = FunctionSpace(1)  # , dtype=default_dtype())
-        super().__init__(space, name=name, static=static, cache=cache,
-                         checkpoint=checkpoint)
+        super().__init__(space, name=name, space_type=space_type,
+                         static=static, cache=cache, checkpoint=checkpoint)
         self.assign(value)
 
     def assign(self, y):

--- a/tests/numpy/test_equations.py
+++ b/tests/numpy/test_equations.py
@@ -34,6 +34,7 @@ except ImportError:
 
 
 @pytest.mark.numpy
+@no_space_type_checking
 @seed_test
 def test_AssignmentSolver(setup_test, test_leaks, test_default_dtypes):
     x = Constant(16.0, name="x", static=True)
@@ -96,6 +97,7 @@ def test_AssignmentSolver(setup_test, test_leaks, test_default_dtypes):
 
 
 @pytest.mark.numpy
+@no_space_type_checking
 @seed_test
 def test_AxpySolver(setup_test, test_leaks, test_default_dtypes):
     x = Constant(1.0, name="x", static=True)
@@ -175,6 +177,7 @@ def test_SumSolver(setup_test, test_leaks, test_default_dtypes):
 
 
 @pytest.mark.numpy
+@no_space_type_checking
 @seed_test
 def test_InnerProductSolver(setup_test, test_leaks):
     space = FunctionSpace(10)
@@ -204,6 +207,7 @@ def test_InnerProductSolver(setup_test, test_leaks):
 
 
 @pytest.mark.numpy
+@no_space_type_checking
 @seed_test
 def test_ContractionSolver(setup_test, test_leaks, test_default_dtypes):
     dtype = default_dtype()

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -276,7 +276,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtype
             def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
                 if dep_index == 1:
                     x0, m = nl_deps
-                    F = function_new(x0)
+                    F = function_new_dual(x0)
                     function_set_values(
                         F,
                         0.5 * function_get_values(adj_x)
@@ -285,7 +285,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtype
                     return F
                 elif dep_index == 2:
                     x0, m = nl_deps
-                    F = function_new(x0)
+                    F = function_new_dual(x0)
                     function_set_values(
                         F,
                         -0.5 * function_get_values(adj_x)

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -139,12 +139,12 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                 function_assign(x, b)
 
             def adjoint_solve(self, adj_x, nl_deps, b):
-                return function_copy_dual(b)
+                return function_copy_conjugate_dual(b)
 
             def tangent_linear_rhs(self, M, dM, tlm_map, x):
                 return None
 
-        x = Constant(0.0, name="x", space_type="dual")
+        x = Constant(0.0, name="x", space_type="conjugate_dual")
 
         M = IdentityMatrix()
         b = NormSqRHS(m, M=M)
@@ -185,10 +185,10 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert not function_is_replacement(dep)
 
-        y = Constant(0.0, name="y", space_type="dual")
+        y = Constant(0.0, name="y", space_type="conjugate_dual")
         LinearEquation(b, y, A=M, adj_type="primal").solve()
 
-        z = Constant(0.0, name="z", space_type="dual")
+        z = Constant(0.0, name="z", space_type="conjugate_dual")
         AxpySolver(x, 1.0, y, z).solve()
 
         if forward_run:
@@ -281,7 +281,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtype
             def adjoint_derivative_action(self, nl_deps, dep_index, adj_x):
                 if dep_index == 1:
                     x0, m = nl_deps
-                    F = function_new_dual(x0)
+                    F = function_new_conjugate_dual(x0)
                     function_set_values(
                         F,
                         0.5 * function_get_values(adj_x)
@@ -290,7 +290,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtype
                     return F
                 elif dep_index == 2:
                     x0, m = nl_deps
-                    F = function_new_dual(x0)
+                    F = function_new_conjugate_dual(x0)
                     function_set_values(
                         F,
                         -0.5 * function_get_values(adj_x)

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -115,8 +115,9 @@ def test_empty(setup_test, test_leaks, test_default_dtypes):
 def test_Referrers_LinearEquation(setup_test, test_leaks):
     def forward(m, forward_run=False):
         class IdentityMatrix(Matrix):
-            def __init__(self):
-                super().__init__(nl_deps=[], ic=False, adj_ic=False)
+            def __init__(self, col_space_type="conjugate_dual"):
+                super().__init__(nl_deps=[], ic=False, adj_ic=False,
+                                 col_space_type=col_space_type)
 
             @no_space_type_checking
             def forward_action(self, nl_deps, x, b, method="assign"):
@@ -136,6 +137,8 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                     raise EquationException(f"Unexpected method '{method:s}'")
 
             def forward_solve(self, x, nl_deps, b):
+                check_space_type(b, self.b_space_type())
+
                 function_assign(x, b)
 
             def adjoint_solve(self, adj_x, nl_deps, b):
@@ -217,7 +220,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert function_is_replacement(dep)
 
-        M = IdentityMatrix()
+        M = IdentityMatrix(col_space_type="primal")
 
         J = Functional(name="J")
         NormSqSolver(z, J.fn(), M=M).solve()

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -36,6 +36,7 @@ except ImportError:
 
 
 @pytest.mark.numpy
+@no_space_type_checking
 @seed_test
 def test_EmptySolver(setup_test, test_leaks, test_default_dtypes):
     class EmptySolver(Equation):
@@ -117,12 +118,14 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             def __init__(self):
                 super().__init__(nl_deps=[], ic=False, adj_ic=False)
 
+            @no_space_type_checking
             def forward_action(self, nl_deps, x, b, method="assign"):
                 if method == "assign":
                     function_assign(b, x)
                 else:
                     raise EquationException(f"Unexpected method '{method:s}'")
 
+            @no_space_type_checking
             def adjoint_action(self, nl_deps, adj_x, b, b_index=0,
                                method="assign"):
                 if b_index != 0:
@@ -136,16 +139,16 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                 function_assign(x, b)
 
             def adjoint_solve(self, adj_x, nl_deps, b):
-                return b
+                return function_copy_dual(b)
 
             def tangent_linear_rhs(self, M, dM, tlm_map, x):
                 return None
 
-        x = Constant(0.0, name="x")
+        x = Constant(0.0, name="x", space_type="dual")
 
         M = IdentityMatrix()
         b = NormSqRHS(m, M=M)
-        linear_eq = LinearEquation([b, b], x, A=M)
+        linear_eq = LinearEquation([b, b], x, A=M, adj_type="primal")
         linear_eq.solve()
 
         if forward_run:
@@ -182,10 +185,10 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert not function_is_replacement(dep)
 
-        y = Constant(0.0, name="y")
-        LinearEquation(b, y, A=M).solve()
+        y = Constant(0.0, name="y", space_type="dual")
+        LinearEquation(b, y, A=M, adj_type="primal").solve()
 
-        z = Constant(0.0, name="z")
+        z = Constant(0.0, name="z", space_type="dual")
         AxpySolver(x, 1.0, y, z).solve()
 
         if forward_run:
@@ -214,8 +217,10 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
             for dep in b.dependencies():
                 assert function_is_replacement(dep)
 
+        M = IdentityMatrix()
+
         J = Functional(name="J")
-        NormSqSolver(z, J.fn()).solve()
+        NormSqSolver(z, J.fn(), M=M).solve()
         return J
 
     m = Constant(np.sqrt(2.0), name="m")
@@ -402,6 +407,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtype
                                                    (200, 20),
                                                    (200, 50),
                                                    (1000, 50)])
+@no_space_type_checking
 @seed_test
 def test_binomial_checkpointing(setup_test, test_leaks, test_default_dtypes,
                                 n_steps, snaps_in_ram):
@@ -474,6 +480,7 @@ def test_binomial_checkpointing(setup_test, test_leaks, test_default_dtypes,
 
 @pytest.mark.numpy
 @pytest.mark.parametrize("max_depth", [1, 2, 3, 4, 5])
+@no_space_type_checking
 @seed_test
 def test_TangentLinearMap_finalizes(setup_test, test_leaks, test_default_dtypes,  # noqa: E501
                                     max_depth):

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -22,7 +22,7 @@ from .backend import TestFunction, TrialFunction, adjoint, \
     backend_DirichletBC, backend_Function, backend_FunctionSpace, parameters
 from ..interface import check_space_type, function_assign, function_comm, \
     function_dtype, function_get_values, function_id, function_is_scalar, \
-    function_local_size, function_new, function_new_dual, \
+    function_local_size, function_new, function_new_conjugate_dual, \
     function_replacement, function_scalar_value, function_set_values, \
     function_space, function_update_caches, function_update_state, \
     function_zero, is_function
@@ -497,7 +497,7 @@ class EquationSolver(ExprEquation):
             mat, _ = mat_bc
             dep = (eq_deps if deps is None else deps)[dep_index]
             if b is None:
-                b = function_vector(function_new_dual(self.x()))
+                b = function_vector(function_new_conjugate_dual(self.x()))
                 matrix_multiply(mat, function_vector(dep), tensor=b)
             else:
                 matrix_multiply(mat, function_vector(dep), tensor=b,
@@ -697,7 +697,7 @@ class EquationSolver(ExprEquation):
                                 replace_map=self._nonlinear_replace_map(nl_deps))  # noqa: E501
                     else:
                         mat, _ = mat_bc
-                    F = function_vector(function_new_dual(self.dependencies()[dep_index]))  # noqa: E501
+                    F = function_vector(function_new_conjugate_dual(self.dependencies()[dep_index]))  # noqa: E501
                     matrix_multiply(mat, function_vector(adj_x), tensor=F)
                     dep_B.sub(F)
                 else:
@@ -839,7 +839,7 @@ class DirichletBCSolver(Equation):
             return adj_x
         elif dep_index == 1:
             _, y = self.dependencies()
-            F = function_new_dual(y)
+            F = function_new_conjugate_dual(y)
             backend_DirichletBC(
                 function_space(y), adj_x,
                 *self._bc_args, **self._bc_kwargs).apply(function_vector(F))
@@ -978,7 +978,7 @@ class ExprEvaluationSolver(ExprEquation):
         dF = eliminate_zeros(dF)
         dF = self._nonlinear_replace(dF, nl_deps)
         dF_val = evaluate_expr(dF)
-        F = function_new_dual(dep)
+        F = function_new_conjugate_dual(dep)
         if isinstance(dF_val, (int, np.integer,
                                float, np.floating,
                                complex, np.complexfloating)):

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -149,7 +149,7 @@ class AssembleSolver(ExprEquation):
                 raise EquationException("Rank 0 forms can only be assigned to "
                                         "scalars")
         else:
-            raise EquationException("Must be a rank 0 or 1 form")
+            raise EquationException("Must be a rank 0 form")
 
         deps, nl_deps = extract_dependencies(rhs)
         if function_id(x) in deps:

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -398,7 +398,7 @@ class EquationSolver(ExprEquation):
 
         super().__init__(x, deps, nl_deps=nl_deps,
                          ic=initial_guess is None and ic,
-                         adj_ic=adj_ic)
+                         adj_ic=adj_ic, adj_type="primal")
         self._F = F
         self._lhs, self._rhs = lhs, rhs
         self._bcs = bcs

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -266,7 +266,7 @@ class Constant(backend_Constant):
     def __init__(self, value=None, *args, name=None, domain=None, space=None,
                  space_type="primal", shape=None, comm=None, static=False,
                  cache=None, checkpoint=None, **kwargs):
-        if space_type not in ["primal", "dual"]:
+        if space_type not in ["primal", "conjugate_primal", "dual", "conjugate_dual"]:  # noqa: E501
             raise InterfaceException("Invalid space type")
 
         if domain is None and space is not None:
@@ -391,7 +391,7 @@ def eliminate_zeros(expr, *, force_non_empty_form=False):
 class Function(backend_Function):
     def __init__(self, *args, space_type="primal", static=False, cache=None,
                  checkpoint=None, **kwargs):
-        if space_type not in ["primal", "dual"]:
+        if space_type not in ["primal", "conjugate_primal", "dual", "conjugate_dual"]:  # noqa: E501
             raise InterfaceException("Invalid space type")
         if cache is None:
             cache = static

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -240,10 +240,10 @@ class ConstantInterface(_FunctionInterface):
             domain = None
         else:
             domain, = domains
-        space = self._tlm_adjoint__function_interface_attrs["space"]
-        comm = function_comm(self)
-        return Constant(value, name=name, domain=domain, space=space,
-                        comm=comm, static=static, cache=cache,
+        return Constant(value, name=name, domain=domain,
+                        space=function_space(self),
+                        space_type=function_space_type(self),
+                        comm=function_comm(self), static=static, cache=cache,
                         checkpoint=checkpoint)
 
     def _replacement(self):
@@ -316,24 +316,6 @@ class Constant(backend_Constant):
         self._tlm_adjoint__function_interface_attrs.d_setitem("static", static)
         self._tlm_adjoint__function_interface_attrs.d_setitem("cache", cache)
         self._tlm_adjoint__function_interface_attrs.d_setitem("checkpoint", checkpoint)  # noqa: E501
-
-    def is_static(self):
-        warnings.warn("Constant.is_static is deprecated -- "
-                      "use function_is_static instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_static(self)
-
-    def is_cached(self):
-        warnings.warn("Constant.is_cached is deprecated -- "
-                      "use function_is_cached instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_cached(self)
-
-    def is_checkpointed(self):
-        warnings.warn("Constant.is_checkpointed is deprecated -- "
-                      "use function_is_checkpointed instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_checkpointed(self)
 
 
 class Zero(Constant):
@@ -421,24 +403,6 @@ class Function(backend_Function):
         self._tlm_adjoint__function_interface_attrs.d_setitem("static", static)
         self._tlm_adjoint__function_interface_attrs.d_setitem("cache", cache)
         self._tlm_adjoint__function_interface_attrs.d_setitem("checkpoint", checkpoint)  # noqa: E501
-
-    def is_static(self):
-        warnings.warn("Function.is_static is deprecated -- "
-                      "use function_is_static instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_static(self)
-
-    def is_cached(self):
-        warnings.warn("Function.is_cached is deprecated -- "
-                      "use function_is_cached instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_cached(self)
-
-    def is_checkpointed(self):
-        warnings.warn("Function.is_checkpointed is deprecated -- "
-                      "use function_is_checkpointed instead",
-                      DeprecationWarning, stacklevel=2)
-        return function_is_checkpointed(self)
 
 
 class DirichletBC(backend_DirichletBC):

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -71,10 +71,12 @@ class ConstantSpaceInterface(SpaceInterface):
     def _id(self):
         return self._tlm_adjoint__space_interface_attrs["id"]
 
-    def _new(self, *, name=None, static=False, cache=None, checkpoint=None):
+    def _new(self, *, name=None, space_type="primal", static=False, cache=None,
+             checkpoint=None):
         domain = self._tlm_adjoint__space_interface_attrs["domain"]
-        return Constant(name=name, domain=domain, space=self, static=static,
-                        cache=cache, checkpoint=checkpoint)
+        return Constant(name=name, domain=domain, space=self,
+                        space_type=space_type, static=static, cache=cache,
+                        checkpoint=checkpoint)
 
 
 class ConstantInterface(_FunctionInterface):

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -1793,11 +1793,13 @@ class MatrixActionSolver(LinearEquation):
 
 class DotProductSolver(LinearEquation):
     def __init__(self, y, z, x, alpha=1.0):
+        check_space_type(x, "primal")
         super().__init__(DotProductRHS(y, z, alpha=alpha), x)
 
 
 class InnerProductSolver(LinearEquation):
     def __init__(self, y, z, x, alpha=1.0, M=None):
+        check_space_type(x, "primal")
         super().__init__(InnerProductRHS(y, z, alpha=alpha, M=M), x)
 
 
@@ -1808,6 +1810,7 @@ class NormSqSolver(InnerProductSolver):
 
 class SumSolver(LinearEquation):
     def __init__(self, y, x):
+        check_space_type(x, "primal")
         super().__init__(SumRHS(y), x)
 
 

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -28,8 +28,8 @@ from ..interface import InterfaceException, SpaceInterface, \
     add_finalize_adjoint_derivative_action, add_functional_term_eq, \
     add_interface, add_subtract_adjoint_derivative_action, \
     add_time_system_eq, function_copy, function_new, function_space, \
-    new_function_id, new_space_id, space_id, space_new, \
-    subtract_adjoint_derivative_action, weakref_method
+    function_space_type, new_function_id, new_space_id, space_id, space_new, \
+    subtract_adjoint_derivative_action
 from ..interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, is_valid_r0_space, \
     r0_space
@@ -278,13 +278,10 @@ class FunctionInterface(_FunctionInterface):
             cache = static
         if checkpoint is None:
             checkpoint = not static
+        y._tlm_adjoint__function_interface_attrs.d_setitem("space_type", function_space_type(self))  # noqa: E501
         y._tlm_adjoint__function_interface_attrs.d_setitem("static", static)
         y._tlm_adjoint__function_interface_attrs.d_setitem("cache", cache)
         y._tlm_adjoint__function_interface_attrs.d_setitem("checkpoint", checkpoint)  # noqa: E501
-        # Backwards compatibility
-        y.is_static = weakref_method(Function.is_static, y)
-        y.is_cached = weakref_method(Function.is_cached, y)
-        y.is_checkpointed = weakref_method(Function.is_checkpointed, y)
         return y
 
     def _replacement(self):

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -102,9 +102,10 @@ class FunctionSpaceInterface(SpaceInterface):
     def _id(self):
         return self._tlm_adjoint__space_interface_attrs["id"]
 
-    def _new(self, *, name=None, static=False, cache=None, checkpoint=None):
-        return Function(self, name=name, static=static, cache=cache,
-                        checkpoint=checkpoint)
+    def _new(self, *, name=None, space_type="primal", static=False, cache=None,
+             checkpoint=None):
+        return Function(self, name=name, space_type=space_type, static=static,
+                        cache=cache, checkpoint=checkpoint)
 
 
 _FunctionSpace_add_interface = [True]

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -388,6 +388,8 @@ def _subtract_adjoint_derivative_action(x, y):
             and len(y) == 2 \
             and isinstance(y[0], (int, np.integer, float, np.floating)) \
             and isinstance(y[1], backend_Vector):
+        if function_space_type(x) != "dual":
+            warnings.warn("Unexpected space type")
         alpha, y = y
         alpha = backend_ScalarType(alpha)
         if isinstance(x, backend_Constant):

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -397,7 +397,7 @@ def _subtract_adjoint_derivative_action(x, y):
                 x.assign(backend_ScalarType(x) - alpha * y.max())
             else:
                 value = x.values()
-                y_fn = Function(r0_space(x))
+                y_fn = backend_Function(r0_space(x))
                 y_fn.vector().axpy(1.0, y)
                 for i, y_fn_c in enumerate(y_fn.split(deepcopy=True)):
                     value[i] -= alpha * y_fn_c.vector().max()

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -27,9 +27,9 @@ from ..hessian_optimization import CachedGaussNewton as _CachedGaussNewton
 from ..interface import InterfaceException, SpaceInterface, \
     add_finalize_adjoint_derivative_action, add_functional_term_eq, \
     add_interface, add_subtract_adjoint_derivative_action, \
-    add_time_system_eq, function_copy, function_new, function_space, \
-    function_space_type, new_function_id, new_space_id, space_id, space_new, \
-    subtract_adjoint_derivative_action
+    add_time_system_eq, check_space_type, function_copy, function_new, \
+    function_space, function_space_type, new_function_id, new_space_id, \
+    space_id, space_new, subtract_adjoint_derivative_action
 from ..interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, is_valid_r0_space, \
     r0_space
@@ -388,8 +388,7 @@ def _subtract_adjoint_derivative_action(x, y):
             and len(y) == 2 \
             and isinstance(y[0], (int, np.integer, float, np.floating)) \
             and isinstance(y[1], backend_Vector):
-        if function_space_type(x) != "dual":
-            warnings.warn("Unexpected space type")
+        check_space_type(x, "dual")
         alpha, y = y
         alpha = backend_ScalarType(alpha)
         if isinstance(x, backend_Constant):

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -388,7 +388,7 @@ def _subtract_adjoint_derivative_action(x, y):
             and len(y) == 2 \
             and isinstance(y[0], (int, np.integer, float, np.floating)) \
             and isinstance(y[1], backend_Vector):
-        check_space_type(x, "dual")
+        check_space_type(x, "conjugate_dual")
         alpha, y = y
         alpha = backend_ScalarType(alpha)
         if isinstance(x, backend_Constant):

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -82,8 +82,9 @@ def _Constant__init__(self, *args, domain=None, space=None,
                        "dtype": backend_ScalarType, "id": new_space_id()})
     add_interface(self, ConstantInterface,
                   {"id": new_function_id(), "state": 0,
-                   "space": space, "dtype": backend_ScalarType,
-                   "static": False, "cache": False, "checkpoint": True})
+                   "space": space, "space_type": "primal",
+                   "dtype": backend_ScalarType, "static": False,
+                   "cache": False, "checkpoint": True})
 
 
 assert not hasattr(backend_Constant, "_tlm_adjoint__orig___init__")
@@ -135,6 +136,9 @@ backend_FunctionSpace.__init__ = _FunctionSpace__init__
 class FunctionInterface(_FunctionInterface):
     def _space(self):
         return self._tlm_adjoint__function_interface_attrs["space"]
+
+    def _space_type(self):
+        return self._tlm_adjoint__function_interface_attrs["space_type"]
 
     def _id(self):
         return self._tlm_adjoint__function_interface_attrs["id"]
@@ -306,7 +310,7 @@ def _Function__init__(self, *args, **kwargs):
         raise InterfaceException("PETSc backend required")
 
     add_interface(self, FunctionInterface,
-                  {"id": new_function_id(), "state": 0,
+                  {"id": new_function_id(), "state": 0, "space_type": "primal",
                    "static": False, "cache": False, "checkpoint": True})
 
     space = backend_Function._tlm_adjoint__orig_function_space(self)

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -23,7 +23,7 @@ from .backend import Cell, LocalSolver, Mesh, MeshEditor, Point, \
     parameters
 from ..interface import check_space_type, function_assign, function_comm, \
     function_get_values, function_is_scalar, function_local_size, \
-    function_new, function_new_dual, function_scalar_value, \
+    function_new, function_new_conjugate_dual, function_scalar_value, \
     function_set_values, function_space, is_function, space_comm
 from .backend_code_generator_interface import assemble
 
@@ -618,7 +618,7 @@ class PointInterpolationSolver(Equation):
             adj_x_v = np.full(len(adj_X), np.NAN, dtype=backend_ScalarType)
             for i, adj_x in enumerate(adj_X):
                 adj_x_v[i] = function_scalar_value(adj_x)
-            F = function_new_dual(self.dependencies()[-1])
+            F = function_new_conjugate_dual(self.dependencies()[-1])
             function_set_values(F, self._P_T.dot(adj_x_v))
             return (-1.0, F)
         else:

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -21,10 +21,10 @@
 from .backend import Cell, LocalSolver, Mesh, MeshEditor, Point, \
     TestFunction, TrialFunction, backend_Function, backend_ScalarType, \
     parameters
-from ..interface import function_assign, function_comm, function_get_values, \
-    function_is_scalar, function_local_size, function_new, function_new_dual, \
-    function_scalar_value, function_set_values, function_space, is_function, \
-    space_comm
+from ..interface import check_space_type, function_assign, function_comm, \
+    function_get_values, function_is_scalar, function_local_size, \
+    function_new, function_new_dual, function_scalar_value, \
+    function_set_values, function_space, is_function, space_comm
 from .backend_code_generator_interface import assemble
 
 from ..caches import Cache
@@ -486,6 +486,9 @@ class InterpolationSolver(LinearEquation):
             warnings.warn("P_T argument is deprecated and has no effect",
                           DeprecationWarning, stacklevel=2)
 
+        check_space_type(x, "primal")
+        check_space_type(y, "primal")
+
         if not isinstance(x, backend_Function) or len(x.ufl_shape) > 0:
             raise EquationException("Solution must be a scalar-valued "
                                     "Function")
@@ -556,9 +559,12 @@ class PointInterpolationSolver(Equation):
         if is_function(X):
             X = (X,)
         for x in X:
+            check_space_type(x, "primal")
             if not function_is_scalar(x):
                 raise EquationException("Solution must be a scalar, or a "
                                         "sequence of scalars")
+        check_space_type(y, "primal")
+
         if X_coords is None:
             if P is None:
                 raise EquationException("X_coords required when P is not supplied")  # noqa: E501

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -22,7 +22,7 @@ from .backend import Cell, LocalSolver, Mesh, MeshEditor, Point, \
     TestFunction, TrialFunction, backend_Function, backend_ScalarType, \
     parameters
 from ..interface import function_assign, function_comm, function_get_values, \
-    function_is_scalar, function_local_size, function_new, \
+    function_is_scalar, function_local_size, function_new, function_new_dual, \
     function_scalar_value, function_set_values, function_space, is_function, \
     space_comm
 from .backend_code_generator_interface import assemble
@@ -309,7 +309,7 @@ class LocalProjectionSolver(EquationSolver):
             local_solver = LocalSolver(self._lhs,
                                        solver_type=self._local_solver_type)
 
-        adj_x = function_new(b)
+        adj_x = self.new_adj_x()
         local_solver.solve_local(adj_x.vector(), b.vector(),
                                  function_space(adj_x).dofmap())
         return adj_x
@@ -612,7 +612,7 @@ class PointInterpolationSolver(Equation):
             adj_x_v = np.full(len(adj_X), np.NAN, dtype=backend_ScalarType)
             for i, adj_x in enumerate(adj_X):
                 adj_x_v[i] = function_scalar_value(adj_x)
-            F = function_new(self.dependencies()[-1])
+            F = function_new_dual(self.dependencies()[-1])
             function_set_values(F, self._P_T.dot(adj_x_v))
             return (-1.0, F)
         else:

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -333,11 +333,17 @@ def assemble(form, tensor=None, form_compiler_parameters=None,
         form_compiler_parameters = {}
 
     bind_forms(form)
-    tensor = _assemble(
+    b = _assemble(
         form, tensor=tensor, form_compiler_parameters=form_compiler_parameters,
         *args, **kwargs)
     unbind_forms(form)
-    return tensor
+
+    if tensor is None:
+        rank = len(form.arguments())
+        if rank == 1:
+            b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "dual")  # noqa: E501
+
+    return b
 
 
 def assemble_linear_solver(A_form, b_form=None, bcs=None,

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -241,7 +241,7 @@ def _assemble(form, tensor=None, form_compiler_parameters=None,
             (function_id(cache_0[1]), cache_0[2:], cache_1)
 
     if tensor is None and isinstance(b, backend_Function):
-        b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "dual")  # noqa: E501
+        b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "conjugate_dual")  # noqa: E501
 
     return b
 
@@ -341,7 +341,7 @@ def assemble(form, tensor=None, form_compiler_parameters=None,
     unbind_forms(form)
 
     if tensor is None and isinstance(b, backend_Function):
-        b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "dual")  # noqa: E501
+        b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "conjugate_dual")  # noqa: E501
 
     return b
 

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -22,8 +22,8 @@ from .backend import _FORM_CACHE_KEY, FunctionSpace, Parameters, \
     backend_Constant, backend_DirichletBC, backend_Function, \
     backend_LinearSolver, backend_Matrix, backend_assemble, backend_solve, \
     extract_args, homogenize, parameters
-from ..interface import InterfaceException, function_axpy, function_copy, \
-    function_id
+from ..interface import InterfaceException, check_space_type, function_axpy, \
+    function_copy, function_id
 
 from .functions import eliminate_zeros
 
@@ -228,6 +228,9 @@ def _assemble(form, tensor=None, form_compiler_parameters=None,
             form._cache["parloops"] = \
                 (tuple([form, tensor] + list(cache_0)), cache_1)
 
+    if tensor is not None and isinstance(tensor, backend_Function):
+        check_space_type(tensor, "conjugate_dual")
+
     b = backend_assemble(
         form, tensor=tensor,
         form_compiler_parameters=form_compiler_parameters,
@@ -333,6 +336,9 @@ def assemble(form, tensor=None, form_compiler_parameters=None,
 
     if form_compiler_parameters is None:
         form_compiler_parameters = {}
+
+    if tensor is not None and isinstance(tensor, backend_Function):
+        check_space_type(tensor, "conjugate_dual")
 
     bind_forms(form)
     b = _assemble(
@@ -470,10 +476,13 @@ def function_vector(x):
 
 
 def rhs_copy(x):
+    check_space_type(x, "conjugate_dual")
     return function_copy(x)
 
 
 def rhs_addto(x, y):
+    check_space_type(x, "conjugate_dual")
+    check_space_type(y, "conjugate_dual")
     function_axpy(x, 1.0, y)
 
 

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -111,9 +111,10 @@ class FunctionSpaceInterface(SpaceInterface):
     def _id(self):
         return self._tlm_adjoint__space_interface_attrs["id"]
 
-    def _new(self, *, name=None, static=False, cache=None, checkpoint=None):
-        return Function(self, name=name, static=static, cache=cache,
-                        checkpoint=checkpoint)
+    def _new(self, *, name=None, space_type="primal", static=False, cache=None,
+             checkpoint=None):
+        return Function(self, name=name, space_type=space_type, static=static,
+                        cache=cache, checkpoint=checkpoint)
 
 
 def _FunctionSpace__init__(self, *args, **kwargs):

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -27,9 +27,9 @@ from ..hessian_optimization import CachedGaussNewton as _CachedGaussNewton
 from ..interface import InterfaceException, SpaceInterface, \
     add_finalize_adjoint_derivative_action, add_functional_term_eq, \
     add_interface, add_subtract_adjoint_derivative_action, \
-    add_time_system_eq, function_assign, function_comm, function_dtype, \
-    function_is_scalar, function_new, function_scalar_value, function_space, \
-    function_space_type, new_function_id, new_space_id, space_id, space_new, \
+    add_time_system_eq, check_space_types, function_assign, function_comm, \
+    function_dtype, function_is_scalar, function_new, function_scalar_value, \
+    function_space, new_function_id, new_space_id, space_id, space_new, \
     subtract_adjoint_derivative_action
 from ..interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, is_valid_r0_space
@@ -397,8 +397,7 @@ def _subtract_adjoint_derivative_action(x, y):
             alpha = dtype(alpha)
         else:
             return NotImplemented
-        if function_space_type(x) != function_space_type(y):
-            warnings.warn("Unexpected space type")
+        check_space_types(x, y)
         y_value = function_scalar_value(y)
         # annotate=False, tlm=False
         x.assign(dtype(x) - alpha * y_value)

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -91,8 +91,9 @@ def _Constant__init__(self, value, domain=None, *,
                        "dtype": backend_ScalarType, "id": new_space_id()})
     add_interface(self, ConstantInterface,
                   {"id": new_function_id(), "name": name, "state": 0,
-                   "space": space, "dtype": self.dat.dtype.type,
-                   "static": False, "cache": False, "checkpoint": True})
+                   "space": space, "space_type": "primal",
+                   "dtype": self.dat.dtype.type, "static": False,
+                   "cache": False, "checkpoint": True})
 
 
 assert not hasattr(backend_Constant, "_tlm_adjoint__orig___init__")
@@ -132,6 +133,9 @@ class FunctionInterface(_FunctionInterface):
 
     def _space(self):
         return self.function_space()
+
+    def _space_type(self):
+        return self._tlm_adjoint__function_interface_attrs["space_type"]
 
     def _dtype(self):
         return self.dat.dtype.type
@@ -314,7 +318,7 @@ class FunctionInterface(_FunctionInterface):
 def _Function__init__(self, *args, **kwargs):
     backend_Function._tlm_adjoint__orig___init__(self, *args, **kwargs)
     add_interface(self, FunctionInterface,
-                  {"id": new_function_id(), "state": 0,
+                  {"id": new_function_id(), "state": 0, "space_type": "primal",
                    "static": False, "cache": False, "checkpoint": True})
 
 

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -29,7 +29,7 @@ from ..interface import InterfaceException, SpaceInterface, \
     add_interface, add_subtract_adjoint_derivative_action, \
     add_time_system_eq, function_assign, function_comm, function_dtype, \
     function_is_scalar, function_new, function_scalar_value, function_space, \
-    new_function_id, new_space_id, space_id, space_new, \
+    function_space_type, new_function_id, new_space_id, space_id, space_new, \
     subtract_adjoint_derivative_action
 from ..interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, is_valid_r0_space
@@ -397,6 +397,8 @@ def _subtract_adjoint_derivative_action(x, y):
             alpha = dtype(alpha)
         else:
             return NotImplemented
+        if function_space_type(x) != function_space_type(y):
+            warnings.warn("Unexpected space type")
         y_value = function_scalar_value(y)
         # annotate=False, tlm=False
         x.assign(dtype(x) - alpha * y_value)

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -133,7 +133,7 @@ def assemble(expr, tensor=None, bcs=None, *, form_compiler_parameters=None,
             b._tlm_adjoint__form_compiler_parameters = form_compiler_parameters  # noqa: E501
 
         if rank == 1 and tensor is None:
-            b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "dual")  # noqa: E501
+            b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "conjugate_dual")  # noqa: E501
 
     return b
 

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -118,8 +118,6 @@ def assemble(expr, tensor=None, bcs=None, *, form_compiler_parameters=None,
         expr, tensor=tensor, bcs=bcs,
         form_compiler_parameters=form_compiler_parameters,
         **kwargs)
-    if tensor is None:
-        tensor = b
 
     if isinstance(expr, ufl.classes.Form):
         rank = len(expr.arguments())
@@ -131,10 +129,13 @@ def assemble(expr, tensor=None, bcs=None, *, form_compiler_parameters=None,
             form_compiler_parameters = form_compiler_parameters_
 
             if rank != 2:
-                tensor._tlm_adjoint__form = expr
-            tensor._tlm_adjoint__form_compiler_parameters = form_compiler_parameters  # noqa: E501
+                b._tlm_adjoint__form = expr
+            b._tlm_adjoint__form_compiler_parameters = form_compiler_parameters  # noqa: E501
 
-    return tensor
+        if rank == 1 and tensor is None:
+            b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "dual")  # noqa: E501
+
+    return b
 
 
 # Aim for compatibility with Firedrake API, git master revision

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -23,7 +23,7 @@ from .backend import Parameters, Projector, backend_DirichletBC, \
     backend_LinearVariationalSolver, backend_NonlinearVariationalSolver, \
     backend_Vector, backend_assemble, backend_project, backend_solve, \
     extract_args, parameters
-from ..interface import InterfaceException, function_new, \
+from ..interface import InterfaceException, check_space_type, function_new, \
     function_update_state, space_new
 from .backend_code_generator_interface import copy_parameters_dict, \
     update_parameters_dict
@@ -114,10 +114,16 @@ def packed_solver_parameters(solver_parameters, options_prefix=None,
 
 def assemble(expr, tensor=None, bcs=None, *, form_compiler_parameters=None,
              **kwargs):
+    if tensor is not None and isinstance(tensor, backend_Function):
+        check_space_type(tensor, "conjugate_dual")
+
     b = backend_assemble(
         expr, tensor=tensor, bcs=bcs,
         form_compiler_parameters=form_compiler_parameters,
         **kwargs)
+
+    if tensor is None and isinstance(b, backend_Function):
+        b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "conjugate_dual")  # noqa: E501
 
     if isinstance(expr, ufl.classes.Form):
         rank = len(expr.arguments())
@@ -128,12 +134,9 @@ def assemble(expr, tensor=None, bcs=None, *, form_compiler_parameters=None,
                                        form_compiler_parameters)
             form_compiler_parameters = form_compiler_parameters_
 
-            if rank != 2:
+            if rank == 1:
                 b._tlm_adjoint__form = expr
             b._tlm_adjoint__form_compiler_parameters = form_compiler_parameters  # noqa: E501
-
-        if rank == 1 and tensor is None:
-            b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "conjugate_dual")  # noqa: E501
 
     return b
 

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -22,7 +22,7 @@ from .backend import Tensor, TestFunction, TrialFunction, backend_Function, \
     backend_assemble, backend_ScalarType
 from ..interface import check_space_type, function_assign, function_comm, \
     function_dtype, function_get_values, function_is_scalar, \
-    function_local_size, function_new, function_new_dual, \
+    function_local_size, function_new, function_new_conjugate_dual, \
     function_scalar_value, function_set_values, function_space, is_function, \
     weakref_method
 from .backend_code_generator_interface import assemble, matrix_multiply
@@ -342,7 +342,7 @@ class PointInterpolationSolver(Equation):
             adj_x_v = np.full(len(adj_X), np.NAN, dtype=self._dtype)
             for i, adj_x in enumerate(adj_X):
                 adj_x_v[i] = function_scalar_value(adj_x)
-            F = function_new_dual(self.dependencies()[-1])
+            F = function_new_conjugate_dual(self.dependencies()[-1])
             function_set_values(F, self._P_H.dot(adj_x_v))
             return (-1.0, F)
         else:

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -22,8 +22,8 @@ from .backend import Tensor, TestFunction, TrialFunction, backend_Function, \
     backend_assemble, backend_ScalarType
 from ..interface import function_assign, function_comm, function_dtype, \
     function_get_values, function_is_scalar, function_local_size, \
-    function_new, function_scalar_value, function_set_values, function_space, \
-    is_function, weakref_method
+    function_new, function_new_dual, function_scalar_value, \
+    function_set_values, function_space, is_function, weakref_method
 from .backend_code_generator_interface import assemble, matrix_multiply
 
 from ..caches import Cache
@@ -176,7 +176,7 @@ class LocalProjectionSolver(EquationSolver):
                 self._lhs,
                 form_compiler_parameters=self._form_compiler_parameters)
 
-        adj_x = function_new(b)
+        adj_x = self.new_adj_x()
         local_solver.solve_local(adj_x, b)
         return adj_x
 
@@ -339,7 +339,7 @@ class PointInterpolationSolver(Equation):
             adj_x_v = np.full(len(adj_X), np.NAN, dtype=self._dtype)
             for i, adj_x in enumerate(adj_X):
                 adj_x_v[i] = function_scalar_value(adj_x)
-            F = function_new(self.dependencies()[-1])
+            F = function_new_dual(self.dependencies()[-1])
             function_set_values(F, self._P_H.dot(adj_x_v))
             return (-1.0, F)
         else:

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -20,10 +20,11 @@
 
 from .backend import Tensor, TestFunction, TrialFunction, backend_Function, \
     backend_assemble, backend_ScalarType
-from ..interface import function_assign, function_comm, function_dtype, \
-    function_get_values, function_is_scalar, function_local_size, \
-    function_new, function_new_dual, function_scalar_value, \
-    function_set_values, function_space, is_function, weakref_method
+from ..interface import check_space_type, function_assign, function_comm, \
+    function_dtype, function_get_values, function_is_scalar, \
+    function_local_size, function_new, function_new_dual, \
+    function_scalar_value, function_set_values, function_space, is_function, \
+    weakref_method
 from .backend_code_generator_interface import assemble, matrix_multiply
 
 from ..caches import Cache
@@ -258,6 +259,7 @@ class PointInterpolationSolver(Equation):
 
         dtype = None
         for x in X:
+            check_space_type(x, "primal")
             if not function_is_scalar(x):
                 raise EquationException("Solution must be a scalar, or a "
                                         "sequence of scalars")
@@ -267,6 +269,7 @@ class PointInterpolationSolver(Equation):
                 raise EquationException("Invalid dtype")
         if dtype is None:
             dtype = backend_ScalarType
+        check_space_type(y, "primal")
 
         if X_coords is None:
             if P is None:

--- a/tlm_adjoint/functional.py
+++ b/tlm_adjoint/functional.py
@@ -19,8 +19,8 @@
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
 from .interface import function_is_scalar, function_name, function_new, \
-    function_scalar_value, function_space, functional_term_eq, is_function, \
-    space_id, space_new
+    function_scalar_value, function_space, function_space_type, \
+    functional_term_eq, is_function, space_id, space_new
 
 from .equations import AssignmentSolver, AxpySolver
 from .manager import manager as _manager
@@ -60,7 +60,9 @@ class Functional:
                     and space_id(space) != space_id(function_space(fn)):
                 raise FunctionalException("Invalid function space")
         if not function_is_scalar(fn):
-            raise FunctionalException("fn must be a scalar")
+            raise FunctionalException("Functional must be a scalar")
+        if function_space_type(fn) != "primal":
+            raise FunctionalException("Functional must be in the primal space")
         name = function_name(fn)
 
         self._name = name

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -303,7 +303,8 @@ class FunctionInterface:
         raise InterfaceException("Method not overridden")
 
     def _new(self, *, name=None, static=False, cache=None, checkpoint=None):
-        return space_new(function_space(self), name=name, static=static,
+        return space_new(function_space(self), name=name,
+                         space_type=function_space_type(self), static=static,
                          cache=cache, checkpoint=checkpoint)
 
     def _copy(self, *, name=None, static=False, cache=None, checkpoint=None):
@@ -313,8 +314,9 @@ class FunctionInterface:
         if function_is_static(self):
             return None
         else:
-            return function_new(self, name=name, static=False,
-                                cache=function_is_cached(self),
+            return function_new(self, name=name,
+                                space_type=function_space_type(self),
+                                static=False, cache=function_is_cached(self),
                                 checkpoint=function_is_checkpointed(self))
 
     def _replacement(self):

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -314,9 +314,8 @@ class FunctionInterface:
         if function_is_static(self):
             return None
         else:
-            return function_new(self, name=name,
-                                space_type=function_space_type(self),
-                                static=False, cache=function_is_cached(self),
+            return function_new(self, name=name, static=False,
+                                cache=function_is_cached(self),
                                 checkpoint=function_is_checkpointed(self))
 
     def _replacement(self):

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -240,6 +240,7 @@ def no_space_type_checking(fn):
 
 
 def check_space_type(x, space_type):
+    assert space_type in ["primal", "dual"]
     if _check_space_types[0]:
         if function_space_type(x) != space_type:
             warnings.warn("Unexpected space type", stacklevel=2)

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -62,6 +62,7 @@ __all__ = \
         "function_local_size",
         "function_name",
         "function_new",
+        "function_new_dual",
         "function_new_tangent_linear",
         "function_replacement",
         "function_set_values",
@@ -217,8 +218,9 @@ class FunctionInterface:
              "_is_checkpointed", "_caches", "_update_caches", "_zero",
              "_assign", "_axpy", "_inner", "_max_value", "_sum", "_linf_norm",
              "_local_size", "_global_size", "_local_indices", "_get_values",
-             "_set_values", "_new", "_copy", "_new_tangent_linear",
-             "_replacement", "_is_replacement", "_is_scalar", "_scalar_value")
+             "_set_values", "_new", "_new_dual", "_copy",
+             "_new_tangent_linear", "_replacement", "_is_replacement",
+             "_is_scalar", "_scalar_value")
 
     def __init__(self):
         raise InterfaceException("Cannot instantiate FunctionInterface object")
@@ -303,9 +305,18 @@ class FunctionInterface:
         raise InterfaceException("Method not overridden")
 
     def _new(self, *, name=None, static=False, cache=None, checkpoint=None):
+        space_type = function_space_type(self)
         return space_new(function_space(self), name=name,
-                         space_type=function_space_type(self), static=static,
-                         cache=cache, checkpoint=checkpoint)
+                         space_type=space_type, static=static, cache=cache,
+                         checkpoint=checkpoint)
+
+    def _new_dual(self, *, name=None, static=False, cache=None,
+                  checkpoint=None):
+        space_type = function_space_type(self)
+        space_type = {"primal": "dual", "dual": "primal"}[space_type]
+        return space_new(function_space(self), name=name,
+                         space_type=space_type, static=static, cache=cache,
+                         checkpoint=checkpoint)
 
     def _copy(self, *, name=None, static=False, cache=None, checkpoint=None):
         raise InterfaceException("Method not overridden")
@@ -459,6 +470,12 @@ def function_set_values(x, values):
 
 def function_new(x, *, name=None, static=False, cache=None, checkpoint=None):
     return x._tlm_adjoint__function_interface_new(
+        name=name, static=static, cache=cache, checkpoint=checkpoint)
+
+
+def function_new_dual(x, *, name=None, static=False, cache=None,
+                      checkpoint=None):
+    return x._tlm_adjoint__function_interface_new_dual(
         name=name, static=static, cache=cache, checkpoint=checkpoint)
 
 

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -173,7 +173,8 @@ class SpaceInterface:
     def _id(self):
         raise InterfaceException("Method not overridden")
 
-    def _new(self, *, name=None, static=False, cache=None, checkpoint=None):
+    def _new(self, *, name=None, space_type="primal", static=False, cache=None,
+             checkpoint=None):
         raise InterfaceException("Method not overridden")
 
 
@@ -202,9 +203,11 @@ def space_id(space):
     return space._tlm_adjoint__space_interface_id()
 
 
-def space_new(space, *, name=None, static=False, cache=None, checkpoint=None):
+def space_new(space, *, name=None, space_type="primal", static=False,
+              cache=None, checkpoint=None):
     return space._tlm_adjoint__space_interface_new(
-        name=name, static=static, cache=cache, checkpoint=checkpoint)
+        name=name, space_type=space_type, static=static, cache=cache,
+        checkpoint=checkpoint)
 
 
 class FunctionInterface:

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -66,6 +66,7 @@ __all__ = \
         "function_replacement",
         "function_set_values",
         "function_space",
+        "function_space_type",
         "function_state",
         "function_sum",
         "function_update_caches",
@@ -208,13 +209,13 @@ def space_new(space, *, name=None, static=False, cache=None, checkpoint=None):
 
 class FunctionInterface:
     prefix = "_tlm_adjoint__function_interface"
-    names = ("_comm", "_space", "_dtype", "_id", "_name", "_state",
-             "_update_state", "_is_static", "_is_cached", "_is_checkpointed",
-             "_caches", "_update_caches", "_zero", "_assign", "_axpy",
-             "_inner", "_max_value", "_sum", "_linf_norm", "_local_size",
-             "_global_size", "_local_indices", "_get_values", "_set_values",
-             "_new", "_copy", "_new_tangent_linear", "_replacement",
-             "_is_replacement", "_is_scalar", "_scalar_value")
+    names = ("_comm", "_space", "_space_type", "_dtype", "_id", "_name",
+             "_state", "_update_state", "_is_static", "_is_cached",
+             "_is_checkpointed", "_caches", "_update_caches", "_zero",
+             "_assign", "_axpy", "_inner", "_max_value", "_sum", "_linf_norm",
+             "_local_size", "_global_size", "_local_indices", "_get_values",
+             "_set_values", "_new", "_copy", "_new_tangent_linear",
+             "_replacement", "_is_replacement", "_is_scalar", "_scalar_value")
 
     def __init__(self):
         raise InterfaceException("Cannot instantiate FunctionInterface object")
@@ -223,6 +224,9 @@ class FunctionInterface:
         return space_comm(function_space(self))
 
     def _space(self):
+        raise InterfaceException("Method not overridden")
+
+    def _space_type(self):
         raise InterfaceException("Method not overridden")
 
     def _dtype(self):
@@ -333,6 +337,10 @@ def function_comm(x):
 
 def function_space(x):
     return x._tlm_adjoint__function_interface_space()
+
+
+def function_space_type(x):
+    return x._tlm_adjoint__function_interface_space_type()
 
 
 def function_dtype(x):

--- a/tlm_adjoint/numpy/backend_interface.py
+++ b/tlm_adjoint/numpy/backend_interface.py
@@ -23,7 +23,8 @@ from ..functional import Functional as _Functional
 from ..hessian import GeneralGaussNewton as _GaussNewton
 from ..hessian_optimization import CachedGaussNewton as _CachedGaussNewton
 from ..interface import InterfaceException, SpaceInterface, add_interface, \
-    function_space, new_function_id, new_space_id, space_id, space_new
+    function_space, function_space_type, new_function_id, new_space_id, \
+    space_id, space_new
 from ..interface import FunctionInterface as _FunctionInterface
 from ..tlm_adjoint import DEFAULT_COMM
 
@@ -204,8 +205,10 @@ class FunctionInterface(_FunctionInterface):
         self.vector()[:] = values
 
     def _copy(self, *, name=None, static=False, cache=None, checkpoint=None):
-        return Function(self.space(), name=name, static=static, cache=cache,
-                        checkpoint=checkpoint, _data=self.vector().copy())
+        return Function(function_space(self), name=name,
+                        space_type=function_space_type(self), static=static,
+                        cache=cache, checkpoint=checkpoint,
+                        _data=self.vector().copy())
 
     def _replacement(self):
         return self.replacement()

--- a/tlm_adjoint/numpy/backend_interface.py
+++ b/tlm_adjoint/numpy/backend_interface.py
@@ -111,6 +111,9 @@ class FunctionInterface(_FunctionInterface):
     def _space(self):
         return self.space()
 
+    def _space_type(self):
+        return self.space_type()
+
     def _id(self):
         return self.id()
 
@@ -218,8 +221,10 @@ class FunctionInterface(_FunctionInterface):
 
 
 class Function:
-    def __init__(self, space, *, name=None, static=False, cache=None,
-                 checkpoint=None, _data=None):
+    def __init__(self, space, *, name=None, space_type="primal", static=False,
+                 cache=None, checkpoint=None, _data=None):
+        if space_type not in ["primal", "dual"]:
+            raise InterfaceException("Invalid space type")
         id = new_function_id()
         if name is None:
             # Following FEniCS 2019.1.0 behaviour
@@ -230,6 +235,7 @@ class Function:
             checkpoint = not static
 
         self._space = space
+        self._space_type = space_type
         self._id = id
         self._name = name
         self._state = 0
@@ -250,6 +256,9 @@ class Function:
 
     def space(self):
         return self._space
+
+    def space_type(self):
+        return self._space_type
 
     def dtype(self):
         return self._space.dtype()
@@ -291,6 +300,9 @@ class ReplacementInterface(_FunctionInterface):
     def _space(self):
         return self.space()
 
+    def _space_type(self):
+        return self.space_type()
+
     def _id(self):
         return self.id()
 
@@ -322,6 +334,7 @@ class ReplacementInterface(_FunctionInterface):
 class Replacement:
     def __init__(self, x):
         self._space = x.space()
+        self._space_type = x.space_type()
         self._id = x.id()
         self._name = x.name()
         self._static = x.is_static()
@@ -332,6 +345,9 @@ class Replacement:
 
     def space(self):
         return self._space
+
+    def space_type(self):
+        return self._space_type
 
     def id(self):
         return self._id

--- a/tlm_adjoint/numpy/backend_interface.py
+++ b/tlm_adjoint/numpy/backend_interface.py
@@ -75,9 +75,10 @@ class FunctionSpaceInterface(SpaceInterface):
     def _id(self):
         return self.id()
 
-    def _new(self, *, name=None, static=False, cache=None, checkpoint=None):
-        return Function(self, name=name, static=static, cache=cache,
-                        checkpoint=checkpoint)
+    def _new(self, *, name=None, space_type="primal", static=False, cache=None,
+             checkpoint=None):
+        return Function(self, name=name, space_type=space_type, static=static,
+                        cache=cache, checkpoint=checkpoint)
 
 
 class FunctionSpace:

--- a/tlm_adjoint/numpy/backend_interface.py
+++ b/tlm_adjoint/numpy/backend_interface.py
@@ -227,7 +227,7 @@ class FunctionInterface(_FunctionInterface):
 class Function:
     def __init__(self, space, *, name=None, space_type="primal", static=False,
                  cache=None, checkpoint=None, _data=None):
-        if space_type not in ["primal", "dual"]:
+        if space_type not in ["primal", "conjugate_primal", "dual", "conjugate_dual"]:  # noqa: E501
             raise InterfaceException("Invalid space type")
         id = new_function_id()
         if name is None:

--- a/tlm_adjoint/numpy/equations.py
+++ b/tlm_adjoint/numpy/equations.py
@@ -18,8 +18,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from ..interface import function_new
-
 from ..equations import EquationException, LinearEquation, Matrix, RHS
 
 import numpy as np
@@ -82,7 +80,7 @@ class ConstantMatrix(Matrix):
         raise EquationException("Unexpected call to adjoint_derivative_action")
 
     def adjoint_solve(self, adj_x, nl_deps, b):
-        adj_x = function_new(b)
+        adj_x = self.new_adj_x()
         adj_x.vector()[:] = np.linalg.solve(self._A_H, b.vector())
         return adj_x
 

--- a/tlm_adjoint/timestepping.py
+++ b/tlm_adjoint/timestepping.py
@@ -157,11 +157,11 @@ class TimeLevels:
 
 
 class TimeFunction:
-    def __init__(self, levels, space, *, name=None):
+    def __init__(self, levels, space, *, name=None, space_type="primal"):
         # Note that this keeps references to the functions on each time level
         self._fns = {}
         for level in levels:
-            fn = space_new(space, name=name)
+            fn = space_new(space, name=name, space_type=space_type)
             fn._tlm_adjoint__tfn = self
             fn._tlm_adjoint__level = level
             self._fns[level] = fn

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -22,7 +22,7 @@ from .interface import function_assign, function_copy, function_get_values, \
     function_global_size, function_id, function_is_checkpointed, \
     function_is_replacement, function_local_indices, function_name, \
     function_new, function_new_tangent_linear, function_set_values, \
-    function_space, is_function, space_id, space_new
+    function_space, function_space_type, is_function, space_id, space_new
 
 from .alias import Alias, WeakAlias, gc_disabled
 from .binomial_checkpointing import MultistageManager
@@ -1224,6 +1224,7 @@ class EquationManager:
             h = open(cp_filename, "wb")
 
             pickle.dump({key: (self._checkpoint_space_id(F),
+                               function_space_type(F),
                                function_get_values(F))
                          for key, F in cp.items()},
                         h, protocol=pickle.HIGHEST_PROTOCOL)
@@ -1252,6 +1253,10 @@ class EquationManager:
                                      dtype=values.dtype)
                 d[function_local_indices(F)] = values
                 del values
+
+                d = g.create_dataset("space_type", shape=(self._comm.size,),
+                                     dtype=np.uint8)
+                d[self._comm.rank] = {"primal": 0, "dual": 1}[function_space_type(F)]  # noqa: E501
 
                 d = g.create_dataset("space_id", shape=(self._comm.size,),
                                      dtype=np.int64)
@@ -1282,9 +1287,10 @@ class EquationManager:
                 self._comm.barrier()
 
             for key in tuple(cp.keys()):
-                space_id, values = cp.pop(key)
+                space_id, space_type, values = cp.pop(key)
                 if key in storage:
-                    F = space_new(self._cp_spaces[space_id])
+                    F = space_new(self._cp_spaces[space_id],
+                                  space_type=space_type)
                     function_set_values(F, values)
                     storage[key] = F
                 del space_id, values
@@ -1303,10 +1309,16 @@ class EquationManager:
                 d = g["key"]
                 key = int(d[self._comm.rank])
                 if key in storage:
+                    d = g["space_type"]
+                    space_type = {0: "primal", 1: "dual"}[d[self._comm.rank]]
+
                     d = g["space_id"]
-                    F = space_new(self._cp_spaces[d[self._comm.rank]])
+                    F = space_new(self._cp_spaces[d[self._comm.rank]],
+                                  space_type=space_type)
+
                     d = g["value"]
                     function_set_values(F, d[function_local_indices(F)])
+
                     storage[key] = F
                 del g, d
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -18,12 +18,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import function_assign, function_copy, function_copy_dual, \
-    function_get_values, function_global_size, function_id, \
-    function_is_checkpointed, function_is_replacement, \
-    function_local_indices, function_name, function_new, \
-    function_new_tangent_linear, function_set_values, function_space, \
-    function_space_type, is_function, space_id, space_new
+from .interface import function_assign, function_copy, function_get_values, \
+    function_global_size, function_id, function_is_checkpointed, \
+    function_is_replacement, function_local_indices, function_name, \
+    function_new, function_new_tangent_linear, function_set_values, \
+    function_space, function_space_type, is_function, space_id, space_new
 
 from .alias import Alias, WeakAlias, gc_disabled
 from .binomial_checkpointing import MultistageManager
@@ -1257,7 +1256,8 @@ class EquationManager:
 
                 d = g.create_dataset("space_type", shape=(self._comm.size,),
                                      dtype=np.uint8)
-                d[self._comm.rank] = {"primal": 0, "dual": 1}[function_space_type(F)]  # noqa: E501
+                d[self._comm.rank] = {"primal": 0, "conjugate_primal": 1,
+                                      "dual": 2, "conjugate_dual": 3}[function_space_type(F)]  # noqa: E501
 
                 d = g.create_dataset("space_id", shape=(self._comm.size,),
                                      dtype=np.int64)
@@ -1311,7 +1311,8 @@ class EquationManager:
                 key = int(d[self._comm.rank])
                 if key in storage:
                     d = g["space_type"]
-                    space_type = {0: "primal", 1: "dual"}[d[self._comm.rank]]
+                    space_type = {0: "primal", 1: "conjugate_primal",
+                                  2: "dual", 3: "conjugate_dual"}[d[self._comm.rank]]  # noqa: E501
 
                     d = g["space_id"]
                     F = space_new(self._cp_spaces[d[self._comm.rank]],
@@ -1737,8 +1738,6 @@ class EquationManager:
                                     adj_X.append(eq.new_adj_X(m))
                                 elif eq.adj_X_space_type(m) == function_space_type(adj_x_ic):  # noqa: E501
                                     adj_X.append(adj_x_ic)
-                                else:
-                                    adj_X.append(function_copy_dual(adj_x_ic))
                         # Solve adjoint equation, add terms to adjoint
                         # equations
                         adj_X = eq.adjoint(


### PR DESCRIPTION
Add a "space type" property to functions.

Functions can have space type "primal" or "conjugate_dual", indicating whether they are in the function space defined by `function_space`, or the associated conjugate dual space.

Functions can also have space type "dual", indicating that they are in the dual space, or "conjugate_primal", indicating that they are in the conjugate dual space associated with the dual space. There are currently no cases where these are used -- although they may be useful in future, e.g. to assemble and reuse a linear form. Note that Firedrake assembles _conjugate_ linear forms.

Equations can have adjoint type "primal" or "conjugate_dual", indicating whether the adjoint solution is in the same space as the forward ("primal"), or the associated conjugate dual ("conjugate_dual" -- the default). Equations corresponding to the solution of finite element discretized PDEs have adjoint type "primal".

Also
- Add space type checking in various places, to warn if inconsistent space types are encountered.
- Add a `col_space_type` keyword to the `Matrix` constructor, defining the space type ("primal", "conjugate_primal", "dual", or "conjugate_dual" -- default "conjugate_dual") of the result of a matrix action.
- Add `space_type` and `action_type` arguments to `eigendecompose`. `space_type` defines the eigenvector space type ("primal", "conjugate_primal", "dual", or "conjugate_dual"). `action_type` may be either "primal", to indicate that the result of matrix actions are in the same space as the eigenvectors, or "conjugate_dual" (the default), to indicate that they are in the associated conjugate dual space.
- Remove the rank 1 case from the `AssembleSolver`.
- Make the `A` argument keyword-only in the `LinearEquation` constructor.
- Note that `function_axpy` does _not_ apply a complex conjugate to the factor alpha when adding elements in conjugate spaces.