### PR TITLE
Firedrake backend: Use ufl.algorithms.strip_terminal_data and ufl.algorithms.replace_terminal_data, if available

### DIFF
--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -248,9 +248,9 @@ class AssembleSolver(ExprEquation):
 def unbound_form(form, deps):
     replacement_deps = tuple(function_replacement(dep) for dep in deps)
     assert len(deps) == len(replacement_deps)
-    return_value = ufl.replace(form, dict(zip(deps, replacement_deps)))
-    return_value._cache["_tlm_adjoint__replacement_deps"] = replacement_deps
-    return return_value
+    replaced_form = ufl.replace(form, dict(zip(deps, replacement_deps)))
+    replaced_form._cache["_tlm_adjoint__replacement_deps"] = replacement_deps
+    return replaced_form
 
 
 def bind_form(form, deps):

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -378,7 +378,7 @@ def eliminate_zeros(expr, *, force_non_empty_form=False):
             simplified_expr = zero * ufl.ds
         elif len(arguments) == 1:
             test, = arguments
-            simplified_expr = zero * test * ufl.ds
+            simplified_expr = zero * ufl.conj(test) * ufl.ds
         else:
             test, trial = arguments
             simplified_expr = zero * ufl.inner(trial, test) * ufl.ds

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -346,34 +346,46 @@ def extract_coefficients(expr):
 
 
 def eliminate_zeros(expr, *, force_non_empty_form=False):
+    if isinstance(expr, ufl.classes.Form):
+        if force_non_empty_form:
+            if "_tlm_adjoint__simplified_form_non_empty" in expr._cache:
+                return expr._cache["_tlm_adjoint__simplified_form_non_empty"]
+        else:
+            if "_tlm_adjoint__simplified_form" in expr._cache:
+                return expr._cache["_tlm_adjoint__simplified_form"]
+
     replace_map = {}
     for c in extract_coefficients(expr):
         if isinstance(c, Zero):
             replace_map[c] = ufl.classes.Zero(shape=c.ufl_shape)
 
     if len(replace_map) == 0:
-        return expr
+        simplified_expr = expr
     else:
         simplified_expr = ufl.replace(expr, replace_map)
+    if isinstance(expr, ufl.classes.Form):
+        expr._cache["_tlm_adjoint__simplified_form"] = simplified_expr
 
-        if force_non_empty_form \
-                and isinstance(simplified_expr, ufl.classes.Form) \
-                and simplified_expr.empty():
-            # Inefficient, but it is very difficult to generate a non-empty but
-            # zero valued form
-            arguments = expr.arguments()
-            domain = expr.ufl_domains()[0]
-            zero = ZeroConstant(domain=domain)
-            if len(arguments) == 0:
-                simplified_expr = zero * ufl.ds
-            elif len(arguments) == 1:
-                test, = arguments
-                simplified_expr = zero * test * ufl.ds
-            else:
-                test, trial = arguments
-                simplified_expr = zero * ufl.inner(trial, test) * ufl.ds
+    if force_non_empty_form \
+            and isinstance(simplified_expr, ufl.classes.Form) \
+            and simplified_expr.empty():
+        # Inefficient, but it is very difficult to generate a non-empty but
+        # zero valued form
+        arguments = expr.arguments()
+        domain = expr.ufl_domains()[0]
+        zero = ZeroConstant(domain=domain)
+        if len(arguments) == 0:
+            simplified_expr = zero * ufl.ds
+        elif len(arguments) == 1:
+            test, = arguments
+            simplified_expr = zero * test * ufl.ds
+        else:
+            test, trial = arguments
+            simplified_expr = zero * ufl.inner(trial, test) * ufl.ds
+    if isinstance(expr, ufl.classes.Form):
+        expr._cache["_tlm_adjoint__simplified_form_non_empty"] = simplified_expr  # noqa: E501
 
-        return simplified_expr
+    return simplified_expr
 
 
 class Function(backend_Function):

--- a/tlm_adjoint/fenics/backend_overrides.py
+++ b/tlm_adjoint/fenics/backend_overrides.py
@@ -33,6 +33,7 @@ from ..manager import annotation_enabled, tlm_enabled
 
 from .equations import AssignmentSolver, EquationSolver, ProjectionSolver, \
     linear_equation_new_x
+from .functions import eliminate_zeros
 
 import numpy as np
 import ufl
@@ -84,6 +85,7 @@ def assemble(form, tensor=None, form_compiler_parameters=None,
     if tensor is not None and hasattr(tensor, "_tlm_adjoint__function"):
         check_space_type(tensor._tlm_adjoint__function, "conjugate_dual")
 
+    form = eliminate_zeros(form, force_non_empty_form=True)
     b = backend_assemble(form, tensor=tensor,
                          form_compiler_parameters=form_compiler_parameters,
                          add_values=add_values, *args, **kwargs)
@@ -128,6 +130,8 @@ def assemble_system(A_form, b_form, bcs=None, x0=None,
     if b_tensor is not None and hasattr(b_tensor, "_tlm_adjoint__function"):
         check_space_type(b_tensor._tlm_adjoint__function, "conjugate_dual")
 
+    A_form = eliminate_zeros(A_form, force_non_empty_form=True)
+    b_form = eliminate_zeros(b_form, force_non_empty_form=True)
     A, b = backend_assemble_system(
         A_form, b_form, bcs=bcs, x0=x0,
         form_compiler_parameters=form_compiler_parameters,

--- a/tlm_adjoint/firedrake/backend.py
+++ b/tlm_adjoint/firedrake/backend.py
@@ -23,7 +23,6 @@ from firedrake import Constant, DirichletBC, Function, FunctionSpace, \
     NonlinearVariationalSolver, Parameters, Projector, Tensor, TestFunction, \
     TrialFunction, UnitIntervalMesh, Vector, adjoint, assemble, homogenize, \
     info, parameters, project, solve
-from firedrake.assemble import _FORM_CACHE_KEY
 import firedrake
 
 backend = "Firedrake"
@@ -68,7 +67,6 @@ __all__ = \
         "backend_project",
         "backend_solve",
 
-        "_FORM_CACHE_KEY",
         "FunctionSpace",
         "Parameters",
         "Projector",

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -24,7 +24,7 @@ from .backend import FunctionSpace, Parameters, backend_Constant, \
     homogenize, parameters
 from ..interface import InterfaceException, check_space_type, \
     check_space_types, function_axpy, function_copy, function_dtype, \
-    function_id, function_space_type, space_new
+    function_space_type, space_new
 
 from .functions import eliminate_zeros
 
@@ -232,14 +232,6 @@ def _assemble(form, tensor=None, form_compiler_parameters=None,
 
     form = simplify_form(form)
 
-    if "_tlm_adjoint__parloops" in form._cache:
-        tensor_id, cache_0, cache_1 = form._cache.pop("_tlm_adjoint__parloops")
-        if "parloops" not in form._cache \
-                and tensor is not None \
-                and function_id(tensor) == tensor_id:
-            form._cache["parloops"] = \
-                (tuple([form, tensor] + list(cache_0)), cache_1)
-
     if tensor is not None and isinstance(tensor, backend_Function):
         check_space_type(tensor, "conjugate_dual")
 
@@ -247,13 +239,6 @@ def _assemble(form, tensor=None, form_compiler_parameters=None,
         form, tensor=tensor,
         form_compiler_parameters=form_compiler_parameters,
         *args, **kwargs)
-
-    if isinstance(b, backend_Function) and "parloops" in form._cache:
-        cache_0, cache_1 = form._cache.pop("parloops")
-        assert cache_0[0] is form
-        assert cache_0[1] is b
-        form._cache["_tlm_adjoint__parloops"] = \
-            (function_id(cache_0[1]), cache_0[2:], cache_1)
 
     if tensor is None and isinstance(b, backend_Function):
         b._tlm_adjoint__function_interface_attrs.d_setitem("space_type", "conjugate_dual")  # noqa: E501

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -33,6 +33,7 @@ from ..manager import annotation_enabled, tlm_enabled
 from .equations import AssignmentSolver, EquationSolver, ProjectionSolver, \
     linear_equation_new_x
 from .firedrake_equations import LocalProjectionSolver
+from .functions import eliminate_zeros
 
 import copy
 import ufl
@@ -117,6 +118,7 @@ def assemble(expr, tensor=None, bcs=None, *, form_compiler_parameters=None,
     if tensor is not None and isinstance(tensor, backend_Function):
         check_space_type(tensor, "conjugate_dual")
 
+    expr = eliminate_zeros(expr, force_non_empty_form=True)
     b = backend_assemble(
         expr, tensor=tensor, bcs=bcs,
         form_compiler_parameters=form_compiler_parameters,


### PR DESCRIPTION
Also

- Remove custom form binding with the Firedrake backend
- Cache `Zero` elimination
- Apply `Zero` elimination in overridden `assemble` and `assemble_system`