### PR TITLE
Updates to checkpoint storage

### DIFF
--- a/tlm_adjoint/hessian_optimization.py
+++ b/tlm_adjoint/hessian_optimization.py
@@ -87,7 +87,7 @@ class HessianOptimization:
                 manager._block.append(eq)
                 manager._cp.add_equation(
                     (len(manager._blocks), len(manager._block) - 1), eq,
-                    nl_deps=self._nl_deps[(n, i)], copy=lambda x: False)
+                    nl_deps=self._nl_deps[(n, i)], _copy=lambda x: False)
                 yield n, i, eq
 
     def _tangent_linear(self, manager, eq, M, dM):

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -163,10 +163,10 @@ class CheckpointStorage:
     def store_data(self):
         return self._store_data
 
-    def clear(self, *, clear_cp=True, clear_data=True, clear_refs=False):
+    def clear(self, *, clear_ics=True, clear_data=True, clear_refs=False):
         if clear_refs:
             self._refs.clear()
-        if clear_cp:
+        if clear_ics:
             self._seen_ics.clear()
             self._cp.clear()
 
@@ -1812,7 +1812,7 @@ class EquationManager:
             assert len(adj_Xs[J_i]) == 0
 
         if self._cp_method == "multistage":
-            self._cp.clear(clear_cp=False, clear_data=True, clear_refs=False)
+            self._cp.clear(clear_ics=False, clear_data=True, clear_refs=False)
 
         return tuple(dJ)
 


### PR DESCRIPTION
- Maintain consistency between cp, refs, and data.
- Always copy the initial condition values in `EquationManager.initial_condition`.
- Interface updates, including use of keyword-only arguments.