### PR TITLE
Bugfix to space type checking in the adjoint

### DIFF
--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -27,7 +27,7 @@ from ..hessian_optimization import CachedGaussNewton as _CachedGaussNewton
 from ..interface import InterfaceException, SpaceInterface, \
     add_finalize_adjoint_derivative_action, add_functional_term_eq, \
     add_interface, add_subtract_adjoint_derivative_action, \
-    add_time_system_eq, check_space_type, function_copy, function_new, \
+    add_time_system_eq, check_space_types, function_copy, function_new, \
     function_space, function_space_type, new_function_id, new_space_id, \
     space_id, space_new, subtract_adjoint_derivative_action
 from ..interface import FunctionInterface as _FunctionInterface
@@ -415,7 +415,7 @@ def _subtract_adjoint_derivative_action(x, y):
         alpha, y = y
         alpha = backend_ScalarType(alpha)
         if hasattr(y, "_tlm_adjoint__function"):
-            check_space_type(y._tlm_adjoint__function, "conjugate_dual")
+            check_space_types(x, y._tlm_adjoint__function)
         if isinstance(x, backend_Constant):
             if len(x.ufl_shape) == 0:
                 x.assign(backend_ScalarType(x) - alpha * y.max(),

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -27,7 +27,7 @@ from ..hessian_optimization import CachedGaussNewton as _CachedGaussNewton
 from ..interface import InterfaceException, SpaceInterface, \
     add_finalize_adjoint_derivative_action, add_functional_term_eq, \
     add_interface, add_subtract_adjoint_derivative_action, \
-    add_time_system_eq, check_space_type, function_comm, function_dtype, \
+    add_time_system_eq, check_space_types, function_comm, function_dtype, \
     function_is_scalar, function_scalar_value, function_space, \
     new_function_id, new_space_id, space_id, space_new, \
     subtract_adjoint_derivative_action
@@ -422,7 +422,7 @@ def _subtract_adjoint_derivative_action(x, y):
             alpha = dtype(alpha)
         else:
             return NotImplemented
-        check_space_type(y, "conjugate_dual")
+        check_space_types(x, y)
         y_value = function_scalar_value(y)
         x.assign(dtype(x) - alpha * y_value, annotate=False, tlm=False)
     else:

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -647,7 +647,6 @@ def add_subtract_adjoint_derivative_action(backend, fn):
 
 
 def subtract_adjoint_derivative_action(x, y):
-    check_space_type(x, "conjugate_dual")
     for fn in _subtract_adjoint_derivative_action.values():
         if fn(x, y) != NotImplemented:
             break
@@ -655,7 +654,7 @@ def subtract_adjoint_derivative_action(x, y):
         if y is None:
             pass
         elif is_function(y):
-            check_space_type(y, "conjugate_dual")
+            check_space_types(x, y)
             if isinstance(y._tlm_adjoint__function_interface,
                           type(x._tlm_adjoint__function_interface)):
                 function_axpy(x, -1.0, y)
@@ -671,7 +670,7 @@ def subtract_adjoint_derivative_action(x, y):
                 and is_function(y[1]):
             alpha, y = y
             alpha = function_dtype(x)(alpha)
-            check_space_type(y, "conjugate_dual")
+            check_space_types(x, y)
             if isinstance(y._tlm_adjoint__function_interface,
                           type(x._tlm_adjoint__function_interface)):
                 function_axpy(x, -alpha, y)


### PR DESCRIPTION
Correctly handle the case where the forward is not in the primal space