### PR TITLE
FEniCS/Firedrake backends: Bugfix to matrix-multiplication-based rank 1 form assembly optimization in complex mode

### DIFF
--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -23,7 +23,7 @@ from tlm_adjoint.fenics import *
 from tlm_adjoint.fenics import manager as _manager
 from tlm_adjoint.fenics.backend import backend_Constant, backend_Function
 from tlm_adjoint.fenics.backend_code_generator_interface import \
-    interpolate_expression
+    complex_mode, interpolate_expression
 
 import copy
 import functools
@@ -40,6 +40,7 @@ import weakref
 
 __all__ = \
     [
+        "complex_mode",
         "interpolate_expression",
 
         "run_example",

--- a/tests/fenics/test_caches.py
+++ b/tests/fenics/test_caches.py
@@ -20,11 +20,15 @@
 
 from fenics import *
 from tlm_adjoint.fenics import *
+from tlm_adjoint.fenics.backend_code_generator_interface import \
+    function_vector
 
 from .test_base import *
 
 import mpi4py.MPI as MPI
+import numpy as np
 import pytest
+import ufl
 
 pytestmark = pytest.mark.skipif(
     MPI.COMM_WORLD.size not in [1, 4],
@@ -221,3 +225,55 @@ def test_cached_adjoint(setup_test, test_leaks,
 
     min_order = taylor_test(forward, G, J_val=J.value(), dJ=dJ)
     assert min_order > 1.99
+
+
+@pytest.mark.fenics
+@pytest.mark.parametrize("x_conjugate", [False, True])
+@seed_test
+def test_mat_terms(setup_test, test_leaks,
+                   x_conjugate):
+    from tlm_adjoint.fenics.backend_code_generator_interface import \
+        assemble_matrix, matrix_multiply
+
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    test = TestFunction(space)
+
+    x = Function(space, name="x")
+    x_expr = exp(X[0]) * X[1]
+    if issubclass(function_dtype(x), (complex, np.complexfloating)):
+        x_expr += X[0] * sin(X[1]) * 1.j
+    interpolate_expression(x, x_expr)
+
+    form = inner(ufl.conj(x) if x_conjugate else x, test) * dx
+
+    b_ref = Function(space, name="b_ref", space_type="conjugate_dual")
+    assemble(form, tensor=function_vector(b_ref))
+
+    if not complex_mode:
+        form = ufl.algorithms.remove_complex_nodes.remove_complex_nodes(form)
+    cached_terms, mat_terms, non_cached_terms = split_form(form)
+
+    assert cached_terms.empty()
+    if not complex_mode or not x_conjugate:
+        assert len(mat_terms) == 1
+        assert non_cached_terms.empty()
+
+        assert tuple(mat_terms.keys()) == (function_id(x),)
+        A, = tuple(mat_terms.values())
+        A, b_bc = assemble_matrix(A)
+        b = Function(space, name="b", space_type="conjugate_dual")
+        matrix_multiply(A, function_vector(x), tensor=function_vector(b))
+        assert b_bc is None
+    else:
+        assert len(mat_terms) == 0
+        assert not non_cached_terms.empty()
+
+        b = Function(space, name="b", space_type="conjugate_dual")
+        assemble(non_cached_terms, tensor=function_vector(b))
+
+    b_error = function_copy(b_ref)
+    function_axpy(b_error, -1.0, b)
+    assert function_linf_norm(b_error) < 1.0e-17

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -27,7 +27,6 @@ from .test_base import *
 import mpi4py.MPI as MPI
 import numpy as np
 import os
-import petsc4py.PETSc as PETSc
 import pytest
 import ufl
 
@@ -693,9 +692,7 @@ def test_Storage(setup_test, test_leaks,
 
 
 @pytest.mark.fenics
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @no_space_type_checking
 @seed_test
 def test_InnerProductSolver(setup_test, test_leaks):

--- a/tests/fenics/test_examples.py
+++ b/tests/fenics/test_examples.py
@@ -23,8 +23,6 @@ from tlm_adjoint.fenics import *
 from .test_base import *
 
 import mpi4py.MPI as MPI
-import numpy as np
-import petsc4py.PETSc as PETSc
 import os
 import pytest
 
@@ -84,9 +82,7 @@ def test_manual_override_forward(setup_test):
 @pytest.mark.fenics
 @pytest.mark.example
 @pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only")
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_manual_override_adjoint(setup_test, test_leaks):
     run_example(os.path.join("manual", "override_adjoint.py"))

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -27,7 +27,6 @@ from .test_base import *
 
 import mpi4py.MPI as MPI
 import numpy as np
-import petsc4py.PETSc as PETSc
 import pytest
 
 pytestmark = pytest.mark.skipif(
@@ -248,9 +247,7 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
 
 
 @pytest.mark.fenics
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_Referrers_LinearEquation(setup_test, test_leaks):
     def forward(m, forward_run=False):

--- a/tests/fenics/test_minimize.py
+++ b/tests/fenics/test_minimize.py
@@ -24,8 +24,6 @@ from tlm_adjoint.fenics import *
 from .test_base import *
 
 import mpi4py.MPI as MPI
-import numpy as np
-import petsc4py.PETSc as PETSc
 import pytest
 
 pytestmark = pytest.mark.skipif(
@@ -34,9 +32,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.fenics
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_minimize_project(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)
@@ -81,9 +77,7 @@ def test_minimize_project(setup_test, test_leaks):
 
 
 @pytest.mark.fenics
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_minimize_project_multiple(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -23,7 +23,7 @@ from tlm_adjoint.firedrake import *
 from tlm_adjoint.firedrake import manager as _manager
 from tlm_adjoint.firedrake.backend import backend_Constant, backend_Function
 from tlm_adjoint.firedrake.backend_code_generator_interface import \
-    interpolate_expression
+    complex_mode, interpolate_expression
 
 import copy
 import functools
@@ -41,6 +41,7 @@ import weakref
 
 __all__ = \
     [
+        "complex_mode",
         "interpolate_expression",
 
         "run_example",

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -29,7 +29,6 @@ import firedrake
 import mpi4py.MPI as MPI
 import numpy as np
 import os
-import petsc4py.PETSc as PETSc
 import pytest
 import ufl
 
@@ -425,9 +424,7 @@ def test_ExprEvaluationSolver(setup_test, test_leaks):
 
 
 @pytest.mark.firedrake
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_LocalProjectionSolver(setup_test, test_leaks):
     mesh = UnitSquareMesh(10, 10)
@@ -628,9 +625,7 @@ def test_Storage(setup_test, test_leaks,
 
 
 @pytest.mark.firedrake
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @no_space_type_checking
 @seed_test
 def test_InnerProductSolver(setup_test, test_leaks):

--- a/tests/firedrake/test_examples.py
+++ b/tests/firedrake/test_examples.py
@@ -23,8 +23,6 @@ from tlm_adjoint.firedrake import *
 from .test_base import *
 
 import mpi4py.MPI as MPI
-import numpy as np
-import petsc4py.PETSc as PETSc
 import os
 import pytest
 
@@ -84,9 +82,7 @@ def test_manual_override_forward(setup_test):
 @pytest.mark.firedrake
 @pytest.mark.example
 @pytest.mark.skipif(MPI.COMM_WORLD.size > 1, reason="serial only")
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_manual_override_adjoint(setup_test, test_leaks):
     run_example(os.path.join("manual", "override_adjoint.py"))

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -250,9 +250,7 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
 
 
 @pytest.mark.firedrake
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_Referrers_LinearEquation(setup_test, test_leaks):
     def forward(m, forward_run=False):

--- a/tests/firedrake/test_minimize.py
+++ b/tests/firedrake/test_minimize.py
@@ -24,8 +24,6 @@ from tlm_adjoint.firedrake import *
 from .test_base import *
 
 import mpi4py.MPI as MPI
-import numpy as np
-import petsc4py.PETSc as PETSc
 import pytest
 
 pytestmark = pytest.mark.skipif(
@@ -34,9 +32,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.firedrake
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_minimize_project(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)
@@ -81,9 +77,7 @@ def test_minimize_project(setup_test, test_leaks):
 
 
 @pytest.mark.firedrake
-@pytest.mark.skipif(issubclass(PETSc.ScalarType,
-                               (complex, np.complexfloating)),
-                    reason="real only")
+@pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
 def test_minimize_project_multiple(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -27,7 +27,7 @@ from ..interface import check_space_type, function_assign, \
     function_update_caches, function_update_state, function_zero, \
     is_function, space_id
 from .backend_code_generator_interface import assemble, \
-    assemble_linear_solver, copy_parameters_dict, \
+    assemble_linear_solver, complex_mode, copy_parameters_dict, \
     form_form_compiler_parameters, function_vector, homogenize, \
     interpolate_expression, matrix_multiply, \
     process_adjoint_solver_parameters, process_solver_parameters, r0_space, \
@@ -462,6 +462,8 @@ class EquationSolver(ExprEquation):
 
         if self._forward_b_pa is None:
             rhs = eliminate_zeros(self._rhs, force_non_empty_form=True)
+            if not complex_mode:
+                rhs = ufl.algorithms.remove_complex_nodes.remove_complex_nodes(rhs)  # noqa: E501
             cached_form, mat_forms_, non_cached_form = split_form(rhs)
             mat_forms = {}
             for dep_index, dep in enumerate(eq_deps):

--- a/tlm_adjoint/fenics/backend_code_generator_interface.py
+++ b/tlm_adjoint/fenics/backend_code_generator_interface.py
@@ -44,6 +44,7 @@ __all__ = \
         "assemble_arguments",
         "assemble_linear_solver",
         "assemble_matrix",
+        "complex_mode",
         "copy_parameters_dict",
         "form_form_compiler_parameters",
         "function_vector",
@@ -91,6 +92,9 @@ if "jacobian_tolerance" not in _parameters["assembly_verification"]:
 if "rhs_tolerance" not in _parameters["assembly_verification"]:
     _parameters["assembly_verification"].add("rhs_tolerance", np.inf)
 del _parameters
+
+
+complex_mode = False
 
 
 def copy_parameters_dict(parameters):

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -25,7 +25,7 @@ from ..interface import check_space_type, function_assign, function_comm, \
     function_get_values, function_is_scalar, function_local_size, \
     function_new, function_new_conjugate_dual, function_scalar_value, \
     function_set_values, function_space, is_function, space_comm
-from .backend_code_generator_interface import assemble
+from .backend_code_generator_interface import assemble, complex_mode
 
 from ..caches import Cache
 from ..equations import Equation, EquationException, LinearEquation, Matrix, \
@@ -216,6 +216,8 @@ class LocalSolverCache(Cache):
             solver_type = LocalSolver.SolverType.LU
 
         form = eliminate_zeros(form, force_non_empty_form=True)
+        assert not complex_mode
+        form = ufl.algorithms.remove_complex_nodes.remove_complex_nodes(form)
         key = local_solver_key(form, solver_type)
 
         def value():

--- a/tlm_adjoint/firedrake/backend.py
+++ b/tlm_adjoint/firedrake/backend.py
@@ -23,6 +23,7 @@ from firedrake import Constant, DirichletBC, Function, FunctionSpace, \
     NonlinearVariationalSolver, Parameters, Projector, Tensor, TestFunction, \
     TrialFunction, UnitIntervalMesh, Vector, adjoint, assemble, homogenize, \
     info, parameters, project, solve
+from firedrake.utils import complex_mode
 import firedrake
 
 backend = "Firedrake"
@@ -77,6 +78,7 @@ __all__ = \
         "TrialFunction",
         "UnitIntervalMesh",
         "adjoint",
+        "complex_mode",
         "homogenize",
         "info",
         "parameters"

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -20,8 +20,8 @@
 
 from .backend import FunctionSpace, Parameters, backend_Constant, \
     backend_DirichletBC, backend_Function, backend_LinearSolver, \
-    backend_Matrix, backend_assemble, backend_solve, extract_args, \
-    homogenize, parameters
+    backend_Matrix, backend_assemble, backend_solve, complex_mode, \
+    extract_args, homogenize, parameters
 from ..interface import InterfaceException, check_space_type, \
     check_space_types, function_axpy, function_copy, function_dtype, \
     function_space_type, space_new
@@ -41,6 +41,7 @@ __all__ = \
         "assemble_arguments",
         "assemble_linear_solver",
         "assemble_matrix",
+        "complex_mode",
         "copy_parameters_dict",
         "form_form_compiler_parameters",
         "function_vector",

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -25,7 +25,8 @@ from ..interface import check_space_type, function_assign, function_comm, \
     function_local_size, function_new, function_new_conjugate_dual, \
     function_scalar_value, function_set_values, function_space, is_function, \
     weakref_method
-from .backend_code_generator_interface import assemble, matrix_multiply
+from .backend_code_generator_interface import assemble, complex_mode, \
+    matrix_multiply
 
 from ..caches import Cache
 from ..equations import Equation, EquationException, NullSolver, \
@@ -82,6 +83,8 @@ class LocalSolverCache(Cache):
             form_compiler_parameters = {}
 
         form = eliminate_zeros(form, force_non_empty_form=True)
+        if not complex_mode:
+            form = ufl.algorithms.remove_complex_nodes.remove_complex_nodes(form)  # noqa: E501
         key = local_solver_key(form, form_compiler_parameters)
 
         def value():


### PR DESCRIPTION
Also:
- Remove complex nodes in caching when not in complex mode.
- Add `complex_mode` to backend_code_generator_interfaces module.