### PR TITLE
Two-level checkpointing

### DIFF
--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -110,8 +110,7 @@ and adjoint information using the approach described in [1, 2].
 
 ===============================================================================
 
-tlm_adjoint implements the binomial checkpointing strategy described in [3],
-choosing the maximum step size permitted when choosing the next snapshot block.
+tlm_adjoint implements the binomial checkpointing strategy described in [3].
 tlm_adjoint further implements multi-stage offline checkpointing, using a brute
 force approach to yield behaviour described in [4].
 

--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -129,11 +129,11 @@ implements the two-level mixed periodic/binomial checkpointing approach
 described in [5, 6].
 
 [5]  Gavin J. Pringle, Daniel C. Jones, Sudipta Goswami, Sri Hari Krishna
-     Narayanan, and Daniel Goldberg, Providing the ARCHER community with
+     Narayanan, and Daniel Goldberg, "Providing the ARCHER community with
      adjoint modelling tools for high-performance oceanographic and cryospheric
-     computation, version 1.1, EPCC, 2016
+     computation", version 1.1, EPCC, 2016
 [6]  D. N. Goldberg, T. A. Smith, S. H. K. Narayanan, P. Heimbach, and
-     M. Morlighem, Bathymetric influences on Antarctic ice-shelf melt rates,
+     M. Morlighem, "Bathymetric influences on Antarctic ice-shelf melt rates",
      Journal of Geophysical Research: Oceans, 125(11), e2020JC016370, 2020
 
 ===============================================================================

--- a/ACKNOWLEDGEMENTS
+++ b/ACKNOWLEDGEMENTS
@@ -124,10 +124,24 @@ force approach to yield behaviour described in [4].
 
 ===============================================================================
 
+The TwoLevelCheckpointingManager class in tlm_adjoint/binomial_checkpointing.py
+implements the two-level mixed periodic/binomial checkpointing approach
+described in [5, 6].
+
+[5]  Gavin J. Pringle, Daniel C. Jones, Sudipta Goswami, Sri Hari Krishna
+     Narayanan, and Daniel Goldberg, Providing the ARCHER community with
+     adjoint modelling tools for high-performance oceanographic and cryospheric
+     computation, version 1.1, EPCC, 2016
+[6]  D. N. Goldberg, T. A. Smith, S. H. K. Narayanan, P. Heimbach, and
+     M. Morlighem, Bathymetric influences on Antarctic ice-shelf melt rates,
+     Journal of Geophysical Research: Oceans, 125(11), e2020JC016370, 2020
+
+===============================================================================
+
 The interface provided in tlm_adjoint/timestepping.py aims for a degree of
 consistency with the API of the 'timestepping' library, as in dolfin-adjoint
-timestepping_2017.1.0 branch, and as described in [5].
-[5]  J. R. Maddison and P. E. Farrell, "Rapid development and adjoining of
+timestepping_2017.1.0 branch, and as described in [7].
+[7]  J. R. Maddison and P. E. Farrell, "Rapid development and adjoining of
      transient finite element models", Computer Methods in Applied Mechanics
      and Engineering, 276, pp. 95--121, 2014
 

--- a/tlm_adjoint/binomial_checkpointing.py
+++ b/tlm_adjoint/binomial_checkpointing.py
@@ -271,20 +271,6 @@ class MultistageCheckpointingManager(CheckpointingManager):
     def uses_disk_storage(self):
         return self._snapshots_on_disk > 0
 
-    def used_snapshots_in_ram(self):
-        snapshots = 0
-        for i in range(len(self._snapshots)):
-            if self._storage[i] == "RAM":
-                snapshots += 1
-        return snapshots
-
-    def used_snapshots_on_disk(self):
-        snapshots = 0
-        for i in range(len(self._snapshots)):
-            if self._storage[i] == "disk":
-                snapshots += 1
-        return snapshots
-
     def _snapshot(self, n):
         assert n >= 0 and n < self._max_n
         if len(self._snapshots) >= \

--- a/tlm_adjoint/binomial_checkpointing.py
+++ b/tlm_adjoint/binomial_checkpointing.py
@@ -405,7 +405,7 @@ class TwoLevelCheckpointingManager(CheckpointingManager):
 
                         yield "configure", (False, False)
 
-                        n_snapshots = (self._binomial_snapshots
+                        n_snapshots = (self._binomial_snapshots + 1
                                        - len(snapshots) + 1)
                         n0 = self._n
                         n1 = n0 + n_advance(self._max_n - self._r - n0,
@@ -418,7 +418,7 @@ class TwoLevelCheckpointingManager(CheckpointingManager):
                         while self._n < self._max_n - self._r - 1:
                             yield "configure", (True, False)
 
-                            n_snapshots = (self._binomial_snapshots
+                            n_snapshots = (self._binomial_snapshots + 1
                                            - len(snapshots))
                             n0 = self._n
                             n1 = n0 + n_advance(self._max_n - self._r - n0,
@@ -428,7 +428,7 @@ class TwoLevelCheckpointingManager(CheckpointingManager):
                             self._n = n1
                             yield "forward", (n0, n1)
 
-                            if len(snapshots) >= self._binomial_snapshots:
+                            if len(snapshots) >= self._binomial_snapshots + 1:
                                 raise RuntimeError("Invalid checkpointing "
                                                    "state")
                             snapshots.append(n0)

--- a/tlm_adjoint/binomial_checkpointing.py
+++ b/tlm_adjoint/binomial_checkpointing.py
@@ -33,12 +33,12 @@
 # This file further implements the two-level mixed periodic/binomial
 # checkpointing approach described in
 #   Gavin J. Pringle, Daniel C. Jones, Sudipta Goswami, Sri Hari Krishna
-#   Narayanan, and Daniel Goldberg, Providing the ARCHER community with adjoint
-#   modelling tools for high-performance oceanographic and cryospheric
-#   computation, version 1.1, EPCC, 2016
+#   Narayanan, and Daniel Goldberg, "Providing the ARCHER community with
+#   adjoint modelling tools for high-performance oceanographic and cryospheric
+#   computation", version 1.1, EPCC, 2016
 # and
 #   D. N. Goldberg, T. A. Smith, S. H. K. Narayanan, P. Heimbach, and
-#   M. Morlighem, Bathymetric influences on Antarctic ice-shelf melt rates,
+#   M. Morlighem, "Bathymetric influences on Antarctic ice-shelf melt rates",
 #   Journal of Geophysical Research: Oceans, 125(11), e2020JC016370, 2020
 
 from .checkpointing import CheckpointingManager
@@ -324,13 +324,13 @@ class TwoLevelCheckpointingManager(CheckpointingManager):
         """
         The two-level mixed periodic/binomial checkpointing approach of
           Gavin J. Pringle, Daniel C. Jones, Sudipta Goswami, Sri Hari Krishna
-          Narayanan, and Daniel Goldberg, Providing the ARCHER community with
+          Narayanan, and Daniel Goldberg, "Providing the ARCHER community with
           adjoint modelling tools for high-performance oceanographic and
-          cryospheric computation, version 1.1, EPCC, 2016
+          cryospheric computation", version 1.1, EPCC, 2016
         and
           D. N. Goldberg, T. A. Smith, S. H. K. Narayanan, P. Heimbach, and
-          M. Morlighem, Bathymetric influences on Antarctic ice-shelf melt
-          rates, Journal of Geophysical Research: Oceans, 125(11),
+          M. Morlighem, "Bathymetric influences on Antarctic ice-shelf melt
+          rates", Journal of Geophysical Research: Oceans, 125(11),
           e2020JC016370, 2020
         """
 

--- a/tlm_adjoint/binomial_checkpointing.py
+++ b/tlm_adjoint/binomial_checkpointing.py
@@ -428,6 +428,9 @@ class TwoLevelCheckpointingManager(CheckpointingManager):
                             self._n = n1
                             yield "forward", (n0, n1)
 
+                            if len(snapshots) >= self._binomial_snapshots:
+                                raise RuntimeError("Invalid checkpointing "
+                                                   "state")
                             snapshots.append(n0)
                             yield "write", (n0, self._binomial_storage)
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -628,7 +628,8 @@ class EquationManager:
                 cp_parameters["blocks"],
                 cp_parameters.get("snaps_in_ram", 0),
                 cp_parameters.get("snaps_on_disk", 0),
-                keep_block_0_ics=True)
+                keep_block_0_ics=True,
+                trajectory="maximum")
         else:
             raise ValueError(f"Unrecognized checkpointing method: "
                              f"{cp_method:s}")

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -621,12 +621,14 @@ class EquationManager:
             cp_manager = MemoryCheckpointingManager()
         elif cp_method == "periodic_disk":
             cp_manager = PeriodicDiskCheckpointingManager(
-                cp_parameters["period"])
+                cp_parameters["period"],
+                keep_block_0_ics=True)
         elif cp_method == "multistage":
             cp_manager = MultistageCheckpointingManager(
                 cp_parameters["blocks"],
                 cp_parameters.get("snaps_in_ram", 0),
-                cp_parameters.get("snaps_on_disk", 0))
+                cp_parameters.get("snaps_on_disk", 0),
+                keep_block_0_ics=True)
         else:
             raise ValueError(f"Unrecognized checkpointing method: "
                              f"{cp_method:s}")

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -529,15 +529,10 @@ class EquationManager:
         info(f"  Initial conditions stored: {len(self._cp._cp):d}")
         info(f"  Initial conditions referenced: {len(self._cp._refs):d}")
         info("Checkpointing:")
-        info(f"  Method: {self._cp_method:s}")
-        if self._cp_method in ["none", "memory", "periodic_disk"]:
-            pass
-        elif self._cp_method == "multistage":
-            info(f"  Snapshots in RAM: {self._cp_manager.used_snapshots_in_ram():d}")  # noqa: E501
-            info(f"  Snapshots on disk: {self._cp_manager.used_snapshots_on_disk():d}")  # noqa: E501
+        if callable(self._cp_method):
+            info("  Method: custom")
         else:
-            raise ValueError(f"Unrecognized checkpointing method: "
-                             f"{self._cp_method:s}")
+            info(f"  Method: {self._cp_method:s}")
 
     def new(self, cp_method=None, cp_parameters=None):
         """
@@ -598,9 +593,9 @@ class EquationManager:
             raise RuntimeError("Cannot configure checkpointing after "
                                "annotation has started, or after finalization")
 
-        cp_parameters = copy.deepcopy(cp_parameters)
+        cp_parameters = copy.copy(cp_parameters)
 
-        if cp_method in ["none", "memory"]:
+        if not callable(cp_method) and cp_method in ["none", "memory"]:
             if "replace" in cp_parameters:
                 warnings.warn("'replace' cp_parameters key is deprecated",
                               DeprecationWarning, stacklevel=2)
@@ -613,7 +608,14 @@ class EquationManager:
         else:
             alias_eqs = True
 
-        if cp_method == "none":
+        if callable(cp_method):
+            cp_manager_kwargs = copy.copy(cp_parameters)
+            if "path" in cp_manager_kwargs:
+                del cp_manager_kwargs["path"]
+            if "format" in cp_manager_kwargs:
+                del cp_manager_kwargs["format"]
+            cp_manager = cp_method(**cp_manager_kwargs)
+        elif cp_method == "none":
             cp_manager = NoneCheckpointingManager()
         elif cp_method == "memory":
             cp_manager = MemoryCheckpointingManager()


### PR DESCRIPTION
Implement the two-level checkpointing approach described in Pringle et al 2016 and Goldberg et al 2020 (references [5, 6] in ACKNOWLEDGEMENTS).

Also
- Allow an `EquationManager` to be supplied with a custom `CheckpointingManager`.
- `EquationManager.compute_gradient` retains forward data associated with the first block at the end of an adjoint calculation. Make this optional (default disabled) in the `PeriodicDiskCheckpointingManager` and `MultistageCheckpointingManager` classes, and the new `TwoLevelCheckpointingManager` class.
- Allow the original Griewank and Walther 2000 (reference [3] in ACKNOWLEDGEMENTS) schedule to be used with the `MultistageCheckpointingManager` class.