### PR TITLE
Adjoint caching

### DIFF
--- a/README
+++ b/README
@@ -50,5 +50,6 @@ tlm_adjoint optionally uses
     SciPy, for gradient-based optimization and interpolation equations
     h5py, with the 'mpio' driver for parallel calculations, for HDF5 storage
     petsc4py and slepc4py, for eigendecomposition functionality
+    more-itertools
 
 License: GNU LGPL version 3

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -2373,8 +2373,8 @@ def tlm(M, dM, x, max_depth=1, manager=None):
 Calls \texttt{EquationManager.tlm}. Accesses a tangent-linear variable.
 \begin{lstlisting}
 def compute_gradient(Js, M, callback=None, prune_forward=True,
-                     prune_adjoint=True, prune_replay=True, cache_adjoint=True,
-                     adj_ics=None, manager=None):
+                     prune_adjoint=True, prune_replay=True,
+                     cache_adjoint_degree=None, adj_ics=None, manager=None):
 \end{lstlisting}
 Calls \texttt{EquationManager.compute\_gradient}. Computes a forward model
 constrained derivative (see sections \ref{sect:first_order_adjoint} and
@@ -2382,10 +2382,12 @@ constrained derivative (see sections \ref{sect:first_order_adjoint} and
 \texttt{prune\_adjoint} control pruning of the transpose dependency graph via
 forward and reverse traversal respectively. \texttt{prune\_replay} controls
 pruning of the dependency graph during rerunning of the forward.
-\texttt{cache\_adjoint} controls the caching and reuse of first order adjoint
-solutions between different adjoint models. The optional \texttt{adj\_ics} is a
-map, or a sequence of maps, from forward functions or function IDs to adjoint
-initial conditions. The optional \texttt{callback} argument takes the form
+\texttt{cache\_adjoint\_degree} controls the caching and reuse of adjoint
+solutions between different adjoint models, with caching applied for adjoint
+models of the given degree and lower. By default caching is applied for all
+degrees. The optional \texttt{adj\_ics} is a map, or a sequence of maps, from
+forward functions or function IDs to adjoint initial conditions. The optional
+\texttt{callback} argument takes the form
 \begin{lstlisting}
 def callback(J_i, n, i, eq, adj_X)
 \end{lstlisting}

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -2373,18 +2373,19 @@ def tlm(M, dM, x, max_depth=1, manager=None):
 Calls \texttt{EquationManager.tlm}. Accesses a tangent-linear variable.
 \begin{lstlisting}
 def compute_gradient(Js, M, callback=None, prune_forward=True,
-                     prune_adjoint=True, prune_replay=True, adj_ics=None,
-                     manager=None):
+                     prune_adjoint=True, prune_replay=True, cache_adjoint=True,
+                     adj_ics=None, manager=None):
 \end{lstlisting}
 Calls \texttt{EquationManager.compute\_gradient}. Computes a forward model
 constrained derivative (see sections \ref{sect:first_order_adjoint} and
 \ref{sect:higher_order_adjoint}). \texttt{prune\_forward} and
 \texttt{prune\_adjoint} control pruning of the transpose dependency graph via
 forward and reverse traversal respectively. \texttt{prune\_replay} controls
-pruning of the dependency graph during rerunning of the forward. The optional
-\texttt{adj\_ics} is a map, or a sequence of maps, from forward functions or
-function IDs to adjoint initial conditions. The optional \texttt{callback}
-argument takes the form
+pruning of the dependency graph during rerunning of the forward.
+\texttt{cache\_adjoint} controls the caching and reuse of first order adjoint
+solutions between different adjoint models. The optional \texttt{adj\_ics} is a
+map, or a sequence of maps, from forward functions or function IDs to adjoint
+initial conditions. The optional \texttt{callback} argument takes the form
 \begin{lstlisting}
 def callback(J_i, n, i, eq, adj_X)
 \end{lstlisting}

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -33,6 +33,7 @@ import inspect
 import logging
 import mpi4py.MPI as MPI
 import numpy as np
+from operator import itemgetter
 import os
 import pytest
 import runpy
@@ -94,7 +95,7 @@ def seed_test(fn):
         h = hashlib.sha256()
         h.update(fn.__name__.encode("utf-8"))
         h.update(str(args).encode("utf-8"))
-        h.update(str(sorted(h_kwargs.items(), key=lambda e: e[0])).encode("utf-8"))  # noqa: E501
+        h.update(str(sorted(h_kwargs.items(), key=itemgetter(0))).encode("utf-8"))  # noqa: E501
         seed = int(h.hexdigest(), 16) + MPI.COMM_WORLD.rank
         seed %= 2 ** 32
         np.random.seed(seed)

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -195,6 +195,7 @@ def test_leaks():
     manager._cp.clear(clear_refs=True)
     manager._cp_memory.clear()
     manager._tlm.clear()
+    manager._adj_cache.clear()
 
     gc.collect()
 

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -878,11 +878,14 @@ def test_adjoint_caching(setup_test, test_leaks):
 
     adj_cache = manager()._adj_cache
     assert tuple(adj_cache._keys.keys()) == ((3, 0, 25), (3, 0, 9),
+                                             (1, 0, 4), (3, 0, 4),
                                              (2, 0, 2), (3, 0, 2))
     # First order
     assert tuple(adj_cache._keys[(3, 0, 25)]) == ((2, 0, 24), (1, 0, 23), (0, 0, 22))  # noqa: E501
     assert tuple(adj_cache._keys[(3, 0, 9)]) == ((2, 0, 8), (1, 0, 7), (0, 0, 6))  # noqa: E501
     # Second order
+    assert tuple(adj_cache._keys[(1, 0, 4)]) == ((0, 0, 3),)
+    assert tuple(adj_cache._keys[(3, 0, 4)]) == ((2, 0, 3),)
     assert tuple(adj_cache._keys[(2, 0, 2)]) == ((0, 0, 1),)
     assert tuple(adj_cache._keys[(3, 0, 2)]) == ((1, 0, 1),)
 

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -34,6 +34,7 @@ import inspect
 import logging
 import mpi4py.MPI as MPI
 import numpy as np
+from operator import itemgetter
 import os
 import pytest
 import runpy
@@ -101,7 +102,7 @@ def seed_test(fn):
         h = hashlib.sha256()
         h.update(fn.__name__.encode("utf-8"))
         h.update(str(args).encode("utf-8"))
-        h.update(str(sorted(h_kwargs.items(), key=lambda e: e[0])).encode("utf-8"))  # noqa: E501
+        h.update(str(sorted(h_kwargs.items(), key=itemgetter(0))).encode("utf-8"))  # noqa: E501
         seed = int(h.hexdigest(), 16) + MPI.COMM_WORLD.rank
         seed %= 2 ** 32
         np.random.seed(seed)

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -190,6 +190,7 @@ def test_leaks():
     manager._cp.clear(clear_refs=True)
     manager._cp_memory.clear()
     manager._tlm.clear()
+    manager._adj_cache.clear()
 
     gc.collect()
 

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -881,11 +881,14 @@ def test_adjoint_caching(setup_test, test_leaks):
 
     adj_cache = manager()._adj_cache
     assert tuple(adj_cache._keys.keys()) == ((3, 0, 25), (3, 0, 9),
+                                             (1, 0, 4), (3, 0, 4),
                                              (2, 0, 2), (3, 0, 2))
     # First order
     assert tuple(adj_cache._keys[(3, 0, 25)]) == ((2, 0, 24), (1, 0, 23), (0, 0, 22))  # noqa: E501
     assert tuple(adj_cache._keys[(3, 0, 9)]) == ((2, 0, 8), (1, 0, 7), (0, 0, 6))  # noqa: E501
     # Second order
+    assert tuple(adj_cache._keys[(1, 0, 4)]) == ((0, 0, 3),)
+    assert tuple(adj_cache._keys[(3, 0, 4)]) == ((2, 0, 3),)
     assert tuple(adj_cache._keys[(2, 0, 2)]) == ((0, 0, 1),)
     assert tuple(adj_cache._keys[(3, 0, 2)]) == ((1, 0, 1),)
 

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -652,7 +652,7 @@ def test_TangentLinearMap_finalizes(setup_test, test_leaks,
 
 @pytest.mark.firedrake
 @seed_test
-def test_first_order_adjoint_caching(setup_test, test_leaks):
+def test_adjoint_caching(setup_test, test_leaks):
     mesh = UnitSquareMesh(10, 10)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -701,7 +701,7 @@ def test_first_order_adjoint_caching(setup_test, test_leaks):
     K_val = K.value()
     dJ_0, dK_0 = compute_gradient(
         [J, K], m,
-        cache_adjoint=False)
+        cache_adjoint_degree=0)
 
     min_order = taylor_test(forward_J, m, J_val=J_val, dJ=dJ_0, dM=dm_0)
     assert min_order >= 2.00
@@ -738,10 +738,11 @@ def test_first_order_adjoint_caching(setup_test, test_leaks):
 
     dJ_1, ddJ_1, dK_1 = manager().compute_gradient(
         [J, J.tlm(m, dm_0), K], m,
-        cache_adjoint=True)
+        cache_adjoint_degree=1)
 
     adj_cache = manager()._adj_cache
-    assert tuple(adj_cache._keys.keys()) == ((2, 0, 4), (1, 0, 3), (1, 0, 1), (2, 0, 0))  # noqa: E501
+    assert tuple(adj_cache._keys.keys()) == ((2, 0, 4), (1, 0, 3),
+                                             (1, 0, 1), (2, 0, 0))
     assert tuple(adj_cache._keys[(2, 0, 4)]) == ()
     assert tuple(adj_cache._keys[(1, 0, 3)]) == ((0, 0, 2),)
     assert tuple(adj_cache._keys[(1, 0, 1)]) == ((0, 0, 0),)
@@ -770,14 +771,15 @@ def test_first_order_adjoint_caching(setup_test, test_leaks):
 
     dddJ_2 = compute_gradient(
         J.tlm(m, dm_0).tlm(m, dm_1), m,
-        cache_adjoint=False)
+        cache_adjoint_degree=0)
 
     ddJ_2a, ddJ_2b, dddJ_2b, dJ_2, dK_2 = manager().compute_gradient(
         [J.tlm(m, dm_0), J.tlm(m, dm_1), J.tlm(m, dm_0).tlm(m, dm_1), J, K], m,
-        cache_adjoint=True)
+        cache_adjoint_degree=1)
 
     adj_cache = manager()._adj_cache
-    assert tuple(adj_cache._keys.keys()) == ((4, 0, 8), (2, 0, 7), (2, 0, 3), (4, 0, 0))  # noqa: E501
+    assert tuple(adj_cache._keys.keys()) == ((4, 0, 8), (2, 0, 7),
+                                             (2, 0, 3), (4, 0, 0))
     assert tuple(adj_cache._keys[(4, 0, 8)]) == ()
     assert tuple(adj_cache._keys[(2, 0, 7)]) == ((1, 0, 6), (0, 0, 5), (3, 0, 4))  # noqa: E501
     assert tuple(adj_cache._keys[(2, 0, 3)]) == ((1, 0, 2), (0, 0, 1), (3, 0, 0))  # noqa: E501
@@ -813,10 +815,11 @@ def test_first_order_adjoint_caching(setup_test, test_leaks):
 
     ddJ_3, dddJ_3, dJ_3, dK_3 = manager().compute_gradient(
         [J.tlm(m, dm_0), J.tlm(m, dm_0, max_depth=2), J, K], m,
-        cache_adjoint=True)
+        cache_adjoint_degree=1)
 
     adj_cache = manager()._adj_cache
-    assert tuple(adj_cache._keys.keys()) == ((3, 0, 6), (1, 0, 5), (1, 0, 2), (3, 0, 0))  # noqa: E501
+    assert tuple(adj_cache._keys.keys()) == ((3, 0, 6), (1, 0, 5),
+                                             (1, 0, 2), (3, 0, 0))
     assert tuple(adj_cache._keys[(3, 0, 6)]) == ()
     assert tuple(adj_cache._keys[(1, 0, 5)]) == ((0, 0, 4), (2, 0, 3))
     assert tuple(adj_cache._keys[(1, 0, 2)]) == ((0, 0, 1), (2, 0, 0))
@@ -837,3 +840,67 @@ def test_first_order_adjoint_caching(setup_test, test_leaks):
     dddJ_error = function_copy(dddJ_2)
     function_axpy(dddJ_error, -1.0, dddJ_3)
     assert function_linf_norm(dddJ_error) < 1.0e-18
+
+    reset_manager()
+    stop_manager()
+
+    dm_0 = Function(space, name="dm_0")
+    interpolate_expression(dm_0, sin(pi * X[0]) * sin(pi * X[1]))
+    dm_1 = Function(space, name="dm_1")
+    interpolate_expression(dm_1, sin(2.0 * pi * X[0]) * sin(pi * X[1]))
+    dm_2 = Function(space, name="dm_2")
+    interpolate_expression(dm_2, sin(3.0 * pi * X[0]) * sin(pi * X[1]))
+    dm_3 = Function(space, name="dm_3")
+    interpolate_expression(dm_3, sin(4.0 * pi * X[0]) * sin(pi * X[1]))
+
+    add_tlm(m, dm_0)
+    add_tlm(m, dm_1)
+    add_tlm(m, dm_2)
+    add_tlm(m, dm_3)
+    start_manager()
+    J, K = forward(m)
+    stop_manager()
+
+    dddJ_02_0 = compute_gradient(
+        J.tlm(m, dm_0).tlm(m, dm_2), m,
+        cache_adjoint_degree=0)
+    dddJ_03_0 = compute_gradient(
+        J.tlm(m, dm_0).tlm(m, dm_3), m,
+        cache_adjoint_degree=0)
+    dddJ_12_0 = compute_gradient(
+        J.tlm(m, dm_1).tlm(m, dm_2), m,
+        cache_adjoint_degree=0)
+    dddJ_13_0 = compute_gradient(
+        J.tlm(m, dm_1).tlm(m, dm_3), m,
+        cache_adjoint_degree=0)
+
+    dddJ_02_1, dddJ_03_1, dddJ_12_1, dddJ_13_1 = compute_gradient(
+        [J.tlm(m, dm_0).tlm(m, dm_2), J.tlm(m, dm_0).tlm(m, dm_3),
+         J.tlm(m, dm_1).tlm(m, dm_2), J.tlm(m, dm_1).tlm(m, dm_3)], m,
+        cache_adjoint_degree=2)
+
+    adj_cache = manager()._adj_cache
+    assert tuple(adj_cache._keys.keys()) == ((3, 0, 25), (3, 0, 9),
+                                             (2, 0, 2), (3, 0, 2))
+    # First order
+    assert tuple(adj_cache._keys[(3, 0, 25)]) == ((2, 0, 24), (1, 0, 23), (0, 0, 22))  # noqa: E501
+    assert tuple(adj_cache._keys[(3, 0, 9)]) == ((2, 0, 8), (1, 0, 7), (0, 0, 6))  # noqa: E501
+    # Second order
+    assert tuple(adj_cache._keys[(2, 0, 2)]) == ((0, 0, 1),)
+    assert tuple(adj_cache._keys[(3, 0, 2)]) == ((1, 0, 1),)
+
+    dddJ_error = function_copy(dddJ_02_0)
+    function_axpy(dddJ_error, -1.0, dddJ_02_1)
+    assert function_linf_norm(dddJ_error) == 0.0
+
+    dddJ_error = function_copy(dddJ_03_0)
+    function_axpy(dddJ_error, -1.0, dddJ_03_1)
+    assert function_linf_norm(dddJ_error) == 0.0
+
+    dddJ_error = function_copy(dddJ_12_0)
+    function_axpy(dddJ_error, -1.0, dddJ_12_1)
+    assert function_linf_norm(dddJ_error) == 0.0
+
+    dddJ_error = function_copy(dddJ_13_0)
+    function_axpy(dddJ_error, -1.0, dddJ_13_1)
+    assert function_linf_norm(dddJ_error) == 0.0

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -648,3 +648,192 @@ def test_TangentLinearMap_finalizes(setup_test, test_leaks,
     x = Constant(0.0, name="x")
     DotProductSolver(m, m, x).solve()
     stop_manager()
+
+
+@pytest.mark.firedrake
+@seed_test
+def test_first_order_adjoint_caching(setup_test, test_leaks):
+    mesh = UnitSquareMesh(10, 10)
+    X = SpatialCoordinate(mesh)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    test, trial = TestFunction(space), TrialFunction(space)
+
+    def forward(m):
+        u = Function(space, name="u")
+
+        solve(inner(grad(trial), grad(test)) * dx
+              == inner(m * cos(Constant(0.0) * m), test) * dx,
+              u, DirichletBC(space, 0.0, "on_boundary"),
+              solver_parameters=ls_parameters_cg)
+
+        J = Functional(name="J")
+        v = Constant(1.0, name="v")
+        J.assign((dot(u + v, u + v) ** 3) * dx)
+
+        K = Functional(name="K")
+        K.assign((dot(u + v, u + v) ** 4) * dx)
+
+        return J, K
+
+    m = Function(space, name="m")
+    interpolate_expression(m, sin(pi * X[0]) * sin(2.0 * pi * X[1]))
+
+    dm_0 = Function(space, name="dm_0")
+    if issubclass(function_dtype(dm_0), (complex, np.complexfloating)):
+        dm_0.assign(Constant(1.0 + 1.0j))
+    else:
+        dm_0.assign(Constant(1.0))
+    dm_1 = function_copy(dm_0, name="dm_1")
+
+    start_manager()
+    J, K = forward(m)
+    stop_manager()
+
+    def forward_J(m):
+        J, K = forward(m)
+        return J
+
+    def forward_K(m):
+        J, K = forward(m)
+        return K
+
+    J_val = J.value()
+    K_val = K.value()
+    dJ_0, dK_0 = compute_gradient(
+        [J, K], m,
+        cache_adjoint=False)
+
+    min_order = taylor_test(forward_J, m, J_val=J_val, dJ=dJ_0, dM=dm_0)
+    assert min_order >= 2.00
+
+    min_order = taylor_test(forward_K, m, J_val=K_val, dJ=dK_0, dM=dm_0)
+    assert min_order >= 2.00
+
+    ddJ = Hessian(forward_J)
+    J_val_0b, dJ_0b, ddJ_0 = ddJ.action(m, dm_0)
+    assert abs(J_val - J_val_0b) == 0.0
+    assert abs(dJ_0b - function_inner(dm_0, dJ_0)) < 1.0e-15
+
+    min_order = taylor_test(forward_J, m, J_val=J_val, ddJ=ddJ, dM=dm_0)
+    assert min_order > 2.99
+
+    for order in range(1, 4):
+        min_order = taylor_test_tlm(
+            forward_J, m, tlm_order=order,
+            dMs=tuple(dm_0 for i in range(order)))
+        assert min_order > 2.00
+
+        min_order = taylor_test_tlm_adjoint(
+            forward_J, m, adjoint_order=order,
+            dMs=tuple(dm_0 for i in range(order)))
+        assert min_order > 2.00
+
+    reset_manager()
+    stop_manager()
+
+    add_tlm(m, dm_0)
+    start_manager()
+    J, K = forward(m)
+    stop_manager()
+
+    dJ_1, ddJ_1, dK_1 = manager().compute_gradient(
+        [J, J.tlm(m, dm_0), K], m,
+        cache_adjoint=True)
+
+    adj_cache = manager()._adj_cache
+    assert tuple(adj_cache._keys.keys()) == ((2, 0, 4), (1, 0, 3), (1, 0, 1), (2, 0, 0))  # noqa: E501
+    assert tuple(adj_cache._keys[(2, 0, 4)]) == ()
+    assert tuple(adj_cache._keys[(1, 0, 3)]) == ((0, 0, 2),)
+    assert tuple(adj_cache._keys[(1, 0, 1)]) == ((0, 0, 0),)
+    assert tuple(adj_cache._keys[(2, 0, 0)]) == ()
+
+    dJ_error = function_copy(dJ_0)
+    function_axpy(dJ_error, -1.0, dJ_1)
+    assert function_linf_norm(dJ_error) == 0.0
+
+    dK_error = function_copy(dK_0)
+    function_axpy(dK_error, -1.0, dK_1)
+    assert function_linf_norm(dK_error) == 0.0
+
+    ddJ_error = function_copy(ddJ_0)
+    function_axpy(ddJ_error, -1.0, ddJ_1)
+    assert function_linf_norm(ddJ_error) == 0.0
+
+    reset_manager()
+    stop_manager()
+
+    add_tlm(m, dm_0)
+    add_tlm(m, dm_1)
+    start_manager()
+    J, K = forward(m)
+    stop_manager()
+
+    dddJ_2 = compute_gradient(
+        J.tlm(m, dm_0).tlm(m, dm_1), m,
+        cache_adjoint=False)
+
+    ddJ_2a, ddJ_2b, dddJ_2b, dJ_2, dK_2 = manager().compute_gradient(
+        [J.tlm(m, dm_0), J.tlm(m, dm_1), J.tlm(m, dm_0).tlm(m, dm_1), J, K], m,
+        cache_adjoint=True)
+
+    adj_cache = manager()._adj_cache
+    assert tuple(adj_cache._keys.keys()) == ((4, 0, 8), (2, 0, 7), (2, 0, 3), (4, 0, 0))  # noqa: E501
+    assert tuple(adj_cache._keys[(4, 0, 8)]) == ()
+    assert tuple(adj_cache._keys[(2, 0, 7)]) == ((1, 0, 6), (0, 0, 5), (3, 0, 4))  # noqa: E501
+    assert tuple(adj_cache._keys[(2, 0, 3)]) == ((1, 0, 2), (0, 0, 1), (3, 0, 0))  # noqa: E501
+    assert tuple(adj_cache._keys[(4, 0, 0)]) == ()
+
+    dJ_error = function_copy(dJ_0)
+    function_axpy(dJ_error, -1.0, dJ_2)
+    assert function_linf_norm(dJ_error) == 0.0
+
+    dK_error = function_copy(dK_0)
+    function_axpy(dK_error, -1.0, dK_2)
+    assert function_linf_norm(dK_error) == 0.0
+
+    ddJ_error = function_copy(ddJ_0)
+    function_axpy(ddJ_error, -1.0, ddJ_2a)
+    assert function_linf_norm(ddJ_error) == 0.0
+
+    ddJ_error = function_copy(ddJ_0)
+    function_axpy(ddJ_error, -1.0, ddJ_2b)
+    assert function_linf_norm(ddJ_error) == 0.0
+
+    dddJ_error = function_copy(dddJ_2)
+    function_axpy(dddJ_error, -1.0, dddJ_2b)
+    assert function_linf_norm(dddJ_error) == 0.0
+
+    reset_manager()
+    stop_manager()
+
+    add_tlm(m, dm_0, max_depth=2)
+    start_manager()
+    J, K = forward(m)
+    stop_manager()
+
+    ddJ_3, dddJ_3, dJ_3, dK_3 = manager().compute_gradient(
+        [J.tlm(m, dm_0), J.tlm(m, dm_0, max_depth=2), J, K], m,
+        cache_adjoint=True)
+
+    adj_cache = manager()._adj_cache
+    assert tuple(adj_cache._keys.keys()) == ((3, 0, 6), (1, 0, 5), (1, 0, 2), (3, 0, 0))  # noqa: E501
+    assert tuple(adj_cache._keys[(3, 0, 6)]) == ()
+    assert tuple(adj_cache._keys[(1, 0, 5)]) == ((0, 0, 4), (2, 0, 3))
+    assert tuple(adj_cache._keys[(1, 0, 2)]) == ((0, 0, 1), (2, 0, 0))
+    assert tuple(adj_cache._keys[(3, 0, 0)]) == ()
+
+    dJ_error = function_copy(dJ_0)
+    function_axpy(dJ_error, -1.0, dJ_3)
+    assert function_linf_norm(dJ_error) == 0.0
+
+    dK_error = function_copy(dK_0)
+    function_axpy(dK_error, -1.0, dK_3)
+    assert function_linf_norm(dK_error) == 0.0
+
+    ddJ_error = function_copy(ddJ_0)
+    function_axpy(ddJ_error, -1.0, ddJ_3)
+    assert function_linf_norm(ddJ_error) == 0.0
+
+    dddJ_error = function_copy(dddJ_2)
+    function_axpy(dddJ_error, -1.0, dddJ_3)
+    assert function_linf_norm(dddJ_error) < 1.0e-18

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -133,6 +133,7 @@ def test_leaks():
     manager._cp.clear(clear_refs=True)
     manager._cp_memory.clear()
     manager._tlm.clear()
+    manager._adj_cache.clear()
 
     gc.collect()
 

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -28,6 +28,7 @@ import hashlib
 import inspect
 import logging
 import numpy as np
+from operator import itemgetter
 import os
 import pytest
 import runpy
@@ -73,7 +74,7 @@ def seed_test(fn):
         h = hashlib.sha256()
         h.update(fn.__name__.encode("utf-8"))
         h.update(str(args).encode("utf-8"))
-        h.update(str(sorted(h_kwargs.items(), key=lambda e: e[0])).encode("utf-8"))  # noqa: E501
+        h.update(str(sorted(h_kwargs.items(), key=itemgetter(0))).encode("utf-8"))  # noqa: E501
         seed = int(h.hexdigest(), 16)
         seed %= 2 ** 32
         np.random.seed(seed)

--- a/tlm_adjoint/binomial_checkpointing.py
+++ b/tlm_adjoint/binomial_checkpointing.py
@@ -20,6 +20,8 @@
 
 from .checkpointing import CheckpointingManager
 
+from operator import itemgetter
+
 __all__ = \
     [
         "MultistageCheckpointingManager",
@@ -141,7 +143,7 @@ def allocate_snapshots(max_n, snapshots_in_ram, snapshots_on_disk, *,
     assert snapshot_i == -1
 
     allocation = ["disk" for i in range(snapshots)]
-    for i in [p[0] for p in sorted(enumerate(weights), key=lambda p: p[1],
+    for i in [p[0] for p in sorted(enumerate(weights), key=itemgetter(1),
                                    reverse=True)][:snapshots_in_ram]:
         allocation[i] = "RAM"
 

--- a/tlm_adjoint/caches.py
+++ b/tlm_adjoint/caches.py
@@ -154,7 +154,7 @@ class Cache:
 
         value = value()
         value_ref = CacheRef(value)
-        dep_ids = tuple(function_id(dep) for dep in deps)
+        dep_ids = tuple(map(function_id, deps))
 
         self._cache[key] = value_ref
 

--- a/tlm_adjoint/checkpointing.py
+++ b/tlm_adjoint/checkpointing.py
@@ -338,9 +338,9 @@ class ReplayStorage:
                     if active[n][i]:
                         # Forward equation is active, mark forward equations
                         # solving for dependencies as active
-                        X_ids = {function_id(x) for x in eq.X()}
-                        ic_ids = {function_id(dep)
-                                  for dep in eq.initial_condition_dependencies()}  # noqa: E501
+                        X_ids = set(map(function_id, eq.X()))
+                        ic_ids = set(map(function_id,
+                                         eq.initial_condition_dependencies()))
                         for dep in eq.dependencies():
                             dep_id = function_id(dep)
                             if dep_id in X_ids:

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -297,7 +297,8 @@ class Equation(Referrer):
 
         if is_function(X):
             X = (X,)
-        X_ids = {function_id(x) for x in X}
+        X_ids = set(map(function_id, X))
+        dep_ids = {function_id(dep): i for i, dep in enumerate(deps)}
         for x in X:
             if not is_function(x):
                 raise ValueError("Solution must be a function")
@@ -305,10 +306,9 @@ class Equation(Referrer):
                 raise ValueError("Solution must be checkpointed")
             if function_is_alias(x):
                 raise ValueError("Solution cannot be an alias")
-            if x not in deps:
+            if function_id(x) not in dep_ids:
                 raise ValueError("Solution must be a dependency")
 
-        dep_ids = {function_id(dep): i for i, dep in enumerate(deps)}
         if len(dep_ids) != len(deps):
             raise ValueError("Duplicate dependency")
         for dep in deps:
@@ -317,7 +317,7 @@ class Equation(Referrer):
 
         if nl_deps is None:
             nl_deps = tuple(deps)
-        nl_dep_ids = {function_id(dep) for dep in nl_deps}
+        nl_dep_ids = set(map(function_id, nl_deps))
         if len(nl_dep_ids) != len(nl_deps):
             raise ValueError("Duplicate non-linear dependency")
         for dep in nl_deps:
@@ -331,7 +331,7 @@ class Equation(Referrer):
         else:
             if ic is None:
                 ic = False
-        ic_dep_ids = {function_id(dep) for dep in ic_deps}
+        ic_dep_ids = set(map(function_id, ic_deps))
         if len(ic_dep_ids) != len(ic_deps):
             raise ValueError("Duplicate initial condition dependency")
         for dep in ic_deps:
@@ -348,7 +348,7 @@ class Equation(Referrer):
         else:
             if adj_ic is None:
                 adj_ic = False
-        adj_ic_dep_ids = {function_id(dep) for dep in adj_ic_deps}
+        adj_ic_dep_ids = set(map(function_id, adj_ic_deps))
         if len(adj_ic_dep_ids) != len(adj_ic_deps):
             raise ValueError("Duplicate adjoint initial condition dependency")
         for dep in adj_ic_deps:
@@ -1776,13 +1776,13 @@ class Matrix(Referrer):
 
 class RHS(Referrer):
     def __init__(self, deps, nl_deps=None):
-        dep_ids = {function_id(dep) for dep in deps}
+        dep_ids = set(map(function_id, deps))
         if len(dep_ids) != len(deps):
             raise ValueError("Duplicate dependency")
 
         if nl_deps is None:
             nl_deps = tuple(deps)
-        nl_dep_ids = {function_id(dep) for dep in nl_deps}
+        nl_dep_ids = set(map(function_id, nl_deps))
         if len(nl_dep_ids) != len(nl_deps):
             raise ValueError("Duplicate non-linear dependency")
         if len(dep_ids.intersection(nl_dep_ids)) != len(nl_deps):

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -38,6 +38,7 @@ import copy
 import inspect
 import logging
 import numpy as np
+from operator import itemgetter
 import warnings
 import weakref
 
@@ -247,7 +248,7 @@ class Referrer:
                         if child_id not in referrers and child_id not in remaining_referrers:  # noqa: E501
                             remaining_referrers[child_id] = child
         return tuple(e[1] for e in sorted(tuple(referrers.items()),
-                                          key=lambda e: e[0]))
+                                          key=itemgetter(0)))
 
     def _drop_references(self):
         if not self._references_dropped:

--- a/tlm_adjoint/hessian_optimization.py
+++ b/tlm_adjoint/hessian_optimization.py
@@ -24,7 +24,7 @@ from .caches import clear_caches
 from .functional import Functional
 from .hessian import GaussNewton, Hessian
 from .manager import manager as _manager
-from .tlm_adjoint import EquationManager, FirstOrderAdjointCache
+from .tlm_adjoint import AdjointCache, EquationManager
 
 from collections.abc import Sequence
 import warnings
@@ -69,7 +69,7 @@ class HessianOptimization:
         self._ics = ics
         self._nl_deps = nl_deps
         self._cache_adjoint = cache_adjoint
-        self._adj_cache = FirstOrderAdjointCache()
+        self._adj_cache = AdjointCache()
         if cache_adjoint:
             self._M_ids = None
 
@@ -197,8 +197,10 @@ class CachedHessian(Hessian, HessianOptimization):
         dJ = self._J.tlm(M, dM, manager=manager)
 
         J_val = self._J.value()
-        dJ = manager.compute_gradient(dJ, dM,
-                                      store_adjoint=self._cache_adjoint)
+        dJ = manager.compute_gradient(
+            dJ, dM,
+            cache_adjoint_degree={True: 1, False: 0}[self._cache_adjoint],
+            store_adjoint=self._cache_adjoint)
 
         return J_val, dJ
 
@@ -218,8 +220,10 @@ class CachedHessian(Hessian, HessianOptimization):
 
         J_val = self._J.value()
         dJ_val = dJ.value()
-        ddJ = manager.compute_gradient(dJ, M,
-                                       store_adjoint=self._cache_adjoint)
+        ddJ = manager.compute_gradient(
+            dJ, M,
+            cache_adjoint_degree={True: 1, False: 0}[self._cache_adjoint],
+            store_adjoint=self._cache_adjoint)
 
         return J_val, dJ_val, ddJ
 

--- a/tlm_adjoint/hessian_optimization.py
+++ b/tlm_adjoint/hessian_optimization.py
@@ -24,7 +24,7 @@ from .caches import clear_caches
 from .functional import Functional
 from .hessian import GaussNewton, Hessian
 from .manager import manager as _manager
-from .tlm_adjoint import AdjointCache, EquationManager
+from .tlm_adjoint import EquationManager, FirstOrderAdjointCache
 
 from collections.abc import Sequence
 import warnings
@@ -69,7 +69,7 @@ class HessianOptimization:
         self._ics = ics
         self._nl_deps = nl_deps
         self._cache_adjoint = cache_adjoint
-        self._adj_cache = None
+        self._adj_cache = FirstOrderAdjointCache()
         if cache_adjoint:
             self._M_ids = None
 
@@ -135,10 +135,6 @@ class HessianOptimization:
             len(manager._blocks), len(manager._block) - 1, tlm_eq,
             deps=tlm_deps)
 
-        if self._adj_cache is not None:
-            self._adj_cache.register(
-                0, len(manager._blocks), len(manager._block) - 1)
-
     def _setup_manager(self, M, dM, M0=None, *, solve_tlm=True):
         M = tuple(M)
         dM = tuple(dM)
@@ -146,14 +142,15 @@ class HessianOptimization:
 
         clear_caches(*dM)
 
-        if self._cache_adjoint:
-            M_ids = {function_id(m) for m in M}
-            if self._M_ids is None or self._M_ids != M_ids:
-                self._M_ids = M_ids
-                self._adj_cache = AdjointCache()
-
         manager = self._new_manager()
         manager.add_tlm(M, dM)
+
+        if self._cache_adjoint:
+            M_ids = set(map(function_id, M))
+            if self._M_ids is None or self._M_ids != M_ids:
+                self._M_ids = M_ids
+                self._adj_cache.clear()
+        manager._adj_cache = self._adj_cache
 
         for n, i, eq in self._add_forward_equations(manager):
             tlm_eq = self._tangent_linear(manager, eq, M, dM)
@@ -200,7 +197,8 @@ class CachedHessian(Hessian, HessianOptimization):
         dJ = self._J.tlm(M, dM, manager=manager)
 
         J_val = self._J.value()
-        dJ = manager.compute_gradient(dJ, dM, adj_cache=self._adj_cache)
+        dJ = manager.compute_gradient(dJ, dM,
+                                      store_adjoint=self._cache_adjoint)
 
         return J_val, dJ
 
@@ -220,7 +218,8 @@ class CachedHessian(Hessian, HessianOptimization):
 
         J_val = self._J.value()
         dJ_val = dJ.value()
-        ddJ = manager.compute_gradient(dJ, M, adj_cache=self._adj_cache)
+        ddJ = manager.compute_gradient(dJ, M,
+                                       store_adjoint=self._cache_adjoint)
 
         return J_val, dJ_val, ddJ
 

--- a/tlm_adjoint/hessian_optimization.py
+++ b/tlm_adjoint/hessian_optimization.py
@@ -199,7 +199,7 @@ class CachedHessian(Hessian, HessianOptimization):
         J_val = self._J.value()
         dJ = manager.compute_gradient(
             dJ, dM,
-            cache_adjoint_degree={True: 1, False: 0}[self._cache_adjoint],
+            cache_adjoint_degree=1 if self._cache_adjoint else 0,
             store_adjoint=self._cache_adjoint)
 
         return J_val, dJ
@@ -222,7 +222,7 @@ class CachedHessian(Hessian, HessianOptimization):
         dJ_val = dJ.value()
         ddJ = manager.compute_gradient(
             dJ, M,
-            cache_adjoint_degree={True: 1, False: 0}[self._cache_adjoint],
+            cache_adjoint_degree=1 if self._cache_adjoint else 0,
             store_adjoint=self._cache_adjoint)
 
         return J_val, dJ_val, ddJ

--- a/tlm_adjoint/manager.py
+++ b/tlm_adjoint/manager.py
@@ -164,15 +164,15 @@ def reset_adjoint(manager=None):
 
 
 def compute_gradient(Js, M, callback=None, prune_forward=True,
-                     prune_adjoint=True, prune_replay=True, cache_adjoint=True,
-                     adj_ics=None, manager=None):
+                     prune_adjoint=True, prune_replay=True,
+                     cache_adjoint_degree=None, adj_ics=None, manager=None):
     if manager is None:
         manager = globals()["manager"]()
     return manager.compute_gradient(Js, M, callback=callback,
                                     prune_forward=prune_forward,
                                     prune_adjoint=prune_adjoint,
                                     prune_replay=prune_replay,
-                                    cache_adjoint=cache_adjoint,
+                                    cache_adjoint_degree=cache_adjoint_degree,
                                     adj_ics=adj_ics)
 
 

--- a/tlm_adjoint/manager.py
+++ b/tlm_adjoint/manager.py
@@ -164,14 +164,15 @@ def reset_adjoint(manager=None):
 
 
 def compute_gradient(Js, M, callback=None, prune_forward=True,
-                     prune_adjoint=True, prune_replay=True, adj_ics=None,
-                     manager=None):
+                     prune_adjoint=True, prune_replay=True, cache_adjoint=True,
+                     adj_ics=None, manager=None):
     if manager is None:
         manager = globals()["manager"]()
     return manager.compute_gradient(Js, M, callback=callback,
                                     prune_forward=prune_forward,
                                     prune_adjoint=prune_adjoint,
                                     prune_replay=prune_replay,
+                                    cache_adjoint=cache_adjoint,
                                     adj_ics=adj_ics)
 
 

--- a/tlm_adjoint/timestepping.py
+++ b/tlm_adjoint/timestepping.py
@@ -24,6 +24,7 @@ from .alias import Alias
 from .equations import AssignmentSolver, Equation
 
 from collections import OrderedDict
+from operator import itemgetter
 
 __all__ = \
     [
@@ -137,7 +138,7 @@ class TimeLevels:
     def __init__(self, levels, cycle_map):
         levels = tuple(sorted(set(levels)))
         # Always assign to earlier time levels first in the cycle
-        cycle_map = OrderedDict(sorted(cycle_map.items(), key=lambda i: i[0]))
+        cycle_map = OrderedDict(sorted(cycle_map.items(), key=itemgetter(0)))
 
         self._levels = levels
         self._cycle_map = cycle_map

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -39,6 +39,7 @@ import gc
 import itertools
 import logging
 import numpy as np
+from operator import itemgetter
 import os
 import warnings
 import weakref
@@ -403,7 +404,7 @@ def J_tangent_linears(Js, blocks):
             break
 
     return (tuple(J_roots),
-            {tlm_key: tuple(sorted(adj_key, key=lambda e: e[0]))
+            {tlm_key: tuple(sorted(adj_key, key=itemgetter(0)))
              for tlm_key, adj_key in tlm_adj.items()})
 
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -350,10 +350,14 @@ def J_tangent_linears(Js, blocks):
             for J_i, J in remaining_Js.items():
                 if J_root_ids[function_id(J)] in eq_X_ids:
                     found_Js.append(J_i)
+                    seen_tlm_keys = set()
                     for ks in itertools.chain.from_iterable(
                             itertools.combinations(range(len(eq_tlm_key)), j)
                             for j in range(len(eq_tlm_key) + 1)):
                         tlm_key = tuple(eq_tlm_key[k] for k in ks)
+                        if tlm_key in seen_tlm_keys:
+                            continue
+                        seen_tlm_keys.add(tlm_key)
                         ks = set(ks)
                         adj_tlm_key = tuple(eq_tlm_key[k]
                                             for k in range(len(eq_tlm_key))
@@ -1009,10 +1013,9 @@ class EquationManager:
                         tlm_eq = NullSolver([tlm_map[x] for x in X])
                     tlm_eq._tlm_adjoint__tlm_root_id = getattr(
                         eq, "_tlm_adjoint__tlm_root_id", eq.id())
-                    parent_tlm_key = getattr(eq, "_tlm_adjoint__tlm_key", ())
                     tlm_eq._tlm_adjoint__tlm_key = tuple(
-                        list(parent_tlm_key)
-                        + [(len(parent_tlm_key), key)])
+                        list(getattr(eq, "_tlm_adjoint__tlm_key", ()))
+                        + [key])
 
                     eq_tlm_eqs[key] = tlm_eq
                     break

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -418,7 +418,7 @@ class AdjointCache:
     def __init__(self):
         self._cache = {}
         self._keys = {}
-        self._adj_key = None
+        self._cache_key = None
 
     def __len__(self):
         return len(self._cache)
@@ -430,7 +430,7 @@ class AdjointCache:
     def clear(self):
         self._cache.clear()
         self._keys.clear()
-        self._adj_key = None
+        self._cache_key = None
 
     def get(self, J_i, n, i, *, copy=True):
         adj_X = self._cache[(J_i, n, i)]
@@ -467,18 +467,18 @@ class AdjointCache:
         J_root_ids = tuple(getattr(J, "_tlm_adjoint__tlm_root_id", function_id(J))  # noqa: E501
                            for J in J_roots)
 
-        adj_key = tuple((J_root_ids[J_i], adj_tlm_key)
-                        for J_i, adj_tlm_key
-                        in sorted(itertools.chain.from_iterable(tlm_adj.values())))  # noqa: E501
+        cache_key = tuple((J_root_ids[J_i], adj_tlm_key)
+                          for J_i, adj_tlm_key
+                          in sorted(itertools.chain.from_iterable(tlm_adj.values())))  # noqa: E501
 
-        if self._adj_key is None or self._adj_key != adj_key:
+        if self._cache_key is None or self._cache_key != cache_key:
             self.clear()
 
         self._keys.clear()
-        self._adj_key = None
+        self._cache_key = None
 
         if cache_degree is None or cache_degree > 0:
-            self._adj_key = adj_key
+            self._cache_key = cache_key
 
             if isinstance(blocks, Sequence):
                 # Sequence


### PR DESCRIPTION
When performing multiple adjoint calculations associated with the same functional, or with tangent-linears associated with the same functional, the first order adjoint solutions are the same. For example in

```
add_tlm(m, dm)

# Forward calculation

dJ, ddJ = compute_gradient([J, J.tlm(m, dm)], m)
```

there are three sets of adjoint solutions: a first order adjoint associated with the calculation of `dJ`, and first and second order adjoints associated with the calculation of `ddJ`. The two first order adjoints are equal, allowing caching and reuse between the two adjoint calculations. This PR applies such optimizations automatically.

In some cases this optimization is not needed. For example the calculation above can be replaced with

```
dJ, ddJ = compute_gradient(J.tlm(m, dm), [dm, m])
```

The intended use case is the calculation of multiple Hessian actions in a single call to `compute_gradient`, to follow in a later PR.

Caching and reuse of second and higher order adjoints is also applied automatically.

Also fix a bug in detection of adjoint initial conditions, and some minor code tidying.