### PR TITLE
Use M for control reference value in taylor_test

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1938,9 +1938,8 @@ with arguments
     1 \right)$ (generated using the NumPy \texttt{numpy.random.random}
     function) is used.
   \item \texttt{M0}, a function, or a sequence of functions, defining the value
-    of the unperturbed reference value for the control. Extracted from internal
-    storage associated with the first block of the model (see section
-    \ref{sect:blocks}) if not supplied.
+    of the unperturbed reference value for the control. \texttt{M} is used if
+    not supplied.
   \item \texttt{size}, an integer, the number of control perturbations.
     Perturbations whose degrees of freedom are $\alpha 2^{-p}$ times
     \texttt{seed} times the values of the degrees of freedom of \texttt{dM} are

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -627,7 +627,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
         info(f"Optimal number of forward steps: {n_forward_solves_optimal:d}")
         assert n_forward_solves[0] == n_forward_solves_optimal
 
-    min_order = taylor_test(forward, m, J_val=J.value(), dJ=dJ, M0=m)
+    min_order = taylor_test(forward, m, J_val=J.value(), dJ=dJ)
     assert min_order > 1.99
 
 

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -630,7 +630,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
         info(f"Optimal number of forward steps: {n_forward_solves_optimal:d}")
         assert n_forward_solves[0] == n_forward_solves_optimal
 
-    min_order = taylor_test(forward, m, J_val=J.value(), dJ=dJ, M0=m)
+    min_order = taylor_test(forward, m, J_val=J.value(), dJ=dJ)
     assert min_order > 1.99
 
 

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -489,7 +489,7 @@ def test_binomial_checkpointing(setup_test, test_leaks, test_default_dtypes,
         info(f"Optimal number of forward steps: {n_forward_solves_optimal:d}")
         assert n_forward_solves[0] == n_forward_solves_optimal
 
-    min_order = taylor_test(forward, m, J_val=J.value(), dJ=dJ, M0=m)
+    min_order = taylor_test(forward, m, J_val=J.value(), dJ=dJ)
     assert min_order > 1.99
 
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -956,20 +956,6 @@ class EquationManager:
 
             self._cp.add_initial_condition(x)
 
-    def initial_condition(self, x):
-        """
-        Return the value of the initial condition for x recorded for the first
-        block. Finalizes the manager.
-        """
-
-        self.finalize()
-
-        x_id = function_id(x)
-        for eq in self._blocks[0]:
-            if x_id in {function_id(dep) for dep in eq.dependencies()}:
-                return self._cp.initial_condition(x, copy=True)
-        raise KeyError("Initial condition not found")
-
     def add_equation(self, eq, annotate=None, tlm=None):
         """
         Process the provided equation, annotating and / or deriving (and

--- a/tlm_adjoint/verification.py
+++ b/tlm_adjoint/verification.py
@@ -78,12 +78,12 @@ def taylor_test(forward, M, J_val, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
 
     if not isinstance(M, Sequence):
         if dJ is not None:
-            dJ = [dJ]
+            dJ = (dJ,)
         if dM is not None:
-            dM = [dM]
+            dM = (dM,)
         if M0 is not None:
-            M0 = [M0]
-        return taylor_test(forward, [M], J_val, dJ=dJ, ddJ=ddJ, seed=seed,
+            M0 = (M0,)
+        return taylor_test(forward, (M,), J_val, dJ=dJ, ddJ=ddJ, seed=seed,
                            dM=dM, M0=M0, size=size, manager=manager)
 
     logger = logging.getLogger("tlm_adjoint.verification")
@@ -91,11 +91,11 @@ def taylor_test(forward, M, J_val, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
         manager = _manager()
 
     if M0 is None:
-        M0 = [manager.initial_condition(m) for m in M]
-    M1 = [function_new(m, static=function_is_static(m),
-                       cache=function_is_cached(m),
-                       checkpoint=function_is_checkpointed(m))
-          for m in M]
+        M0 = tuple(map(function_copy, M))
+    M1 = tuple(function_new(m, static=function_is_static(m),
+                            cache=function_is_cached(m),
+                            checkpoint=function_is_checkpointed(m))
+               for m in M)
 
     def functions_inner(X, Y):
         inner = 0.0
@@ -114,7 +114,7 @@ def taylor_test(forward, M, J_val, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
     eps = np.array([2 ** -p for p in range(size)], dtype=np.float64)
     eps = seed * eps * max(1.0, functions_linf_norm(M0))
     if dM is None:
-        dM = [function_new(m1, static=True) for m1 in M1]
+        dM = tuple(function_new(m1, static=True) for m1 in M1)
         for dm in dM:
             dm_arr = np.random.random(function_local_size(dm))
             if issubclass(function_dtype(dm),
@@ -172,7 +172,7 @@ def taylor_test_tlm(forward, M, tlm_order, seed=1.0e-2, dMs=None, size=5,
     if not isinstance(M, Sequence):
         if dMs is not None:
             dMs = tuple((dM,) for dM in dMs)
-        return taylor_test_tlm(forward, [M], tlm_order, seed=seed, dMs=dMs,
+        return taylor_test_tlm(forward, (M,), tlm_order, seed=seed, dMs=dMs,
                                size=size, manager=manager)
 
     logger = logging.getLogger("tlm_adjoint.verification")
@@ -181,14 +181,14 @@ def taylor_test_tlm(forward, M, tlm_order, seed=1.0e-2, dMs=None, size=5,
     tlm_manager = manager.new("memory", {})
     tlm_manager.stop()
 
-    M = [function_copy(m, name=function_name(m),
-                       static=function_is_static(m),
-                       cache=function_is_cached(m),
-                       checkpoint=function_is_checkpointed(m)) for m in M]
-    M1 = [function_new(m, static=function_is_static(m),
-                       cache=function_is_cached(m),
-                       checkpoint=function_is_checkpointed(m))
-          for m in M]
+    M = tuple(function_copy(m, name=function_name(m),
+                            static=function_is_static(m),
+                            cache=function_is_cached(m),
+                            checkpoint=function_is_checkpointed(m)) for m in M)
+    M1 = tuple(function_new(m, static=function_is_static(m),
+                            cache=function_is_cached(m),
+                            checkpoint=function_is_checkpointed(m))
+               for m in M)
 
     def functions_linf_norm(X):
         norm = 0.0
@@ -260,7 +260,7 @@ def taylor_test_tlm_adjoint(forward, M, adjoint_order, seed=1.0e-2, dMs=None,
         if dMs is not None:
             dMs = tuple((dM,) for dM in dMs)
         return taylor_test_tlm_adjoint(
-            forward, [M], adjoint_order, seed=seed, dMs=dMs, size=size,
+            forward, (M,), adjoint_order, seed=seed, dMs=dMs, size=size,
             manager=manager)
 
     if manager is None:
@@ -268,10 +268,10 @@ def taylor_test_tlm_adjoint(forward, M, adjoint_order, seed=1.0e-2, dMs=None,
     tlm_manager = manager.new()
     tlm_manager.stop()
 
-    M = [function_copy(m, name=function_name(m),
-                       static=function_is_static(m),
-                       cache=function_is_cached(m),
-                       checkpoint=function_is_checkpointed(m)) for m in M]
+    M = tuple(function_copy(m, name=function_name(m),
+                            static=function_is_static(m),
+                            cache=function_is_cached(m),
+                            checkpoint=function_is_checkpointed(m)) for m in M)
 
     if dMs is None:
         dM_test = None


### PR DESCRIPTION
Previously the value stored in the checkpoint storage was used.

This changes the behaviour of `taylor_test` and `taylor_test_tlm_adjoint` in some cases where the control value is modified, but avoids potential bugs associated with the use of data from the checkpoint storage.

Also remove `EquationManager.initial_condition`, and change some lists to tuples