### PR TITLE
Minor fixes and tidying

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -2330,14 +2330,14 @@ def reset_manager(cp_method=None, cp_parameters=None, manager=None):
 Calls \texttt{EquationManager.reset}. Resets the \texttt{EquationManager}, and
 optionally defines a new checkpointing configuration.
 \begin{lstlisting}
-def start_manager(annotation=True, tlm=True, manager=None):
+def start_manager(*, annotate=True, tlm=True, manager=None):
 \end{lstlisting}
 Calls \texttt{EquationManager.start}. Enables the \texttt{EquationManager}. If
 \texttt{annotation} is true then enables recording of solved equations. If
 \texttt{tlm} is true then enables derivation and solution of tangent-linear
 equations.
 \begin{lstlisting}
-def stop_manager(annotation=True, tlm=True, manager=None):
+def stop_manager(*, annotate=True, tlm=True, manager=None):
 \end{lstlisting}
 Calls \texttt{EquationManager.stop}. Disables the \texttt{EquationManager}. If
 \texttt{annotation} is true then disables recording of solved equations. If

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -163,24 +163,6 @@ _Function__init__orig = backend_Function.__init__
 backend_Function.__init__ = _Function__init__
 
 
-def _EquationManager_configure_checkpointing(self, *args, **kwargs):
-    if hasattr(self, "_cp_manager") \
-            and hasattr(self, "_cp_path"):
-        if self._cp_manager.is_exhausted() \
-                and self._cp_manager.max_n() is not None \
-                and self._cp_manager.r() == self._cp_manager.max_n() \
-                and self._cp_path is not None:
-            self._comm.barrier()
-            if os.path.exists(self._cp_path):
-                assert len(os.listdir(self._cp_path)) == 0
-
-    _EquationManager_configure_checkpointing__orig(self, *args, **kwargs)
-
-
-_EquationManager_configure_checkpointing__orig = EquationManager.configure_checkpointing  # noqa: E501
-EquationManager.configure_checkpointing = _EquationManager_configure_checkpointing  # noqa: E501
-
-
 @pytest.fixture
 def test_leaks():
     function_ids.clear()

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -217,6 +217,8 @@ def test_leaks():
 
 @pytest.fixture
 def tmp_path(tmp_path):
+    if MPI.COMM_WORLD.rank != 0:
+        tmp_path = None
     return MPI.COMM_WORLD.bcast(tmp_path, root=0)
 
 

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -158,24 +158,6 @@ _Function__init__orig = backend_Function.__init__
 backend_Function.__init__ = _Function__init__
 
 
-def _EquationManager_configure_checkpointing(self, *args, **kwargs):
-    if hasattr(self, "_cp_manager") \
-            and hasattr(self, "_cp_path"):
-        if self._cp_manager.is_exhausted() \
-                and self._cp_manager.max_n() is not None \
-                and self._cp_manager.r() == self._cp_manager.max_n() \
-                and self._cp_path is not None:
-            self._comm.barrier()
-            if os.path.exists(self._cp_path):
-                assert len(os.listdir(self._cp_path)) == 0
-
-    _EquationManager_configure_checkpointing__orig(self, *args, **kwargs)
-
-
-_EquationManager_configure_checkpointing__orig = EquationManager.configure_checkpointing  # noqa: E501
-EquationManager.configure_checkpointing = _EquationManager_configure_checkpointing  # noqa: E501
-
-
 @pytest.fixture
 def test_leaks():
     function_ids.clear()

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -212,6 +212,8 @@ def test_leaks():
 
 @pytest.fixture
 def tmp_path(tmp_path):
+    if MPI.COMM_WORLD.rank != 0:
+        tmp_path = None
     return MPI.COMM_WORLD.bcast(tmp_path, root=0)
 
 

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -101,24 +101,6 @@ _Function__init__orig = Function.__init__
 Function.__init__ = _Function__init__
 
 
-def _EquationManager_configure_checkpointing(self, *args, **kwargs):
-    if hasattr(self, "_cp_manager") \
-            and hasattr(self, "_cp_path"):
-        if self._cp_manager.is_exhausted() \
-                and self._cp_manager.max_n() is not None \
-                and self._cp_manager.r() == self._cp_manager.max_n() \
-                and self._cp_path is not None:
-            self._comm.barrier()
-            if os.path.exists(self._cp_path):
-                assert len(os.listdir(self._cp_path)) == 0
-
-    _EquationManager_configure_checkpointing__orig(self, *args, **kwargs)
-
-
-_EquationManager_configure_checkpointing__orig = EquationManager.configure_checkpointing  # noqa: E501
-EquationManager.configure_checkpointing = _EquationManager_configure_checkpointing  # noqa: E501
-
-
 @pytest.fixture
 def test_leaks():
     function_ids.clear()

--- a/tlm_adjoint/_code_generator/caches.py
+++ b/tlm_adjoint/_code_generator/caches.py
@@ -26,7 +26,7 @@ from .backend_code_generator_interface import assemble, assemble_arguments, \
 
 from ..caches import Cache
 
-from .functions import eliminate_zeros, replaced_form
+from .functions import eliminate_zeros, extract_coefficients, replaced_form
 
 from collections import defaultdict
 import ufl
@@ -48,8 +48,8 @@ __all__ = \
     ]
 
 
-def is_cached(e):
-    for c in ufl.algorithms.extract_coefficients(e):
+def is_cached(expr):
+    for c in extract_coefficients(expr):
         if not is_function(c) or not function_is_cached(c):
             return False
     return True

--- a/tlm_adjoint/_code_generator/caches.py
+++ b/tlm_adjoint/_code_generator/caches.py
@@ -276,12 +276,12 @@ class AssemblyCache(Cache):
             form_compiler_parameters = {}
 
         if solver_parameters is not None:
-            warnings.warn("'solver_parameters' argument is deprecated -- use "
-                          "'linear_solver_parameters' instead",
+            warnings.warn("solver_parameters argument is deprecated -- use "
+                          "linear_solver_parameters instead",
                           DeprecationWarning, stacklevel=2)
             if linear_solver_parameters is not None:
-                raise TypeError("Cannot pass both 'solver_parameters' and "
-                                "'linear_solver_parameters' arguments")
+                raise TypeError("Cannot pass both solver_parameters and "
+                                "linear_solver_parameters arguments")
             linear_solver_parameters = solver_parameters
         elif linear_solver_parameters is None:
             linear_solver_parameters = {}
@@ -359,7 +359,7 @@ class LinearSolverCache(Cache):
                                        linear_solver_parameters)
                 return solver, A, b_bc
         else:
-            warnings.warn("'A' argument is deprecated",
+            warnings.warn("A argument is deprecated",
                           DeprecationWarning, stacklevel=2)
 
             # A = matrix_copy(A)  # Caller's responsibility

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -41,7 +41,6 @@ from .caches import assembly_cache, form_neg, is_cached, linear_solver_cache, \
 from .functions import bcs_is_cached, bcs_is_homogeneous, bcs_is_static, \
     eliminate_zeros, extract_coefficients
 
-import copy
 import numpy as np
 import ufl
 import warnings
@@ -830,8 +829,8 @@ class DirichletBCSolver(Equation):
         check_space_type(y, "primal")
 
         super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
-        self._bc_args = copy.copy(args)
-        self._bc_kwargs = copy.copy(kwargs)
+        self._bc_args = args
+        self._bc_kwargs = kwargs
 
     def forward_solve(self, x, deps=None):
         _, y = self.dependencies() if deps is None else deps

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -346,7 +346,7 @@ class EquationSolver(ExprEquation):
                         deps[dep_id] = dep
 
         if initial_guess is not None:
-            warnings.warn("'initial_guess' argument is deprecated",
+            warnings.warn("initial_guess argument is deprecated",
                           DeprecationWarning, stacklevel=2)
             if initial_guess == x:
                 initial_guess = None

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -215,8 +215,9 @@ class AssembleSolver(ExprEquation):
             return None
 
         dF = self._nonlinear_replace(dF, nl_deps)
-        dF = ufl.Form([integral.reconstruct(integrand=ufl.conj(integral.integrand()))  # noqa: E501
-                       for integral in dF.integrals()])  # dF = adjoint(dF)
+        dF = ufl.classes.Form(
+            [integral.reconstruct(integrand=ufl.conj(integral.integrand()))
+             for integral in dF.integrals()])  # dF = adjoint(dF)
         dF = assemble(
             dF, form_compiler_parameters=self._form_compiler_parameters)
         return (-function_scalar_value(adj_x), dF)

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -52,7 +52,6 @@ __all__ = \
         "eliminate_zeros",
         "extract_coefficients",
         "new_count",
-        "replaced_expr",
         "replaced_form"
     ]
 
@@ -571,14 +570,6 @@ class ReplacementConstant(backend_Constant, Replacement):
 class ReplacementFunction(backend_Function, Replacement):
     def __init__(self, x):
         Replacement.__init__(self, x)
-
-
-def replaced_expr(expr):
-    replace_map = {}
-    for c in ufl.algorithms.extract_coefficients(expr):
-        if is_function(c):
-            replace_map[c] = function_replacement(c)
-    return ufl.replace(expr, replace_map)
 
 
 def replaced_form(form):

--- a/tlm_adjoint/binomial_checkpointing.py
+++ b/tlm_adjoint/binomial_checkpointing.py
@@ -165,7 +165,7 @@ class MultistageCheckpointingManager(CheckpointingManager):
     """
 
     def __init__(self, max_n, snapshots_in_ram, snapshots_on_disk, *,
-                 keep_block_0_ics=False, trajectory="maximum"):
+                 trajectory="maximum"):
         if snapshots_in_ram == 0:
             storage = tuple("disk" for i in range(snapshots_on_disk))
         elif snapshots_on_disk == 0:
@@ -184,7 +184,6 @@ class MultistageCheckpointingManager(CheckpointingManager):
         self._snapshots = []
         self._storage = storage
         self._exhausted = False
-        self._keep_block_0_ics = keep_block_0_ics
         self._trajectory = trajectory
 
     def iter(self):
@@ -213,7 +212,7 @@ class MultistageCheckpointingManager(CheckpointingManager):
 
         # Forward -> reverse
 
-        yield "configure", (self._keep_block_0_ics and self._n == 0, True)
+        yield "configure", (False, True)
 
         self._n += 1
         yield "forward", (self._n - 1, self._n)
@@ -271,14 +270,14 @@ class MultistageCheckpointingManager(CheckpointingManager):
                 if self._n != self._max_n - self._r - 1:
                     raise RuntimeError("Invalid checkpointing state")
 
-            yield "configure", (self._keep_block_0_ics and self._n == 0, True)
+            yield "configure", (False, True)
 
             self._n += 1
             yield "forward", (self._n - 1, self._n)
 
             self._r += 1
             yield "reverse", (self._n, self._n - 1)
-            yield "clear", (not self._keep_block_0_ics or self._n != 1, True)
+            yield "clear", (True, True)
         if self._r != self._max_n:
             raise RuntimeError("Invalid checkpointing state")
         if len(self._snapshots) != 0:
@@ -304,7 +303,7 @@ class MultistageCheckpointingManager(CheckpointingManager):
 
 class TwoLevelCheckpointingManager(CheckpointingManager):
     def __init__(self, disk_period, binomial_snapshots, *,
-                 binomial_storage="disk", keep_block_0_ics=False,
+                 binomial_storage="disk",
                  binomial_trajectory="maximum"):
         """
         The two-level mixed periodic/binomial checkpointing approach of
@@ -329,7 +328,6 @@ class TwoLevelCheckpointingManager(CheckpointingManager):
         self._period = disk_period
         self._binomial_snapshots = binomial_snapshots
         self._binomial_storage = binomial_storage
-        self._keep_block_0_ics = keep_block_0_ics
         self._trajectory = binomial_trajectory
 
     def iter(self):
@@ -417,14 +415,14 @@ class TwoLevelCheckpointingManager(CheckpointingManager):
                         if self._n != self._max_n - self._r - 1:
                             raise RuntimeError("Invalid checkpointing state")
 
-                    yield "configure", (self._keep_block_0_ics and self._n == 0, True)  # noqa: E501
+                    yield "configure", (False, True)
 
                     self._n += 1
                     yield "forward", (self._n - 1, self._n)
 
                     self._r += 1
                     yield "reverse", (self._n, self._n - 1)
-                    yield "clear", (not self._keep_block_0_ics or self._n != 1, True)  # noqa: E501
+                    yield "clear", (True, True)
                 if self._r != self._max_n - n0s:
                     raise RuntimeError("Invalid checkpointing state")
                 if len(snapshots) != 0:

--- a/tlm_adjoint/binomial_checkpointing.py
+++ b/tlm_adjoint/binomial_checkpointing.py
@@ -175,6 +175,9 @@ class MultistageCheckpointingManager(CheckpointingManager):
                 max_n, snapshots_in_ram, snapshots_on_disk,
                 trajectory=trajectory)
 
+        snapshots_in_ram = storage.count("RAM")
+        snapshots_on_disk = storage.count("disk")
+
         super().__init__(max_n=max_n)
         self._snapshots_in_ram = snapshots_in_ram
         self._snapshots_on_disk = snapshots_on_disk

--- a/tlm_adjoint/caches.py
+++ b/tlm_adjoint/caches.py
@@ -69,9 +69,15 @@ class Cache:
         self._id_counter[0] += 1
         self._caches[self._id] = self
 
-    def __del__(self):
-        for value in self._cache.values():
-            value._clear()
+        def finalize_callback(self_ref):
+            self = self_ref()
+            if self is not None:
+                for value in self._cache.values():
+                    value._clear()
+
+        finalize = weakref.finalize(self, finalize_callback,
+                                    weakref.ref(self))
+        finalize.atexit = True
 
     def __len__(self):
         return len(self._cache)

--- a/tlm_adjoint/checkpointing.py
+++ b/tlm_adjoint/checkpointing.py
@@ -872,6 +872,11 @@ class NoneCheckpointingManager(CheckpointingManager):
     def iter(self):
         # Forward
 
+        if self._max_n is not None:
+            # Unexpected finalize
+            raise RuntimeError("Invalid checkpointing state")
+        yield "configure", (False, False)
+
         while self._max_n is None:
             n0 = self._n
             n1 = n0 + sys.maxsize

--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -180,7 +180,7 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
     A_action = wrapped_action(space, space_type, action_type, A_action)
     if B_action is None:
         if action_type in ["dual", "conjugate_dual"]:
-            space_type_warning("'B_action' argument expected with action type "
+            space_type_warning("B_action argument expected with action type "
                                "'dual' or 'conjugate_dual'")
         else:
             assert action_type == "primal"

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -506,7 +506,7 @@ class Equation(Referrer):
         try:
             self.forward(self.X())
         finally:
-            manager.start(annotation=annotation_enabled, tlm=tlm_enabled)
+            manager.start(annotate=annotation_enabled, tlm=tlm_enabled)
 
         self._post_process(manager=manager, annotate=annotate, tlm=tlm)
 

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -984,14 +984,14 @@ class FixedPointSolver(Equation, CustomNormSq):
 
         solver_parameters = copy.deepcopy(solver_parameters)
         if "nonzero_adjoint_initial_guess" in solver_parameters:
-            warnings.warn("'nonzero_adjoint_initial_guess' parameter is "
-                          "deprecated -- use 'adjoint_nonzero_initial_guess' "
+            warnings.warn("nonzero_adjoint_initial_guess parameter is "
+                          "deprecated -- use adjoint_nonzero_initial_guess "
                           "instead",
                           DeprecationWarning, stacklevel=2)
             if "adjoint_nonzero_initial_guess" in solver_parameters:
                 raise ValueError("Cannot supply both "
-                                 "'nonzero_adjoint_initial_guess' and "
-                                 "'adjoint_nonzero_initial_guess' "
+                                 "nonzero_adjoint_initial_guess and "
+                                 "adjoint_nonzero_initial_guess "
                                  "parameters")
             solver_parameters["adjoint_nonzero_initial_guess"] = \
                 solver_parameters.pop("nonzero_adjoint_initial_guess")
@@ -1623,12 +1623,11 @@ class Matrix(Referrer):
             raise ValueError("Duplicate non-linear dependency")
 
         if has_ic_dep is not None:
-            warnings.warn("'has_ic_dep' argument is deprecated -- use 'ic' "
+            warnings.warn("has_ic_dep argument is deprecated -- use ic "
                           "instead",
                           DeprecationWarning, stacklevel=2)
             if ic is not None:
-                raise TypeError("Cannot pass both 'has_ic_dep' and 'ic' "
-                                "arguments")
+                raise TypeError("Cannot pass both has_ic_dep and ic arguments")
             ic = has_ic_dep
         elif ic is None:
             ic = True

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -1000,8 +1000,7 @@ class FixedPointSolver(Equation, CustomNormSq):
                                    ("nonzero_initial_guess", True),
                                    ("adjoint_nonzero_initial_guess", True),
                                    ("adjoint_eqs_index_0", 0)]:
-            if key not in solver_parameters:
-                solver_parameters[key] = default_value
+            solver_parameters.setdefault(key, default_value)
 
         nonzero_initial_guess = solver_parameters["nonzero_initial_guess"]
         adjoint_nonzero_initial_guess = \

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -1939,7 +1939,7 @@ class DotProductRHS(RHS):
 
         check_space_types_dual(x, y)
 
-        x_equals_y = x == y
+        x_equals_y = function_id(x) == function_id(y)
         if x_equals_y:
             deps = [x]
         else:
@@ -2050,7 +2050,7 @@ class InnerProductRHS(RHS):
             raise NotImplementedError("Non-linear matrix dependencies not "
                                       "supported")
 
-        norm_sq = x == y
+        norm_sq = function_id(x) == function_id(y)
         if norm_sq:
             deps = [x]
         else:

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -62,29 +62,17 @@ __all__ = \
     ]
 
 
-if "tlm_adjoint" not in parameters:
-    parameters["tlm_adjoint"] = {}
-_parameters = parameters["tlm_adjoint"]
-if "AssembleSolver" not in _parameters:
-    _parameters["AssembleSolver"] = {}
-if "match_quadrature" not in _parameters["AssembleSolver"]:
-    _parameters["AssembleSolver"]["match_quadrature"] = False
-if "EquationSolver" not in _parameters:
-    _parameters["EquationSolver"] = {}
-if "enable_jacobian_caching" not in _parameters["EquationSolver"]:
-    _parameters["EquationSolver"]["enable_jacobian_caching"] = True
-if "cache_rhs_assembly" not in _parameters["EquationSolver"]:
-    _parameters["EquationSolver"]["cache_rhs_assembly"] = True
-if "match_quadrature" not in _parameters["EquationSolver"]:
-    _parameters["EquationSolver"]["match_quadrature"] = False
-if "defer_adjoint_assembly" not in _parameters["EquationSolver"]:
-    _parameters["EquationSolver"]["defer_adjoint_assembly"] = False
-if "assembly_verification" not in _parameters:
-    _parameters["assembly_verification"] = {}
-if "jacobian_tolerance" not in _parameters["assembly_verification"]:
-    _parameters["assembly_verification"]["jacobian_tolerance"] = np.inf
-if "rhs_tolerance" not in _parameters["assembly_verification"]:
-    _parameters["assembly_verification"]["rhs_tolerance"] = np.inf
+_parameters = parameters.setdefault("tlm_adjoint", {})
+_parameters.setdefault("AssembleSolver", {})
+_parameters["AssembleSolver"].setdefault("match_quadrature", False)
+_parameters.setdefault("EquationSolver", {})
+_parameters["EquationSolver"].setdefault("enable_jacobian_caching", True)
+_parameters["EquationSolver"].setdefault("cache_rhs_assembly", True)
+_parameters["EquationSolver"].setdefault("match_quadrature", False)
+_parameters["EquationSolver"].setdefault("defer_adjoint_assembly", False)
+_parameters.setdefault("assembly_verification", {})
+_parameters["assembly_verification"].setdefault("jacobian_tolerance", np.inf)
+_parameters["assembly_verification"].setdefault("rhs_tolerance", np.inf)
 del _parameters
 
 
@@ -113,26 +101,14 @@ def update_parameters_dict(parameters, new_parameters):
 
 def process_solver_parameters(solver_parameters, linear):
     solver_parameters = copy_parameters_dict(solver_parameters)
-    if "tlm_adjoint" in solver_parameters:
-        tlm_adjoint_parameters = solver_parameters["tlm_adjoint"]
-    else:
-        tlm_adjoint_parameters = solver_parameters["tlm_adjoint"] = {}
+    tlm_adjoint_parameters = solver_parameters.setdefault("tlm_adjoint", {})
 
-    if "options_prefix" not in tlm_adjoint_parameters:
-        tlm_adjoint_parameters["options_prefix"] = None
+    tlm_adjoint_parameters.setdefault("options_prefix", None)
+    tlm_adjoint_parameters.setdefault("nullspace", None)
+    tlm_adjoint_parameters.setdefault("transpose_nullspace", None)
+    tlm_adjoint_parameters.setdefault("near_nullspace", None)
 
-    if "nullspace" not in tlm_adjoint_parameters:
-        tlm_adjoint_parameters["nullspace"] = None
-
-    if "transpose_nullspace" not in tlm_adjoint_parameters:
-        tlm_adjoint_parameters["transpose_nullspace"] = None
-
-    if "near_nullspace" not in tlm_adjoint_parameters:
-        tlm_adjoint_parameters["near_nullspace"] = None
-
-    if "ksp_initial_guess_nonzero" not in solver_parameters:
-        solver_parameters["ksp_initial_guess_nonzero"] = False
-    linear_solver_ic = solver_parameters["ksp_initial_guess_nonzero"]
+    linear_solver_ic = solver_parameters.setdefault("ksp_initial_guess_nonzero", False)  # noqa: E501
 
     return (solver_parameters, solver_parameters,
             not linear or linear_solver_ic, linear_solver_ic)

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -191,7 +191,10 @@ class FunctionInterface(_FunctionInterface):
         if e.family() == "Real" and e.degree() == 0:
             # Work around Firedrake issue #1459
             values = self.dat.data_ro.copy()
-            values = function_comm(self).bcast(values, root=0)
+            comm = function_comm(self)
+            if comm.rank != 0:
+                values = None
+            values = comm.bcast(values, root=0)
             self.dat.data[:] = values
 
     def _axpy(self, alpha, x, /):
@@ -217,7 +220,10 @@ class FunctionInterface(_FunctionInterface):
         if e.family() == "Real" and e.degree() == 0:
             # Work around Firedrake issue #1459
             values = self.dat.data_ro.copy()
-            values = function_comm(self).bcast(values, root=0)
+            comm = function_comm(self)
+            if comm.rank != 0:
+                values = None
+            values = comm.bcast(values, root=0)
             self.dat.data[:] = values
 
     def _inner(self, y):

--- a/tlm_adjoint/manager.py
+++ b/tlm_adjoint/manager.py
@@ -104,40 +104,40 @@ def annotation_enabled(manager=None):
     return manager.annotation_enabled()
 
 
-def start_manager(annotation=True, tlm=True, manager=None):
+def start_manager(*, annotate=True, tlm=True, manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.start(annotation=annotation, tlm=tlm)
+    manager.start(annotate=annotate, tlm=tlm)
 
 
 def start_annotating(manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.start(annotation=True, tlm=False)
+    manager.start(annotate=True, tlm=False)
 
 
 def start_tlm(manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.start(annotation=False, tlm=True)
+    manager.start(annotate=False, tlm=True)
 
 
-def stop_manager(annotation=True, tlm=True, manager=None):
+def stop_manager(*, annotate=True, tlm=True, manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.stop(annotation=annotation, tlm=tlm)
+    manager.stop(annotate=annotate, tlm=tlm)
 
 
 def stop_annotating(manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.stop(annotation=True, tlm=False)
+    manager.stop(annotate=True, tlm=False)
 
 
 def stop_tlm(manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.stop(annotation=False, tlm=True)
+    manager.stop(annotate=False, tlm=True)
 
 
 def configure_tlm(*args, annotate=None, tlm=True, manager=None):

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -808,7 +808,7 @@ class EquationManager:
 
         if not callable(cp_method) and cp_method in ["none", "memory"]:
             if "replace" in cp_parameters:
-                warnings.warn("'replace' cp_parameters key is deprecated",
+                warnings.warn("replace cp_parameters key is deprecated",
                               DeprecationWarning, stacklevel=2)
                 if "drop_references" in cp_parameters:
                     if cp_parameters["replace"] != cp_parameters["drop_references"]:  # noqa: E501

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -505,7 +505,6 @@ class AdjointCache:
 
     def initialize(self, Js, blocks, transpose_deps, *,
                    cache_degree=None):
-
         J_roots, tlm_adj = J_tangent_linears(Js, blocks,
                                              max_adjoint_degree=cache_degree)
         J_root_ids = tuple(getattr(J, "_tlm_adjoint__tlm_root_id", function_id(J))  # noqa: E501

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -36,7 +36,6 @@ from collections import defaultdict, deque
 from collections.abc import Sequence
 import copy
 import enum
-import gc
 import itertools
 import logging
 import numpy as np
@@ -1552,7 +1551,6 @@ class EquationManager:
             return dJ
 
         set_manager(self)
-        gc.collect()
         self.finalize()
         self.reset_adjoint(_warning=False)
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -832,14 +832,12 @@ class EquationManager:
             cp_manager = MemoryCheckpointingManager()
         elif cp_method == "periodic_disk":
             cp_manager = PeriodicDiskCheckpointingManager(
-                cp_parameters["period"],
-                keep_block_0_ics=True)
+                cp_parameters["period"])
         elif cp_method == "multistage":
             cp_manager = MultistageCheckpointingManager(
                 cp_parameters["blocks"],
                 cp_parameters.get("snaps_in_ram", 0),
                 cp_parameters.get("snaps_on_disk", 0),
-                keep_block_0_ics=True,
                 trajectory="maximum")
         else:
             raise ValueError(f"Unrecognized checkpointing method: "

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -1444,7 +1444,7 @@ class EquationManager:
                 and len(self._blocks) == self._cp_manager.max_n() - 1:
             # Wait for the finalize
             warnings.warn(
-                "Attempting to end the final block without finalising -- "
+                "Attempting to end the final block without finalizing -- "
                 "ignored", RuntimeWarning, stacklevel=2)
             return
 

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -1012,12 +1012,12 @@ class EquationManager:
 
         return self._annotation_state == AnnotationState.ANNOTATING
 
-    def start(self, annotation=True, tlm=True):
+    def start(self, *, annotate=True, tlm=True):
         """
         Start annotation or tangent-linear derivation.
         """
 
-        if annotation:
+        if annotate:
             self._annotation_state \
                 = {AnnotationState.STOPPED: AnnotationState.ANNOTATING,
                    AnnotationState.ANNOTATING: AnnotationState.ANNOTATING}[self._annotation_state]  # noqa: E501
@@ -1027,7 +1027,7 @@ class EquationManager:
                 = {TangentLinearState.STOPPED: TangentLinearState.DERIVING,
                    TangentLinearState.DERIVING: TangentLinearState.DERIVING}[self._tlm_state]  # noqa: E501
 
-    def stop(self, annotation=True, tlm=True):
+    def stop(self, *, annotate=True, tlm=True):
         """
         Pause annotation or tangent-linear derivation. Returns a tuple
         containing:
@@ -1039,7 +1039,7 @@ class EquationManager:
 
         state = (self.annotation_enabled(), self.tlm_enabled())
 
-        if annotation:
+        if annotate:
             self._annotation_state \
                 = {AnnotationState.STOPPED: AnnotationState.STOPPED,
                    AnnotationState.ANNOTATING: AnnotationState.STOPPED,

--- a/tlm_adjoint/verification.py
+++ b/tlm_adjoint/verification.py
@@ -151,7 +151,7 @@ def taylor_test(forward, M, J_val, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
         try:
             J_vals[i] = forward(*M1).value()
         finally:
-            manager.start(annotation=annotation_enabled, tlm=tlm_enabled)
+            manager.start(annotate=annotation_enabled, tlm=tlm_enabled)
     if abs(J_vals.imag).max() == 0.0:
         J_vals = J_vals.real
 
@@ -235,7 +235,7 @@ def taylor_test_tlm(forward, M, tlm_order, seed=1.0e-2, dMs=None, size=5,
         clear_caches()
 
         tlm_manager.configure_tlm(*[(M, dM) for dM in dMs])
-        tlm_manager.start(annotation=False, tlm=True)
+        tlm_manager.start(annotate=False, tlm=True)
         J = forward(*M)
         for dM in dMs:
             J = J.tlm_functional((M, dM), manager=tlm_manager)
@@ -315,7 +315,7 @@ def taylor_test_tlm_adjoint(forward, M, adjoint_order, seed=1.0e-2, dMs=None,
 
         tlm_manager.configure_tlm(*[(M, dM) for dM in dMs],
                                   annotate=annotate)
-        tlm_manager.start(annotation=annotate, tlm=True)
+        tlm_manager.start(annotate=annotate, tlm=True)
         J = forward(*M)
         for dM in dMs:
             J = J.tlm_functional((M, dM), manager=tlm_manager)

--- a/tlm_adjoint/verification.py
+++ b/tlm_adjoint/verification.py
@@ -29,9 +29,9 @@ from .functional import Functional
 from .manager import manager as _manager, restore_manager, set_manager
 
 from collections.abc import Sequence
+import functools
 import logging
 import numpy as np
-import functools
 
 __all__ = \
     [


### PR DESCRIPTION
Changes include:
- Allow the `forward` callable to be a function in verification functions
- Backport some fixes/updates from the jrmaddison/H_revolve branch
- API change in `EquationManager.start`, `EquationManager.stop`, `start_manager`, and `stop_manager`, changing the `annotation` argument to `annotate` and making arguments keyword-only