### PR TITLE
Use duplicate MPI communicators

### DIFF
--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -21,10 +21,10 @@
 from .backend import backend_Constant, backend_DirichletBC, backend_Function, \
     backend_ScalarType
 from ..interface import DEFAULT_COMM, SpaceInterface, add_interface, \
-    function_caches, function_comm, function_dtype, function_id, \
+    comm_parent, function_caches, function_comm, function_dtype, function_id, \
     function_is_cached, function_is_checkpointed, function_is_static, \
     function_name, function_replacement, function_space, function_space_type, \
-    is_function, parent_comm, space_comm
+    is_function, space_comm
 from ..interface import FunctionInterface as _FunctionInterface
 
 from ..caches import Caches
@@ -289,7 +289,7 @@ class Constant(backend_Constant):
             if space is None:
                 comm = DEFAULT_COMM
             else:
-                comm = parent_comm(space_comm(space))
+                comm = comm_parent(space_comm(space))
 
         if cache is None:
             cache = static

--- a/tlm_adjoint/_code_generator/functions.py
+++ b/tlm_adjoint/_code_generator/functions.py
@@ -20,11 +20,11 @@
 
 from .backend import backend_Constant, backend_DirichletBC, backend_Function, \
     backend_ScalarType
-from ..interface import SpaceInterface, add_interface, function_caches, \
-    function_comm, function_dtype, function_id, function_is_cached, \
-    function_is_checkpointed, function_is_static, function_name, \
-    function_replacement, function_space, function_space_type, is_function, \
-    space_comm
+from ..interface import DEFAULT_COMM, SpaceInterface, add_interface, \
+    function_caches, function_comm, function_dtype, function_id, \
+    function_is_cached, function_is_checkpointed, function_is_static, \
+    function_name, function_replacement, function_space, function_space_type, \
+    is_function, parent_comm, space_comm
 from ..interface import FunctionInterface as _FunctionInterface
 
 from ..caches import Caches
@@ -287,9 +287,9 @@ class Constant(backend_Constant):
         # Default comm
         if comm is None:
             if space is None:
-                comm = MPI.COMM_WORLD
+                comm = DEFAULT_COMM
             else:
-                comm = space_comm(space)
+                comm = parent_comm(space_comm(space))
 
         if cache is None:
             cache = static

--- a/tlm_adjoint/caches.py
+++ b/tlm_adjoint/caches.py
@@ -75,9 +75,8 @@ class Cache:
                 for value in self._cache.values():
                     value._clear()
 
-        finalize = weakref.finalize(self, finalize_callback,
-                                    weakref.ref(self))
-        finalize.atexit = True
+        weakref.finalize(self, finalize_callback,
+                         weakref.ref(self))
 
     def __len__(self):
         return len(self._cache)

--- a/tlm_adjoint/checkpointing.py
+++ b/tlm_adjoint/checkpointing.py
@@ -18,10 +18,11 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import DEFAULT_COMM, function_copy, function_get_values, \
-    function_global_size, function_id, function_is_checkpointed, \
-    function_local_indices, function_new, function_set_values, \
-    function_space, function_space_type, space_id, space_new
+from .interface import DEFAULT_COMM, comm_dup, function_copy, \
+    function_get_values, function_global_size, function_id, \
+    function_is_checkpointed, function_local_indices, function_new, \
+    function_set_values, function_space, function_space_type, space_id, \
+    space_new
 
 from abc import ABC, abstractmethod
 from collections import deque
@@ -472,21 +473,19 @@ def root_pid(comm, *, root=0):
 
 
 class PickleCheckpoints(Checkpoints):
-    def __init__(self, prefix, *, comm=DEFAULT_COMM):
-        comm = comm.Dup()
+    def __init__(self, prefix, *, comm=None):
+        if comm is None:
+            comm = DEFAULT_COMM
+
+        comm = comm_dup(comm)
         cp_filenames = {}
 
-        def finalize_callback(comm, cp_filenames):
-            try:
-                for filename in cp_filenames.values():
-                    os.remove(filename)
-            finally:
-                if MPI is not None and not MPI.Is_finalized():
-                    comm.Free()
+        def finalize_callback(cp_filenames):
+            for filename in cp_filenames.values():
+                os.remove(filename)
 
-        finalize = weakref.finalize(self, finalize_callback,
-                                    comm, cp_filenames)
-        finalize.atexit = True
+        weakref.finalize(self, finalize_callback,
+                         cp_filenames)
 
         self._prefix = prefix
         self._comm = comm
@@ -562,26 +561,24 @@ class PickleCheckpoints(Checkpoints):
 
 
 class HDF5Checkpoints(Checkpoints):
-    def __init__(self, prefix, *, comm=DEFAULT_COMM):
-        comm = comm.Dup()
+    def __init__(self, prefix, *, comm=None):
+        if comm is None:
+            comm = DEFAULT_COMM
+
+        comm = comm_dup(comm)
         cp_filenames = {}
 
         def finalize_callback(comm, rank, cp_filenames):
-            try:
-                if MPI is not None and not MPI.Is_finalized():
-                    comm.barrier()
-                if rank == 0:
-                    for filename in cp_filenames.values():
-                        os.remove(filename)
-                if MPI is not None and not MPI.Is_finalized():
-                    comm.barrier()
-            finally:
-                if MPI is not None and not MPI.Is_finalized():
-                    comm.Free()
+            if MPI is not None and not MPI.Is_finalized():
+                comm.barrier()
+            if rank == 0:
+                for filename in cp_filenames.values():
+                    os.remove(filename)
+            if MPI is not None and not MPI.Is_finalized():
+                comm.barrier()
 
-        finalize = weakref.finalize(self, finalize_callback,
-                                    comm, comm.rank, cp_filenames)
-        finalize.atexit = True
+        weakref.finalize(self, finalize_callback,
+                         comm, comm.rank, cp_filenames)
 
         self._prefix = prefix
         self._comm = comm

--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -57,7 +57,7 @@
 
 from .interface import check_space_types, function_get_values, \
     function_global_size, function_local_size, function_set_values, \
-    is_function, space_comm, space_new, space_type_warning
+    is_function, parent_comm, space_comm, space_new, space_type_warning
 
 import functools
 import numpy as np
@@ -200,7 +200,9 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
     del X
     N_ev = N if N_eigenvalues is None else N_eigenvalues
 
-    comm = space_comm(space)  # .Dup()
+    # Use the parent communicator, as we don't want to free the communicator
+    # before PETSc/SLEPc objects have been destroyed
+    comm = parent_comm(space_comm(space))
 
     A_matrix = PETSc.Mat().createPython(((n, N), (n, N)),
                                         PythonMatrix(A_action),
@@ -275,8 +277,6 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
             if v_i is not None:
                 with v_i as v_i_a:
                     function_set_values(V_i[i], v_i_a)
-
-    # comm.Free()
 
     if V_i is None:
         return lam, V_r

--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -55,9 +55,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .interface import check_space_types, function_get_values, \
+from .interface import check_space_types, comm_parent, function_get_values, \
     function_global_size, function_local_size, function_set_values, \
-    is_function, parent_comm, space_comm, space_new, space_type_warning
+    is_function, space_comm, space_new, space_type_warning
 
 import functools
 import numpy as np
@@ -202,7 +202,7 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
 
     # Use the parent communicator, as we don't want to free the communicator
     # before PETSc/SLEPc objects have been destroyed
-    comm = parent_comm(space_comm(space))
+    comm = comm_parent(space_comm(space))
 
     A_matrix = PETSc.Mat().createPython(((n, N), (n, N)),
                                         PythonMatrix(A_action),

--- a/tlm_adjoint/hessian_optimization.py
+++ b/tlm_adjoint/hessian_optimization.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import function_id, function_new, function_state
+from .interface import comm_dup, function_id, function_new, function_state
 
 from .caches import clear_caches
 from .functional import Functional
@@ -28,7 +28,6 @@ from .tlm_adjoint import AdjointCache, EquationManager
 
 from collections.abc import Sequence
 import warnings
-import weakref
 
 __all__ = \
     [
@@ -45,14 +44,7 @@ class HessianOptimization:
         if manager._alias_eqs:
             raise RuntimeError("Invalid equation manager state")
 
-        comm = manager.comm().Dup()
-
-        def finalize_callback(comm):
-            comm.Free()
-
-        finalize = weakref.finalize(self, finalize_callback,
-                                    comm)
-        finalize.atexit = False
+        comm = comm_dup(manager.comm())
 
         blocks = list(manager._blocks) + [list(manager._block)]
 

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -199,6 +199,9 @@ _comms = weakref.WeakValueDictionary()
 
 
 def comm_dup_cached(comm):
+    if MPI is not None and comm is MPI.COMM_NULL:
+        return comm
+
     comm_py2f = comm.py2f()
     dup_comm = _comms.get(comm_py2f, None)
 

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -209,12 +209,6 @@ def comm_dup_cached(comm):
         dup_comm = comm_dup(comm)
         _dup_comms[comm_py2f] = dup_comm
 
-        def finalize_callback(comm_py2f):
-            del _dup_comms[comm_py2f]
-
-        weakref.finalize(comm, finalize_callback,
-                         comm_py2f)
-
     return dup_comm
 
 

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -199,7 +199,7 @@ _comms = weakref.WeakValueDictionary()
 
 
 def comm_dup_cached(comm):
-    comm_py2f = parent_comm(comm).py2f()
+    comm_py2f = comm.py2f()
     dup_comm = _comms.get(comm_py2f, None)
 
     if dup_comm is None:

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -38,7 +38,7 @@ __all__ = \
         "DEFAULT_COMM",
         "comm_dup",
         "comm_dup_cached",
-        "parent_comm",
+        "comm_parent",
 
         "add_interface",
         "weakref_method",
@@ -195,7 +195,7 @@ def comm_dup(comm):
     return dup_comm
 
 
-_comms = weakref.WeakValueDictionary()
+_dup_comms = weakref.WeakValueDictionary()
 
 
 def comm_dup_cached(comm):
@@ -203,14 +203,14 @@ def comm_dup_cached(comm):
         return comm
 
     comm_py2f = comm.py2f()
-    dup_comm = _comms.get(comm_py2f, None)
+    dup_comm = _dup_comms.get(comm_py2f, None)
 
     if dup_comm is None:
         dup_comm = comm_dup(comm)
-        _comms[comm_py2f] = dup_comm
+        _dup_comms[comm_py2f] = dup_comm
 
         def finalize_callback(comm_py2f):
-            del _comms[comm_py2f]
+            del _dup_comms[comm_py2f]
 
         weakref.finalize(comm, finalize_callback,
                          comm_py2f)
@@ -218,7 +218,7 @@ def comm_dup_cached(comm):
     return dup_comm
 
 
-def parent_comm(dup_comm):
+def comm_parent(dup_comm):
     return _parent_comms.get(dup_comm.py2f(), dup_comm)
 
 

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -18,12 +18,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-import numpy as np
-
 from collections.abc import Mapping
 import copy
 import functools
 import logging
+try:
+    import mpi4py.MPI as MPI
+except ImportError:
+    MPI = None
+import numpy as np
 import sys
 import warnings
 import weakref
@@ -33,6 +36,9 @@ __all__ = \
         "InterfaceException",
 
         "DEFAULT_COMM",
+        "comm_dup",
+        "comm_dup_cached",
+        "parent_comm",
 
         "add_interface",
         "weakref_method",
@@ -117,9 +123,7 @@ class InterfaceException(Exception):  # noqa: N818
         super().__init__(*args, **kwargs)
 
 
-try:
-    from mpi4py.MPI import COMM_WORLD as DEFAULT_COMM
-except ImportError:
+if MPI is None:
     # As for mpi4py 3.0.3 API
     class SerialComm:
         _id_counter = [-1]
@@ -164,6 +168,55 @@ except ImportError:
             return copy.deepcopy(sendobj)
 
     DEFAULT_COMM = SerialComm()
+else:
+    DEFAULT_COMM = MPI.COMM_WORLD
+
+
+_parent_comms = {}
+
+
+def comm_dup(comm):
+    if MPI is not None and comm is MPI.COMM_NULL:
+        return comm
+
+    dup_comm = comm.Dup()
+    dup_comm_py2f = dup_comm.py2f()
+    _parent_comms[dup_comm_py2f] = comm
+
+    def finalize_callback(dup_comm_py2f):
+        if MPI is not None and not MPI.Is_finalized():
+            dup_comm = MPI.Comm.f2py(dup_comm_py2f)
+            dup_comm.Free()
+        del _parent_comms[dup_comm_py2f]
+
+    weakref.finalize(dup_comm, finalize_callback,
+                     dup_comm_py2f)
+
+    return dup_comm
+
+
+_comms = weakref.WeakValueDictionary()
+
+
+def comm_dup_cached(comm):
+    comm_py2f = parent_comm(comm).py2f()
+    dup_comm = _comms.get(comm_py2f, None)
+
+    if dup_comm is None:
+        dup_comm = comm_dup(comm)
+        _comms[comm_py2f] = dup_comm
+
+        def finalize_callback(comm_py2f):
+            del _comms[comm_py2f]
+
+        weakref.finalize(comm, finalize_callback,
+                         comm_py2f)
+
+    return dup_comm
+
+
+def parent_comm(dup_comm):
+    return _parent_comms.get(dup_comm.py2f(), dup_comm)
 
 
 def weakref_method(fn, obj):

--- a/tlm_adjoint/numpy/backend_interface.py
+++ b/tlm_adjoint/numpy/backend_interface.py
@@ -23,7 +23,8 @@ from ..functional import Functional as _Functional
 from ..hessian import GeneralGaussNewton as _GaussNewton
 from ..hessian_optimization import CachedGaussNewton as _CachedGaussNewton
 from ..interface import DEFAULT_COMM, SpaceInterface, add_interface, \
-    function_space, new_function_id, new_space_id, space_id, space_new
+    comm_dup_cached, function_space, new_function_id, new_space_id, space_id, \
+    space_new
 from ..interface import FunctionInterface as _FunctionInterface
 
 import copy
@@ -82,7 +83,7 @@ class FunctionSpaceInterface(SpaceInterface):
 
 class FunctionSpace:
     def __init__(self, dim, *, dtype=None):
-        comm = DEFAULT_COMM
+        comm = comm_dup_cached(DEFAULT_COMM)
         if comm.size > 1:
             raise RuntimeError("Serial only")
         if dtype is None:

--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -18,10 +18,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .interface import function_axpy, function_copy, function_get_values, \
-    function_is_cached, function_is_checkpointed, function_is_static, \
-    function_linf_norm, function_local_size, function_new, \
-    function_set_values, is_function
+from .interface import comm_dup, function_axpy, function_copy, \
+    function_get_values, function_is_cached, function_is_checkpointed, \
+    function_is_static, function_linf_norm, function_local_size, \
+    function_new, function_set_values, is_function
 
 from .caches import clear_caches
 from .functional import Functional
@@ -77,7 +77,7 @@ def minimize_scipy(forward, M0, J0=None, manager=None, **kwargs):
 
     if manager is None:
         manager = _manager()
-    comm = manager.comm().Dup()
+    comm = comm_dup(manager.comm())
 
     N = [0]
     for m0 in M0:
@@ -202,6 +202,5 @@ def minimize_scipy(forward, M0, J0=None, manager=None, **kwargs):
         set(M, None)
 
     clear_caches(*M)
-    comm.Free()
 
     return M, return_value


### PR DESCRIPTION
Various driver routines previously made use of duplicate MPI communicators. This PR extends this throughout the rest of the code.

Adds
- `comm_dup`: Unconditionally duplicate the communicator.
- `comm_dup_cached`: Use a cached version of the duplicate communicator if available, otherwise duplicate the communicator and cache the duplicate communicator. Similar in behaviour to the PyOP2 `dup_comm`, but with automatic freeing of the communicator.
- `comm_parent`: Can be used to obtain the communicator passed to `comm_dup` or `comm_dup_cached`.

Weak referencing and finalizers are used to automatically free the duplicate MPI communicators when the Python MPI communicator is destroyed.

`function_comm` and `space_comm` now return duplicate communicators duplicated using `comm_dup_cached`.

There are two cases where some care is required:
- Communicators should not always be freed when the Python communicator is destroyed -- for example if passing communicators to external libraries. `eigendecompose` uses a parent communicator, *not* a duplicate communicator, to construct PETSc and SLEPc objects, since the `configure` callback may e.g. access and keep a reference to the `EPS`.
- Since freeing of MPI communicators is collective there should be no cyclic references involving duplicate Python communicators returned by `comm_dup` or `comm_dup_cached`, or else the Python garbage collector should be disabled.

Also
- Use `DEFAULT_COMM` instead of `MPI.COMM_WORLD` throughout the code.
- Avoid using communicators as default argument values.
- Remove `finalizer.atexit = True`.

Resolves #182