### PR TITLE
Work around Firedrake parallel deadlocks

### DIFF
--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -24,7 +24,6 @@ from tlm_adjoint.firedrake import manager as _manager
 from tlm_adjoint.firedrake.backend import backend_Constant, backend_Function
 from tlm_adjoint.firedrake.backend_code_generator_interface import \
     complex_mode, interpolate_expression
-from tlm_adjoint.alias import gc_disabled
 
 import copy
 import functools
@@ -65,7 +64,6 @@ _handler.setFormatter(logging.Formatter(fmt="%(message)s"))
 _logger.addHandler(_handler)
 
 
-@gc_disabled  # See Firedrake issue #1569
 @pytest.fixture
 def setup_test():
     parameters["tlm_adjoint"]["AssembleSolver"]["match_quadrature"] = False
@@ -79,6 +77,8 @@ def setup_test():
     # parameters["tlm_adjoint"]["assembly_verification"]["rhs_tolerance"] \
     #     = 1.0e-12
 
+    gc_enabled = gc.isenabled()
+    gc.disable()  # See Firedrake issue #1569
     reset_manager("memory", {"drop_references": True})
     clear_caches()
     stop_manager()
@@ -88,6 +88,8 @@ def setup_test():
 
     yield
 
+    if gc_enabled:
+        gc.enable()
     reset_manager("memory", {"drop_references": False})
 
 

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -82,6 +82,7 @@ def setup_test():
     reset_manager("memory", {"drop_references": True})
     clear_caches()
     stop_manager()
+    gc.collect()
 
     logging.getLogger("firedrake").setLevel(logging.INFO)
     logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
@@ -91,6 +92,7 @@ def setup_test():
     if gc_enabled:
         gc.enable()
     reset_manager("memory", {"drop_references": False})
+    gc.collect()
 
 
 def seed_test(fn):


### PR DESCRIPTION
The most recent version of Firedrake seems to be particularly susceptible to parallel deadlocks. This exposed a bug in the `setup_test` decorator, which did not correctly disable the garbage collector.

This PR fixes this, and also adds some manual garbage collection. This seems to reduce the problem, but may not work around the problem in all cases.

Closes #198