### PR TITLE
Firedrake backend: Do not disable the garbage collector in tests

### DIFF
--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -79,14 +79,12 @@ def setup_test():
     stop_manager()
     clear_caches()
     gc.collect()
-    comm_cleanup()
 
     yield
 
     reset_manager("memory", {"drop_references": False})
     clear_caches()
     gc.collect()
-    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -73,16 +73,20 @@ def setup_test():
     # parameters["tlm_adjoint"]["assembly_verification"]["rhs_tolerance"] \
     #     = 1.0e-12
 
+    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
+
     reset_manager("memory", {"drop_references": True})
     stop_manager()
     clear_caches()
-
-    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
+    gc.collect()
+    comm_cleanup()
 
     yield
 
     reset_manager("memory", {"drop_references": False})
     clear_caches()
+    gc.collect()
+    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -77,23 +77,17 @@ def setup_test():
     # parameters["tlm_adjoint"]["assembly_verification"]["rhs_tolerance"] \
     #     = 1.0e-12
 
-    gc_enabled = gc.isenabled()
-    gc.disable()  # See Firedrake issue #1569
     reset_manager("memory", {"drop_references": True})
     stop_manager()
     clear_caches()
-    gc.collect()
 
     logging.getLogger("firedrake").setLevel(logging.INFO)
     logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
 
     yield
 
-    if gc_enabled:
-        gc.enable()
     reset_manager("memory", {"drop_references": False})
     clear_caches()
-    gc.collect()
 
 
 def seed_test(fn):

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -35,6 +35,7 @@ import mpi4py.MPI as MPI
 import numpy as np
 from operator import itemgetter
 import os
+import petsc4py.PETSc as PETSc
 import pytest
 import runpy
 import sys
@@ -77,17 +78,23 @@ def setup_test():
     # parameters["tlm_adjoint"]["assembly_verification"]["rhs_tolerance"] \
     #     = 1.0e-12
 
+    logging.getLogger("firedrake").setLevel(logging.INFO)
+    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
+
     reset_manager("memory", {"drop_references": True})
     stop_manager()
     clear_caches()
-
-    logging.getLogger("firedrake").setLevel(logging.INFO)
-    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
+    gc.collect()
+    PETSc.garbage_cleanup()
+    comm_cleanup()
 
     yield
 
     reset_manager("memory", {"drop_references": False})
     clear_caches()
+    gc.collect()
+    PETSc.garbage_cleanup()
+    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -86,7 +86,6 @@ def setup_test():
     clear_caches()
     gc.collect()
     PETSc.garbage_cleanup()
-    comm_cleanup()
 
     yield
 
@@ -94,7 +93,6 @@ def setup_test():
     clear_caches()
     gc.collect()
     PETSc.garbage_cleanup()
-    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tests/firedrake/test_models.py
+++ b/tests/firedrake/test_models.py
@@ -228,7 +228,7 @@ def test_diffusion_1d_timestepping(setup_test, test_leaks,
     J_val = J.value()
     if n_steps == 20:
         J_val_ref = diffusion_ref()
-        assert abs(J_val - J_val_ref) < 1.0e-13
+        assert abs(J_val - J_val_ref) < 1.0e-12
 
     dJs = compute_gradient(J, [T_0, kappa])
 

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -50,18 +50,22 @@ __all__ = \
 
 @pytest.fixture
 def setup_test():
-    reset_manager("memory", {"drop_references": True})
-    stop_manager()
-    clear_caches()
+    set_default_dtype(np.float64)
 
     logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
 
-    set_default_dtype(np.float64)
+    reset_manager("memory", {"drop_references": True})
+    stop_manager()
+    clear_caches()
+    gc.collect()
+    comm_cleanup()
 
     yield
 
     reset_manager("memory", {"drop_references": False})
     clear_caches()
+    gc.collect()
+    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -58,14 +58,12 @@ def setup_test():
     stop_manager()
     clear_caches()
     gc.collect()
-    comm_cleanup()
 
     yield
 
     reset_manager("memory", {"drop_references": False})
     clear_caches()
     gc.collect()
-    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tlm_adjoint/alias.py
+++ b/tlm_adjoint/alias.py
@@ -25,21 +25,8 @@ __all__ = \
     [
         "Alias",
         "WeakAlias",
-        "gc_disabled",
-        "gc_is_collecting"
+        "gc_disabled"
     ]
-
-
-def gc_callback(phase, info):
-    _gc_phase[0] = phase
-
-
-_gc_phase = ["stop"]
-gc.callbacks.append(gc_callback)
-
-
-def gc_is_collecting():
-    return {"start": True, "stop": False}[_gc_phase[0]]
 
 
 def gc_disabled(fn):

--- a/tlm_adjoint/alias.py
+++ b/tlm_adjoint/alias.py
@@ -25,8 +25,21 @@ __all__ = \
     [
         "Alias",
         "WeakAlias",
-        "gc_disabled"
+        "gc_disabled",
+        "gc_is_collecting"
     ]
+
+
+def gc_callback(phase, info):
+    _gc_phase[0] = phase
+
+
+_gc_phase = ["stop"]
+gc.callbacks.append(gc_callback)
+
+
+def gc_is_collecting():
+    return {"start": True, "stop": False}[_gc_phase[0]]
 
 
 def gc_disabled(fn):

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -18,12 +18,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
 
-from .alias import gc_disabled, gc_is_collecting
-
 from collections.abc import Mapping
 import copy
 import functools
-import gc
 import logging
 try:
     import mpi4py.MPI as MPI
@@ -39,7 +36,6 @@ __all__ = \
         "InterfaceException",
 
         "DEFAULT_COMM",
-        "comm_cleanup",
         "comm_dup",
         "comm_dup_cached",
         "comm_parent",
@@ -172,35 +168,8 @@ if MPI is None:
             return copy.deepcopy(sendobj)
 
 
-_comm_garbage = {}
 _parent_comms = {}
-_dup_comm_id_counter = [0]
 _dup_comms = weakref.WeakValueDictionary()
-
-
-@gc_disabled
-def comm_cleanup(comm=None):
-    if comm is None:
-        comm = DEFAULT_COMM
-
-    if gc_is_collecting():
-        return
-    gc.collect()
-    if MPI is None or MPI.Is_finalized():
-        _comm_garbage.clear()
-        return
-    if comm.allreduce(len(_comm_garbage), op=MPI.MAX) == 0:
-        return
-
-    for dup_comm_id in sorted(_comm_garbage):
-        dup_comm = MPI.Comm.f2py(_comm_garbage[dup_comm_id])
-        difference = MPI.Group.Difference(dup_comm.group, comm.group)
-        try:
-            if difference.size == 0:
-                del _comm_garbage[dup_comm_id]
-                dup_comm.Free()
-        finally:
-            difference.Free()
 
 
 def comm_dup(comm):
@@ -210,15 +179,15 @@ def comm_dup(comm):
     dup_comm = comm.Dup()
     dup_comm_py2f = dup_comm.py2f()
     _parent_comms[dup_comm_py2f] = comm
-    dup_comm_id = dup_comm.allreduce(_dup_comm_id_counter[0], op=MPI.MAX)
-    _dup_comm_id_counter[0] = dup_comm_id + 1
 
-    def finalize_callback(dup_comm_id, dup_comm_py2f):
-        _comm_garbage[dup_comm_id] = dup_comm_py2f
+    def finalize_callback(dup_comm_py2f):
+        if MPI is not None and not MPI.Is_finalized():
+            dup_comm = MPI.Comm.f2py(dup_comm_py2f)
+            dup_comm.Free()
         del _parent_comms[dup_comm_py2f]
 
     weakref.finalize(dup_comm, finalize_callback,
-                     dup_comm_id, dup_comm_py2f)
+                     dup_comm_py2f)
 
     return dup_comm
 

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -230,7 +230,7 @@ def comm_dup_cached(comm):
     comm_py2f = comm.py2f()
     dup_comm = _dup_comms.get(comm_py2f, None)
 
-    if dup_comm is None:
+    if MPI is None or comm.allreduce(0 if dup_comm is None else 1, MPI.MIN) == 0:  # noqa: E501
         dup_comm = comm_dup(comm)
         _dup_comms[comm_py2f] = dup_comm
 


### PR DESCRIPTION
PETSc object destruction no longer leads to collective communication, meaning that the Python garbage collector can be re-enabled with Firedrake.

Also a minor change to how `EquationManager` IDs are defined, `DEFAULT_COMM` is now duplicated, and a bugfix for cached duplicated communicators which are destroyed on a subset of processes.