### PR TITLE
Do not free communicators on destruction

### DIFF
--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -73,16 +73,20 @@ def setup_test():
     # parameters["tlm_adjoint"]["assembly_verification"]["rhs_tolerance"] \
     #     = 1.0e-12
 
+    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
+
     reset_manager("memory", {"drop_references": True})
     stop_manager()
     clear_caches()
-
-    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
+    gc.collect()
+    comm_cleanup()
 
     yield
 
     reset_manager("memory", {"drop_references": False})
     clear_caches()
+    gc.collect()
+    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -35,6 +35,7 @@ import mpi4py.MPI as MPI
 import numpy as np
 from operator import itemgetter
 import os
+import petsc4py.PETSc as PETSc
 import pytest
 import runpy
 import sys
@@ -77,15 +78,17 @@ def setup_test():
     # parameters["tlm_adjoint"]["assembly_verification"]["rhs_tolerance"] \
     #     = 1.0e-12
 
+    logging.getLogger("firedrake").setLevel(logging.INFO)
+    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
+
     gc_enabled = gc.isenabled()
     gc.disable()  # See Firedrake issue #1569
     reset_manager("memory", {"drop_references": True})
     stop_manager()
     clear_caches()
     gc.collect()
-
-    logging.getLogger("firedrake").setLevel(logging.INFO)
-    logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
+    PETSc.garbage_cleanup()
+    comm_cleanup()
 
     yield
 
@@ -94,6 +97,8 @@ def setup_test():
     reset_manager("memory", {"drop_references": False})
     clear_caches()
     gc.collect()
+    PETSc.garbage_cleanup()
+    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tests/firedrake/test_models.py
+++ b/tests/firedrake/test_models.py
@@ -228,7 +228,7 @@ def test_diffusion_1d_timestepping(setup_test, test_leaks,
     J_val = J.value()
     if n_steps == 20:
         J_val_ref = diffusion_ref()
-        assert abs(J_val - J_val_ref) < 1.0e-13
+        assert abs(J_val - J_val_ref) < 1.0e-12
 
     dJs = compute_gradient(J, [T_0, kappa])
 

--- a/tests/numpy/test_base.py
+++ b/tests/numpy/test_base.py
@@ -50,18 +50,22 @@ __all__ = \
 
 @pytest.fixture
 def setup_test():
-    reset_manager("memory", {"drop_references": True})
-    stop_manager()
-    clear_caches()
+    set_default_dtype(np.float64)
 
     logging.getLogger("tlm_adjoint").setLevel(logging.DEBUG)
 
-    set_default_dtype(np.float64)
+    reset_manager("memory", {"drop_references": True})
+    stop_manager()
+    clear_caches()
+    gc.collect()
+    comm_cleanup()
 
     yield
 
     reset_manager("memory", {"drop_references": False})
     clear_caches()
+    gc.collect()
+    comm_cleanup()
 
 
 def seed_test(fn):

--- a/tlm_adjoint/alias.py
+++ b/tlm_adjoint/alias.py
@@ -25,8 +25,21 @@ __all__ = \
     [
         "Alias",
         "WeakAlias",
-        "gc_disabled"
+        "gc_disabled",
+        "gc_is_collecting"
     ]
+
+
+def gc_callback(phase, info):
+    _gc_phase[0] = phase
+
+
+_gc_phase = ["stop"]
+gc.callbacks.append(gc_callback)
+
+
+def gc_is_collecting():
+    return {"start": True, "stop": False}[_gc_phase[0]]
 
 
 def gc_disabled(fn):


### PR DESCRIPTION
As #200, but leave the garbage collector disabled in Firedrake tests.

Freeing of MPI communicators is collective. Internal duplicated communicators are no longer freed on destruction, and instead communicators should be freed with a call to `comm_cleanup`. `comm_cleanup` is written defensively, involves multiple reduction operations, and might perform poorly in some use cases (e.g. many communicators with large size are freed, followed by many calls to `comm_cleanup` on a communicator with small size).

Also a minor change to how `EquationManager` IDs are defined.