### PR TITLE
Free cached duplicated MPI communicators when the original MPI communicator is freed

### DIFF
--- a/tlm_adjoint/eigendecomposition.py
+++ b/tlm_adjoint/eigendecomposition.py
@@ -55,7 +55,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from .interface import check_space_types, comm_parent, function_get_values, \
+from .interface import check_space_types, function_get_values, \
     function_global_size, function_local_size, function_set_values, \
     is_function, space_comm, space_new, space_type_warning
 
@@ -200,9 +200,7 @@ def eigendecompose(space, A_action, *, B_action=None, space_type="primal",
     del X
     N_ev = N if N_eigenvalues is None else N_eigenvalues
 
-    # Use the parent communicator, as we don't want to free the communicator
-    # before PETSc/SLEPc objects have been destroyed
-    comm = comm_parent(space_comm(space))
+    comm = space_comm(space)
 
     A_matrix = PETSc.Mat().createPython(((n, N), (n, N)),
                                         PythonMatrix(A_action),


### PR DESCRIPTION
Before this PR a cached duplicated MPI communicator was freed on destruction of the associated Python object (see #187). This can cause issues due to non-synchronous object destruction on different processes, and may have been causing deadlocks.

With this PR cached duplicated communicators are freed when the original 'parent' communicator is freed. This moves responsibility for freeing communicators to the calling code.

Some consequences:

- The cached duplicated communicators may be retained for longer than they are needed.
- Cached duplicated communicators cannot be used after the parent communicators are freed. Note that `space_comm` and `function_comm` return cached duplicated communicators, and so these now need to be used with more caution.
- The use cases for `comm_parent` are now more limited, since the cached duplicated communicators are freed together with the parent communicator.

Replaces #201, and attempted workaround in #200