### PR TITLE
Firedrake backend: Add PETSc.garbage_cleanup calls

### DIFF
--- a/tlm_adjoint/optimization.py
+++ b/tlm_adjoint/optimization.py
@@ -21,7 +21,7 @@
 from .interface import comm_dup, function_axpy, function_copy, \
     function_get_values, function_is_cached, function_is_checkpointed, \
     function_is_static, function_linf_norm, function_local_size, \
-    function_new, function_set_values, is_function
+    function_new, function_set_values, garbage_cleanup, is_function, space_comm
 
 from .caches import clear_caches, local_caches
 from .functional import Functional
@@ -151,6 +151,7 @@ def minimize_scipy(forward, M0, *, manager=None, **kwargs):
         J[0] = forward(*M)
         if is_function(J[0]):
             J[0] = Functional(_fn=J[0])
+        garbage_cleanup(space_comm(J[0].space()))
         manager.stop()
 
         J_M[1] = M

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -20,7 +20,7 @@
 
 from .interface import DEFAULT_COMM, check_space_types, comm_dup, \
     function_assign, function_copy, function_id, function_is_replacement, \
-    function_name, function_new_tangent_linear, is_function
+    function_name, function_new_tangent_linear, garbage_cleanup, is_function
 
 from .alias import WeakAlias, gc_disabled
 from .binomial_checkpointing import MultistageCheckpointingManager
@@ -1387,6 +1387,7 @@ class EquationManager:
 
                 storage = ReplayStorage(self._blocks, cp_n, n + 1,
                                         transpose_deps=transpose_deps)
+                garbage_cleanup(self._comm)
                 initialize_storage_cp = True
                 storage.update(self._cp.initial_conditions(cp=False,
                                                            refs=True,
@@ -1733,6 +1734,7 @@ class EquationManager:
                 raise ValueError(f"Unexpected checkpointing action: "
                                  f"{cp_action:s}")
 
+        garbage_cleanup(self._comm)
         return tuple(dJ)
 
 

--- a/tlm_adjoint/verification.py
+++ b/tlm_adjoint/verification.py
@@ -22,7 +22,7 @@ from .interface import function_assign, function_axpy, function_copy, \
     function_dtype, function_inner, function_is_cached, \
     function_is_checkpointed, function_is_static, function_linf_norm, \
     function_local_size, function_name, function_new, function_set_values, \
-    is_function
+    garbage_cleanup, is_function, space_comm
 
 from .caches import clear_caches, local_caches
 from .functional import Functional
@@ -47,6 +47,7 @@ def wrapped_forward(forward):
         J = forward(*M)
         if is_function(J):
             J = Functional(_fn=J)
+        garbage_cleanup(space_comm(J.space()))
         return J
 
     return wrapped_forward


### PR DESCRIPTION
Add `PETSc.garbage_cleanup` calls
- After an adjoint calculation
- When loading checkpoint data
- After running the forward in verification functions
- After running the forward in `minimize_scipy`