### PR TITLE
Reorder Equation constructor arguments

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -188,7 +188,7 @@ def forward(psi_0, psi_n_file=None):
         psi_np1, bc,
         solver_parameters={"ksp_type": "preonly",
                            "pc_type": "lu"})
-    cycle = AssignmentSolver(psi_np1, psi_n)
+    cycle = Assignment(psi_n, psi_np1)
 
     if psi_n_file is not None:
         psi_n_file.write(psi_n, time=0.0)
@@ -222,9 +222,8 @@ The key changes which appear here are
   \item \texttt{start\_manager} and \texttt{stop\_manager}, which enable and
     disable the underlying \texttt{EquationManager}. For further details see
     section \ref{sect:EquationManager_state}.
-  \item The instantiation of \texttt{AssignmentSolver} and
-    \texttt{EquationSolver} objects. For further details see section
-    \ref{sect:Equation}.
+  \item The instantiation of \texttt{Assignment} and \texttt{EquationSolver}
+    objects. For further details see section \ref{sect:Equation}.
   \item The use of a subclass of \texttt{Equation} to define a custom equation.
     For further details see section \ref{sect:custom}.
   \item The \texttt{static} keyword when initialising certain \texttt{Constant}
@@ -325,7 +324,7 @@ def forward(psi_0, psi_n_file=None):
         psi_np1, bc,
         solver_parameters={"ksp_type": "preonly",
                            "pc_type": "lu"})
-    cycle = AssignmentSolver(psi_np1, psi_n)
+    cycle = Assignment(psi_n, psi_np1)
 
     if psi_n_file is not None:
         psi_n_file.write(psi_n, time=0.0)
@@ -526,15 +525,15 @@ The intended use of a \texttt{NullSolver} is in the definition of
 \texttt{tangent\_linear} methods of \texttt{Equation} classes (see section
 \ref{sect:tangent_linear}).
 
-\subsubsection{\texttt{AssignmentSolver}}
+\subsubsection{\texttt{Assignment}}
 
-An \texttt{AssignmentSolver} represents an assignment
+An \texttt{Assignment} represents an assignment
 \begin{equation*}
   x = y.
 \end{equation*}
-An \texttt{AssignmentSolver} can be instantiated via
+An \texttt{Assignment} can be instantiated via
 \begin{lstlisting}
-eq = AssignmentSolver(y, x)
+eq = Assignment(x, y)
 \end{lstlisting}
 where \texttt{x} is the function being solved for.
 

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -787,9 +787,9 @@ supplied to define the maximum permitted distance of a coordinate from a cell.
 In parallel the node-node graph associated with the discrete function space for
 \texttt{y} must have no edges between nodes owned by different processes. In
 parallel the \texttt{InterpolationSolver} can be combined with the
-\texttt{LocalProjectionSolver} in order to project functions in more general
-function spaces onto an appropriate discontinuous Galerkin function space,
-prior to interpolation.
+\texttt{LocalProjection} in order to project functions in more general function
+spaces onto an appropriate discontinuous Galerkin function space, prior to
+interpolation.
 
 \subsubsection{\texttt{PointInterpolation}}
 
@@ -816,15 +816,15 @@ In parallel there are similar node-node graph restrictions for the discrete
 function space for \texttt{y} to those for the \texttt{InterpolationSolver}
 class (section \ref{sect:InterpolationSolver}).
 
-\subsubsection{\texttt{LocalProjectionSolver}}
+\subsubsection{\texttt{LocalProjection}}
 
-A \texttt{LocalProjectionSolver} is a subclass of the \texttt{EquationSolver}
-class, and represents the solution of a projection problem, of the same type as
+A \texttt{LocalProjection} is a subclass of the \texttt{EquationSolver} class,
+and represents the solution of a projection problem, of the same type as
 represented using a \texttt{Projection}, but using a local mass matrix solver.
 
-The \texttt{LocalProjectionSolver} constructor has the form
+The \texttt{LocalProjection} constructor has the form
 \begin{lstlisting}
-def __init__(self, rhs, x, form_compiler_parameters=None,
+def __init__(self, x, rhs, *, form_compiler_parameters=None,
              cache_jacobian=None, cache_rhs_assembly=None,
              match_quadrature=None, defer_adjoint_assembly=None):
 \end{lstlisting}
@@ -857,15 +857,15 @@ optional \texttt{tolerance} argument may be supplied, and this is passed to the
 Firedrake \texttt{MeshGeometry.locate\_cell} method when locating the cells, in
 the mesh for \texttt{y}, containing the coordinates \texttt{X\_coords}.
 
-\subsubsection{\texttt{LocalProjectionSolver}}
+\subsubsection{\texttt{LocalProjection}}
 
-A \texttt{LocalProjectionSolver} is a subclass of the \texttt{EquationSolver}
-class, and represents the solution of a projection problem, of the same type as
+A \texttt{LocalProjection} is a subclass of the \texttt{EquationSolver} class,
+and represents the solution of a projection problem, of the same type as
 represented using a \texttt{Projection}, but using a local mass matrix solver.
 
-The \texttt{LocalProjectionSolver} constructor has the form
+The \texttt{LocalProjection} constructor has the form
 \begin{lstlisting}
-def __init__(self, rhs, x, form_compiler_parameters=None,
+def __init__(self, x, rhs, *, form_compiler_parameters=None,
              cache_jacobian=None, cache_rhs_assembly=None,
              match_quadrature=None, defer_adjoint_assembly=None):
 \end{lstlisting}

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -550,16 +550,16 @@ eq = ScaleSolver(alpha, y, x)
 \end{lstlisting}
 where \texttt{x} is the function being solved for.
 
-\subsubsection{\texttt{AxpySolver}}
+\subsubsection{\texttt{Axpy}}
 
-An \texttt{AxpySolver} represents the equation
+An \texttt{Axpy} represents the equation
 \begin{equation*}
   z = y + \alpha x,
 \end{equation*}
-where $\alpha$ is a scalar constant. An \texttt{AxpySolver} can be instantiated
+where $\alpha$ is a scalar constant. An \texttt{Axpy} can be instantiated
 via
 \begin{lstlisting}
-eq = AxpySolver(y, alpha, x, z)
+eq = Axpy(z, y, alpha, x)
 \end{lstlisting}
 where \texttt{z} is the function being solved for.
 

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -550,16 +550,16 @@ eq = Axpy(z, y, alpha, x)
 \end{lstlisting}
 where \texttt{z} is the function being solved for.
 
-\subsubsection{\texttt{LinearCombinationSolver}}
+\subsubsection{\texttt{LinearCombination}}
 
-A \texttt{LinearCombinationSolver} represents the equation
+A \texttt{LinearCombination} represents the equation
 \begin{equation*}
   x = \sum_{i = 1}^N \alpha_i y_i,
 \end{equation*}
-where the $\alpha_i$ are scalar constants. A \texttt{LinearCombinationSolver}
-is instantiated via
+where the $\alpha_i$ are scalar constants. A \texttt{LinearCombination} is
+instantiated via
 \begin{lstlisting}
-eq = LinearCombinationSolver(x, (alpha_1, y_1), (alpha_2, y_2), [...])
+eq = LinearCombination(x, (alpha_1, y_1), (alpha_2, y_2), [...])
 \end{lstlisting}
 where \texttt{x} is the function being solved for, and where an arbitrary
 number of tuples may be supplied as further arguments.

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -847,7 +847,7 @@ is a vector whose elements are the discrete degrees of freedom for a continuous
 scalar-valued function $\xi \in W$, and where $P$ is a matrix. A
 \texttt{PointInterpolation} can be instantiated via
 \begin{lstlisting}
-eq = PointInterpolation(y, X, X_coords=X_coords)
+eq = PointInterpolation(X, y, X_coords=X_coords)
 \end{lstlisting}
 where \texttt{X} is a sequence of scalars being solved for (for example each as
 returned by the \texttt{new\_scalar\_function} function -- see section

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -731,12 +731,12 @@ where \texttt{xi} and \texttt{psi} are \texttt{Function} objects corresponding
 to $\xi$ and $\psi$ in the equation above. Remaining arguments are passed
 directly to the \texttt{DirichletBC} constructor.
 
-\subsubsection{\texttt{AssembleSolver}}\label{sect:AssembleSolver}
+\subsubsection{\texttt{Assembly}}\label{sect:Assembly}
 
-An \texttt{AssembleSolver} represents the assembly of a rank zero form. The
-\texttt{AssembleSolver} constructor has the form
+An \texttt{Assembly} represents the assembly of a rank zero form. The
+\texttt{Assembly} constructor has the form
 \begin{lstlisting}
-def __init__(self, rhs, x, form_compiler_parameters=None,
+def __init__(self, x, rhs, *, form_compiler_parameters=None,
              match_quadrature=None):
 \end{lstlisting}
 with constructor arguments
@@ -749,7 +749,7 @@ with constructor arguments
   \item \texttt{match\_quadrature}, whether to use the same quadrature degree
     in all finite element assembly. May be required for discrete consistency if
     incomplete quadrature is used. Defaults to
-    \texttt{parameters["tlm\_adjoint"]}\texttt{["AssembleSolver"]}\texttt{["match\_quadrature"]},
+    \texttt{parameters["tlm\_adjoint"]}\texttt{["Assembly"]}\texttt{["match\_quadrature"]},
     which by default is false.
 \end{itemize}
 
@@ -808,7 +808,7 @@ eq = PointInterpolationSolver(y, X, X_coords=X_coords)
 \end{lstlisting}
 where \texttt{X} is a sequence of scalars being solved for (for example each as
 returned by the \texttt{new\_scalar\_function} function -- see section
-\ref{sect:AssembleSolver}) and \texttt{X\_coords} is a NumPy array defining the
+\ref{sect:Assembly}) and \texttt{X\_coords} is a NumPy array defining the
 coordinates at which to interpolate the \texttt{Function} \texttt{y}. An
 optional \texttt{tolerance} argument may be supplied to define the maximum
 permitted distance of a coordinate from a cell.
@@ -853,7 +853,7 @@ eq = PointInterpolationSolver(y, X, X_coords=X_coords)
 \end{lstlisting}
 where \texttt{X} is a sequence of scalars being solved for (for example each as
 returned by the \texttt{new\_scalar\_function} function -- see section
-\ref{sect:AssembleSolver}) and \texttt{X\_coords} is a NumPy array defining the
+\ref{sect:Assembly}) and \texttt{X\_coords} is a NumPy array defining the
 coordinates at which to interpolate the \texttt{Function} \texttt{y}. An
 optional \texttt{tolerance} argument may be supplied, and this is passed to the
 Firedrake \texttt{MeshGeometry.locate\_cell} method when locating the cells, in
@@ -1646,7 +1646,7 @@ J_val = J.value()
 Internally a \texttt{Functional} object stores the value of the
 \texttt{Functional} in an appropriate function. By default this internal
 function is defined to be a function as returned by
-\texttt{new\_scalar\_function()} (see section \ref{sect:AssembleSolver}).
+\texttt{new\_scalar\_function()} (see section \ref{sect:Assembly}).
 
 In advanced usage the function space for the internal function may be specified
 \begin{lstlisting}

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -148,8 +148,8 @@ def forward(psi_0, psi_n_file=None):
     psi_n = Function(space, name="psi_n")
     psi_np1 = Function(space, name="psi_np1")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(function_space(x), 0.0, "on_boundary")
 
@@ -177,9 +177,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    InteriorAssignmentSolver(psi_0, psi_n).solve()
+    InteriorAssignment(psi_n, psi_0).solve()
 
     eq = EquationSolver(
         inner(trial / dt, test) * dx
@@ -284,8 +284,8 @@ def forward(psi_0, psi_n_file=None):
     psi_n = Function(space, name="psi_n")
     psi_np1 = Function(space, name="psi_np1")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(function_space(x), 0.0, "on_boundary")
 
@@ -313,9 +313,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    InteriorAssignmentSolver(psi_0, psi_n).solve()
+    InteriorAssignment(psi_n, psi_0).solve()
 
     eq = EquationSolver(
         inner(trial / dt, test) * dx
@@ -2445,8 +2445,8 @@ def forward(psi_0, psi_n_file=None):
     system = TimeSystem()
     psi = TimeFunction(levels, space, name="psi")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(function_space(x), 0.0, "on_boundary")
 
@@ -2474,9 +2474,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    system.add_solve(InteriorAssignmentSolver(psi_0, psi[0]))
+    system.add_solve(InteriorAssignment(psi[0], psi_0))
 
     system.add_solve(inner(trial / dt, test) * dx
                      + inner(kappa * grad(trial), grad(test)) * dx

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -691,10 +691,10 @@ If the \texttt{adjoint\_solver\_parameters} argument is not passed to the
 \texttt{EquationSolver} constructor then the null space and transpose null
 space are swapped in the adjoint solver parameters.
 
-\subsubsection{\texttt{ProjectionSolver}}
+\subsubsection{\texttt{Projection}}
 
-A \texttt{ProjectionSolver} is a subclass of the \texttt{EquationSolver} class,
-and represents either the equation
+A \texttt{Projection} is a subclass of the \texttt{EquationSolver} class, and
+represents either the equation
 \begin{equation*}
   \int_\Omega \phi^* \cdot \psi = b \left( \phi^* \right) \quad \forall \phi \in V,
 \end{equation*}
@@ -704,9 +704,9 @@ where $\psi \in V$ and $b$ is a linear form, or
 \end{equation*}
 where $\xi$ is a given expression.
 
-The \texttt{ProjectionSolver} constructor has the form
+The \texttt{Projection} constructor has the form
 \begin{lstlisting}
-def __init__(self, rhs, x, *args, **kwargs):
+def __init__(self, x, rhs, *args, **kwargs):
 \end{lstlisting}
 where \texttt{rhs} is a \texttt{ufl.classes.Form} (for the first case above) or
 expression (for the second), and \texttt{x} is the \texttt{Function} being
@@ -821,8 +821,7 @@ class (section \ref{sect:InterpolationSolver}).
 
 A \texttt{LocalProjectionSolver} is a subclass of the \texttt{EquationSolver}
 class, and represents the solution of a projection problem, of the same type as
-represented using the \texttt{ProjectionSolver}, but using a local mass matrix
-solver.
+represented using a \texttt{Projection}, but using a local mass matrix solver.
 
 The \texttt{LocalProjectionSolver} constructor has the form
 \begin{lstlisting}
@@ -863,8 +862,7 @@ the mesh for \texttt{y}, containing the coordinates \texttt{X\_coords}.
 
 A \texttt{LocalProjectionSolver} is a subclass of the \texttt{EquationSolver}
 class, and represents the solution of a projection problem, of the same type as
-represented using the \texttt{ProjectionSolver}, but using a local mass matrix
-solver.
+represented using a \texttt{Projection}, but using a local mass matrix solver.
 
 The \texttt{LocalProjectionSolver} constructor has the form
 \begin{lstlisting}

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -175,7 +175,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 
@@ -311,7 +311,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 
@@ -505,23 +505,23 @@ or a dependency of an \texttt{Equation}.
 
 \subsection{Built-in \texttt{Equation} classes: All backends}
 
-\subsubsection{\texttt{NullSolver}}
+\subsubsection{\texttt{ZeroAssignment}}
 
-A \texttt{NullSolver} represents the trivial equation
+A \texttt{ZeroAssignment} represents the trivial equation
 \begin{equation*}
   x = 0.
 \end{equation*}
-A \texttt{NullSolver} can be instantiated via
+A \texttt{ZeroAssignment} can be instantiated via
 \begin{lstlisting}
-eq = NullSolver(x)
+eq = ZeroAssignment(x)
 \end{lstlisting}
 where \texttt{x} is the function being solved for, or
 \begin{lstlisting}
-eq = NullSolver(X)
+eq = ZeroAssignment(X)
 \end{lstlisting}
 where \texttt{X} is a sequence of functions being solved for.
 
-The intended use of a \texttt{NullSolver} is in the definition of
+The intended use of a \texttt{ZeroAssignment} is in the definition of
 \texttt{tangent\_linear} methods of \texttt{Equation} classes (see section
 \ref{sect:tangent_linear}).
 
@@ -2472,7 +2472,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1519,30 +1519,20 @@ eq = NormSqSolver(y, x, alpha=alpha, M=M)
 \end{lstlisting}
 where \texttt{x} is the function being solved for.
 
-\subsubsection{\texttt{MatrixActionRHS} and \texttt{MatrixActionSolver}}
+\subsubsection{\texttt{MatrixActionRHS}}
 
 A \texttt{MatrixActionRHS} is a \texttt{RHS} representing a right-hand-side
 term resulting from a matrix action,
 \begin{equation*}
   b = A y.
 \end{equation*}
-A \texttt{MatrixActionSolver} is a \texttt{LinearEquation} representing
-\begin{equation*}
-  x = A y,
-\end{equation*}
-solving for $x$.
 
 A \texttt{MatrixActionRHS} can be instantiated via
 \begin{lstlisting}
 b = MatrixActionRHS(A, Y)
 \end{lstlisting}
 where \texttt{A} is a \texttt{Matrix} defining the matrix $A$, and \texttt{Y}
-is a function, or a sequence of functions, defining $y$. A
-\texttt{MatrixActionSolver} can be instantiated via
-\begin{lstlisting}
-eq = MatrixActionSolver(Y, A, X)
-\end{lstlisting}
-where \texttt{X} is a function, or a sequence of functions, being solved for.
+is a function, or a sequence of functions, defining $y$.
 
 \section{Custom storage}
 

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -763,20 +763,19 @@ associated with the function.
 
 \subsection{Built-in \texttt{Equation} classes: FEniCS}
 
-\subsubsection{\texttt{InterpolationSolver}}\label{sect:InterpolationSolver}
+\subsubsection{\texttt{Interpolation}}\label{sect:Interpolation}
 
-An \texttt{InterpolationSolver} represents consistent interpolation of a given
-scalar-valued function $\xi \in W$ onto a function space $V$, represented in
-the form of an equation
+An \texttt{Interpolation} represents interpolation of a given scalar-valued
+function $\xi \in W$ onto a function space $V$, represented in the form of an
+equation
 \begin{equation*}
   \tilde{\psi} = P \tilde{\xi},
 \end{equation*}
 where $\tilde{\psi}$ and $\tilde{\xi}$ are vectors whose elements are the
-discrete degrees of freedom for scalar-valued functions
-$\psi \in V, \xi \in W$, and $P$ is a matrix. An \texttt{InterpolationSolver}
-can be instantiated via
+discrete degrees of freedom for scalar-valued functions $\psi \in V, \xi \in
+W$, and $P$ is a matrix. An \texttt{Interpolation} can be instantiated via
 \begin{lstlisting}
-eq = InterpolationSolver(y, x)
+eq = Interpolation(x, y)
 \end{lstlisting}
 where \texttt{x} is the \texttt{Function} being solved for, and \texttt{y} the
 \texttt{Function} being interpolated. An optional \texttt{x\_coords} argument
@@ -786,7 +785,7 @@ supplied to define the maximum permitted distance of a coordinate from a cell.
 
 In parallel the node-node graph associated with the discrete function space for
 \texttt{y} must have no edges between nodes owned by different processes. In
-parallel the \texttt{InterpolationSolver} can be combined with the
+parallel the \texttt{Interpolation} can be combined with the
 \texttt{LocalProjection} in order to project functions in more general function
 spaces onto an appropriate discontinuous Galerkin function space, prior to
 interpolation.
@@ -813,8 +812,8 @@ optional \texttt{tolerance} argument may be supplied to define the maximum
 permitted distance of a coordinate from a cell.
 
 In parallel there are similar node-node graph restrictions for the discrete
-function space for \texttt{y} to those for the \texttt{InterpolationSolver}
-class (section \ref{sect:InterpolationSolver}).
+function space for \texttt{y} to those for the \texttt{Interpolation} class
+(section \ref{sect:Interpolation}).
 
 \subsubsection{\texttt{LocalProjection}}
 

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -713,19 +713,19 @@ expression (for the second), and \texttt{x} is the \texttt{Function} being
 solved for. Remaining constructor arguments are as for the
 \texttt{EquationSolver} class.
 
-\subsubsection{\texttt{DirichletBCSolver}}
+\subsubsection{\texttt{DirichletBCApplication}}
 
-A \texttt{DirichletBCSolver} represents the application of a strong Dirichlet
-boundary condition, represented in the form of an equation
+A \texttt{DirichletBCApplication} represents the application of a strong
+Dirichlet boundary condition, represented in the form of an equation
 \begin{equation*}
   \tilde{\psi} = P \tilde{\xi},
 \end{equation*}
 where $\tilde{\psi}$ and $\tilde{\xi}$ are vectors whose elements are the
 discrete degrees of freedom for functions $\psi, \xi \in V$, and $P$ is a
-$\left( 0, 1 \right)$-matrix. A \texttt{DirichletBCSolver} can be instantiated
-via
+$\left( 0, 1 \right)$-matrix. A \texttt{DirichletBCApplication} can be
+instantiated via
 \begin{lstlisting}
-eq = DirichletBCSolver(xi, psi, *args, **kwargs)
+eq = DirichletBCApplication(psi, xi, *args, **kwargs)
 \end{lstlisting}
 where \texttt{xi} and \texttt{psi} are \texttt{Function} objects corresponding
 to $\xi$ and $\psi$ in the equation above. Remaining arguments are passed

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -791,20 +791,19 @@ parallel the \texttt{InterpolationSolver} can be combined with the
 function spaces onto an appropriate discontinuous Galerkin function space,
 prior to interpolation.
 
-\subsubsection{\texttt{PointInterpolationSolver}}
+\subsubsection{\texttt{PointInterpolation}}
 
-With the FEniCS backend, a \texttt{PointInterpolationSolver} represents
-consistent interpolation of a given scalar-valued function $\xi \in W$ onto a
-given set of points,
+With the FEniCS backend, a \texttt{PointInterpolation} represents interpolation
+of a given scalar-valued function $\xi \in W$ onto a given set of points,
 \begin{equation*}
   \tilde{\psi} = P \tilde{\xi},
 \end{equation*}
 where the elements of $\tilde{\psi}$ are the interpolated values, $\tilde{\xi}$
 is a vector whose elements are the discrete degrees of freedom for a
 scalar-valued function $\xi \in W$, and where $P$ is a matrix. A
-\texttt{PointInterpolationSolver} can be instantiated via
+\texttt{PointInterpolation} can be instantiated via
 \begin{lstlisting}
-eq = PointInterpolationSolver(y, X, X_coords=X_coords)
+eq = PointInterpolation(X, y, X_coords=X_coords)
 \end{lstlisting}
 where \texttt{X} is a sequence of scalars being solved for (for example each as
 returned by the \texttt{new\_scalar\_function} function -- see section
@@ -835,20 +834,20 @@ Remaining constructor arguments are as for the \texttt{EquationSolver} class.
 
 \subsection{Built-in \texttt{Equation} classes: Firedrake}
 
-\subsubsection{\texttt{PointInterpolationSolver}}
+\subsubsection{\texttt{PointInterpolation}}
 
-With the Firedrake backend, a \texttt{PointInterpolationSolver} represents
-consistent interpolation of a given continuous scalar-valued function
-$\xi \in W$ onto a given set of points,
+With the Firedrake backend, a \texttt{PointInterpolation} represents
+interpolation of a given continuous scalar-valued function $\xi \in W$ onto a
+given set of points,
 \begin{equation*}
   \tilde{\psi} = P \tilde{\xi},
 \end{equation*}
 where the elements of $\tilde{\psi}$ are the interpolated values, $\tilde{\xi}$
 is a vector whose elements are the discrete degrees of freedom for a continuous
 scalar-valued function $\xi \in W$, and where $P$ is a matrix. A
-\texttt{PointInterpolationSolver} can be instantiated via
+\texttt{PointInterpolation} can be instantiated via
 \begin{lstlisting}
-eq = PointInterpolationSolver(y, X, X_coords=X_coords)
+eq = PointInterpolation(y, X, X_coords=X_coords)
 \end{lstlisting}
 where \texttt{X} is a sequence of scalars being solved for (for example each as
 returned by the \texttt{new\_scalar\_function} function -- see section

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1499,26 +1499,6 @@ eq = InnerProduct(x, y, z, alpha=alpha, M=M)
 \end{lstlisting}
 where \texttt{x} is the function being solved for.
 
-\subsubsection{\texttt{NormSqRHS} and \texttt{NormSqSolver}}
-
-A \texttt{NormSqRHS} is an \texttt{InnerProductRHS}, and a
-\texttt{NormSqSolver} is an \texttt{InnerProduct}, each for the case where the
-$y_j$ and $z_k$ correspond to the degrees of freedom for the same function.
-
-A \texttt{NormSqRHS} can be instantiated via
-\begin{lstlisting}
-b = NormSqRHS(y, alpha=alpha, M=M)
-\end{lstlisting}
-where \texttt{y} is a function whose degrees of freedom are the $y_j$,
-\texttt{alpha} is a given floating point value defining $\alpha$ (set equal to
-$1.0$ if not supplied), and \texttt{M} is a \texttt{Matrix} whose elements are
-the $M_{j,k}$ (set equal to an identity matrix if not supplied). A
-\texttt{NormSqSolver} can be instantiated via
-\begin{lstlisting}
-eq = NormSqSolver(y, x, alpha=alpha, M=M)
-\end{lstlisting}
-where \texttt{x} is the function being solved for.
-
 \subsubsection{\texttt{MatrixActionRHS}}
 
 A \texttt{MatrixActionRHS} is a \texttt{RHS} representing a right-hand-side

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1467,7 +1467,7 @@ The \texttt{drop\_references} method must call the base class
 
 \subsection{Built-in linear algebra classes}
 
-\subsubsection{\texttt{InnerProductRHS} and \texttt{InnerProductSolver}}
+\subsubsection{\texttt{InnerProductRHS} and \texttt{InnerProduct}}
 
 An \texttt{InnerProductRHS} is a \texttt{RHS} representing a right-hand-side
 term of the form
@@ -1478,7 +1478,7 @@ Here the $z_j$ and $y_k$ are the degrees of freedom for two functions, which
 may be the same function. $b_i$ are the degrees of freedom for the resulting
 right-hand-side term. The $M_{j,k}$ are the elements of some given matrix
 (which should typically be Hermitian positive definite), and $\alpha$ is some
-scalar constant. An \texttt{InnerProductSolver} is a \texttt{LinearEquation}
+scalar constant. An \texttt{InnerProduct} is a \texttt{LinearEquation}
 representing
 \begin{equation*}
   x_i = \alpha \sum_{j,k} z_j^* M_{j,k} y_k,
@@ -1493,18 +1493,17 @@ where \texttt{y} and \texttt{z} are each functions whose degrees of freedom are
 the $y_j$ and $z_k$, \texttt{alpha} is a given floating point value defining
 $\alpha$ (set equal to $1.0$ if not supplied), and \texttt{M} is a
 \texttt{Matrix} whose elements are the $M_{j,k}$ (set equal to an identity
-matrix if not supplied). An \texttt{InnerProductSolver} can be instantiated via
+matrix if not supplied). An \texttt{InnerProduct} can be instantiated via
 \begin{lstlisting}
-eq = InnerProductSolver(y, z, x, alpha=alpha, M=M)
+eq = InnerProduct(x, y, z, alpha=alpha, M=M)
 \end{lstlisting}
 where \texttt{x} is the function being solved for.
 
 \subsubsection{\texttt{NormSqRHS} and \texttt{NormSqSolver}}
 
 A \texttt{NormSqRHS} is an \texttt{InnerProductRHS}, and a
-\texttt{NormSqSolver} is an \texttt{InnerProductSolver}, each for the case
-where the $y_j$ and $z_k$ correspond to the degrees of freedom for the same
-function.
+\texttt{NormSqSolver} is an \texttt{InnerProduct}, each for the case where the
+$y_j$ and $z_k$ correspond to the degrees of freedom for the same function.
 
 A \texttt{NormSqRHS} can be instantiated via
 \begin{lstlisting}

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1170,13 +1170,13 @@ where $A$ is a matrix and the $b_i$ are independent of $x$.
 
 The \texttt{LinearEquation} constructor has the form
 \begin{lstlisting}
-def __init__(self, B, X, *, A=None, adj_type=None):
+def __init__(self, X, B, *, A=None, adj_type=None):
 \end{lstlisting}
 with constructor arguments
 \begin{itemize}
+  \item \texttt{X}, a function, or a sequence of functions, defining $x$.
   \item \texttt{B}, a \texttt{RHS}, or a sequence of \texttt{RHS} objects,
     defining the $b_i$.
-  \item \texttt{X}, a function, or a sequence of functions, defining $x$.
   \item \texttt{A}, a \texttt{Matrix}. If not provided $A$ is an identity
     matrix.
   \item \texttt{adj\_type}, as for the \texttt{Equation} constructor. Defaults

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -537,19 +537,6 @@ eq = Assignment(x, y)
 \end{lstlisting}
 where \texttt{x} is the function being solved for.
 
-\subsubsection{\texttt{ScaleSolver}}
-
-A \texttt{ScaleSolver} represents the equation
-\begin{equation*}
-  x = \alpha y,
-\end{equation*}
-where $\alpha$ is a scalar constant. A \texttt{ScaleSolver} can be instantiated
-via
-\begin{lstlisting}
-eq = ScaleSolver(alpha, y, x)
-\end{lstlisting}
-where \texttt{x} is the function being solved for.
-
 \subsubsection{\texttt{Axpy}}
 
 An \texttt{Axpy} represents the equation

--- a/examples/fenics/diffusion/diffusion.py
+++ b/examples/fenics/diffusion/diffusion.py
@@ -70,12 +70,12 @@ def forward(kappa, manager=None, output_filename=None):
                                                "preconditioner": "sor",
                                                "krylov_solver": {"absolute_tolerance": 1.0e-16,  # noqa: E501
                                                                  "relative_tolerance": 1.0e-14}})  # noqa: E501
-    cycle = AssignmentSolver(Psi_np1, Psi_n)
+    cycle = Assignment(Psi_n, Psi_np1)
 
     if output_filename is not None:
         f = File(output_filename, "compressed")
 
-    AssignmentSolver(Psi_0, Psi_n).solve(manager=manager)
+    Assignment(Psi_n, Psi_0).solve(manager=manager)
     if output_filename is not None:
         f << (Psi_n, 0.0)
     for n in range(N):

--- a/examples/fenics/manual/diffusion_adjoint.py
+++ b/examples/fenics/manual/diffusion_adjoint.py
@@ -29,8 +29,8 @@ def forward(psi_0, psi_n_file=None):
     psi_n = Function(space, name="psi_n")
     psi_np1 = Function(space, name="psi_np1")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(function_space(x), 0.0, "on_boundary")
 
@@ -58,9 +58,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    InteriorAssignmentSolver(psi_0, psi_n).solve()
+    InteriorAssignment(psi_n, psi_0).solve()
 
     eq = EquationSolver(
         inner(trial / dt, test) * dx

--- a/examples/fenics/manual/diffusion_adjoint.py
+++ b/examples/fenics/manual/diffusion_adjoint.py
@@ -56,7 +56,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 

--- a/examples/fenics/manual/diffusion_adjoint.py
+++ b/examples/fenics/manual/diffusion_adjoint.py
@@ -68,7 +68,7 @@ def forward(psi_0, psi_n_file=None):
         == inner(psi_n / dt, test) * dx,
         psi_np1, bc,
         solver_parameters={"linear_solver": "direct"})
-    cycle = AssignmentSolver(psi_np1, psi_n)
+    cycle = Assignment(psi_n, psi_np1)
 
     if psi_n_file is not None:
         psi_n_file << (psi_n, 0.0)

--- a/examples/fenics/manual/diffusion_adjoint_timestepping.py
+++ b/examples/fenics/manual/diffusion_adjoint_timestepping.py
@@ -58,7 +58,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 

--- a/examples/fenics/manual/diffusion_adjoint_timestepping.py
+++ b/examples/fenics/manual/diffusion_adjoint_timestepping.py
@@ -31,8 +31,8 @@ def forward(psi_0, psi_n_file=None):
     system = TimeSystem()
     psi = TimeFunction(levels, space, name="psi")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(function_space(x), 0.0, "on_boundary")
 
@@ -60,9 +60,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    system.add_solve(InteriorAssignmentSolver(psi_0, psi[0]))
+    system.add_solve(InteriorAssignment(psi[0], psi_0))
 
     system.add_solve(inner(trial / dt, test) * dx
                      + inner(kappa * grad(trial), grad(test)) * dx

--- a/examples/fenics/manual/diffusion_hessian.py
+++ b/examples/fenics/manual/diffusion_hessian.py
@@ -56,7 +56,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 

--- a/examples/fenics/manual/diffusion_hessian.py
+++ b/examples/fenics/manual/diffusion_hessian.py
@@ -29,8 +29,8 @@ def forward(psi_0, psi_n_file=None):
     psi_n = Function(space, name="psi_n")
     psi_np1 = Function(space, name="psi_np1")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(x.function_space(), 0.0, "on_boundary")
 
@@ -58,9 +58,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    InteriorAssignmentSolver(psi_0, psi_n).solve()
+    InteriorAssignment(psi_n, psi_0).solve()
 
     eq = EquationSolver(
         inner(trial / dt, test) * dx

--- a/examples/fenics/manual/diffusion_hessian.py
+++ b/examples/fenics/manual/diffusion_hessian.py
@@ -68,7 +68,7 @@ def forward(psi_0, psi_n_file=None):
         == inner(psi_n / dt, test) * dx,
         psi_np1, bc,
         solver_parameters={"linear_solver": "direct"})
-    cycle = AssignmentSolver(psi_np1, psi_n)
+    cycle = Assignment(psi_n, psi_np1)
 
     if psi_n_file is not None:
         psi_n_file << (psi_n, 0.0)

--- a/examples/firedrake/diffusion/diffusion.py
+++ b/examples/firedrake/diffusion/diffusion.py
@@ -72,12 +72,12 @@ def forward(kappa, manager=None, output_filename=None):
                                                "pc_type": "sor",
                                                "ksp_rtol": 1.0e-14,
                                                "ksp_atol": 1.0e-16})
-    cycle = AssignmentSolver(Psi_np1, Psi_n)
+    cycle = Assignment(Psi_n, Psi_np1)
 
     if output_filename is not None:
         f = File(output_filename)
 
-    AssignmentSolver(Psi_0, Psi_n).solve(manager=manager)
+    Assignment(Psi_n, Psi_0).solve(manager=manager)
     if output_filename is not None:
         f.write(Psi_n, time=0.0)
     for n in range(N):

--- a/examples/firedrake/manual/diffusion_adjoint.py
+++ b/examples/firedrake/manual/diffusion_adjoint.py
@@ -29,8 +29,8 @@ def forward(psi_0, psi_n_file=None):
     psi_n = Function(space, name="psi_n")
     psi_np1 = Function(space, name="psi_np1")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(function_space(x), 0.0, "on_boundary")
 
@@ -58,9 +58,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    InteriorAssignmentSolver(psi_0, psi_n).solve()
+    InteriorAssignment(psi_n, psi_0).solve()
 
     eq = EquationSolver(
         inner(trial / dt, test) * dx

--- a/examples/firedrake/manual/diffusion_adjoint.py
+++ b/examples/firedrake/manual/diffusion_adjoint.py
@@ -69,7 +69,7 @@ def forward(psi_0, psi_n_file=None):
         psi_np1, bc,
         solver_parameters={"ksp_type": "preonly",
                            "pc_type": "lu"})
-    cycle = AssignmentSolver(psi_np1, psi_n)
+    cycle = Assignment(psi_n, psi_np1)
 
     if psi_n_file is not None:
         psi_n_file.write(psi_n, time=0.0)

--- a/examples/firedrake/manual/diffusion_adjoint.py
+++ b/examples/firedrake/manual/diffusion_adjoint.py
@@ -56,7 +56,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 

--- a/examples/firedrake/manual/diffusion_adjoint_timestepping.py
+++ b/examples/firedrake/manual/diffusion_adjoint_timestepping.py
@@ -58,7 +58,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 

--- a/examples/firedrake/manual/diffusion_adjoint_timestepping.py
+++ b/examples/firedrake/manual/diffusion_adjoint_timestepping.py
@@ -31,8 +31,8 @@ def forward(psi_0, psi_n_file=None):
     system = TimeSystem()
     psi = TimeFunction(levels, space, name="psi")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(function_space(x), 0.0, "on_boundary")
 
@@ -60,9 +60,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    system.add_solve(InteriorAssignmentSolver(psi_0, psi[0]))
+    system.add_solve(InteriorAssignment(psi[0], psi_0))
 
     system.add_solve(inner(trial / dt, test) * dx
                      + inner(kappa * grad(trial), grad(test)) * dx

--- a/examples/firedrake/manual/diffusion_hessian.py
+++ b/examples/firedrake/manual/diffusion_hessian.py
@@ -29,8 +29,8 @@ def forward(psi_0, psi_n_file=None):
     psi_n = Function(space, name="psi_n")
     psi_np1 = Function(space, name="psi_np1")
 
-    class InteriorAssignmentSolver(Equation):
-        def __init__(self, y, x):
+    class InteriorAssignment(Equation):
+        def __init__(self, x, y):
             super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
             self._bc = DirichletBC(function_space(x), 0.0, "on_boundary")
 
@@ -58,9 +58,9 @@ def forward(psi_0, psi_n_file=None):
             if tlm_y is None:
                 return NullSolver(tlm_map[x])
             else:
-                return InteriorAssignmentSolver(tlm_y, tlm_map[x])
+                return InteriorAssignment(tlm_map[x], tlm_y)
 
-    InteriorAssignmentSolver(psi_0, psi_n).solve()
+    InteriorAssignment(psi_n, psi_0).solve()
 
     eq = EquationSolver(
         inner(trial / dt, test) * dx

--- a/examples/firedrake/manual/diffusion_hessian.py
+++ b/examples/firedrake/manual/diffusion_hessian.py
@@ -69,7 +69,7 @@ def forward(psi_0, psi_n_file=None):
         psi_np1, bc,
         solver_parameters={"ksp_type": "preonly",
                            "pc_type": "lu"})
-    cycle = AssignmentSolver(psi_np1, psi_n)
+    cycle = Assignment(psi_n, psi_np1)
 
     if psi_n_file is not None:
         psi_n_file.write(psi_n, time=0.0)

--- a/examples/firedrake/manual/diffusion_hessian.py
+++ b/examples/firedrake/manual/diffusion_hessian.py
@@ -56,7 +56,7 @@ def forward(psi_0, psi_n_file=None):
             x, y = self.dependencies()
             tlm_y = get_tangent_linear(y, M, dM, tlm_map)
             if tlm_y is None:
-                return NullSolver(tlm_map[x])
+                return ZeroAssignment(tlm_map[x])
             else:
                 return InteriorAssignment(tlm_map[x], tlm_y)
 

--- a/examples/numpy/diffusion/diffusion.py
+++ b/examples/numpy/diffusion/diffusion.py
@@ -227,11 +227,11 @@ def forward(psi_0, kappa):
 
     psi_n = Function(space, name="psi_n")
     psi_np1 = Function(space, name="psi_np1")
-    AssignmentSolver(psi_0, psi_n).solve()
+    Assignment(psi_n, psi_0).solve()
 
     eqs = [LinearEquation(ContractionRHS(B, (1,), (psi_n,)),
                           psi_np1, A=DiffusionMatrix(kappa)),
-           AssignmentSolver(psi_np1, psi_n)]
+           Assignment(psi_n, psi_np1)]
 
     for n in range(N_t):
         for eq in eqs:

--- a/examples/numpy/diffusion/diffusion.py
+++ b/examples/numpy/diffusion/diffusion.py
@@ -245,7 +245,7 @@ def forward(psi_0, kappa):
     Axpy(phi, psi_n, 1.0, one).solve()
 
     J = Functional(name="J")
-    NormSqSolver(phi, J.function(), M=ConstantMatrix(mass)).solve()
+    InnerProduct(J.function(), phi, phi, M=ConstantMatrix(mass)).solve()
 
     return J
 

--- a/examples/numpy/diffusion/diffusion.py
+++ b/examples/numpy/diffusion/diffusion.py
@@ -242,7 +242,7 @@ def forward(psi_0, kappa):
     one = Function(space, name="one", static=True)
     function_assign(one, 1.0)
     phi = Function(space, name="phi")
-    AxpySolver(psi_n, 1.0, one, phi).solve()
+    Axpy(phi, psi_n, 1.0, one).solve()
 
     J = Functional(name="J")
     NormSqSolver(phi, J.function(), M=ConstantMatrix(mass)).solve()

--- a/examples/numpy/diffusion/diffusion.py
+++ b/examples/numpy/diffusion/diffusion.py
@@ -229,8 +229,8 @@ def forward(psi_0, kappa):
     psi_np1 = Function(space, name="psi_np1")
     Assignment(psi_n, psi_0).solve()
 
-    eqs = [LinearEquation(ContractionRHS(B, (1,), (psi_n,)),
-                          psi_np1, A=DiffusionMatrix(kappa)),
+    eqs = [LinearEquation(psi_np1, ContractionRHS(B, (1,), (psi_n,)),
+                          A=DiffusionMatrix(kappa)),
            Assignment(psi_n, psi_np1)]
 
     for n in range(N_t):

--- a/tests/fenics/test_base.py
+++ b/tests/fenics/test_base.py
@@ -69,7 +69,7 @@ __all__ = \
 @pytest.fixture
 def setup_test():
     parameters["ghost_mode"] = "none"
-    parameters["tlm_adjoint"]["AssembleSolver"]["match_quadrature"] = False
+    parameters["tlm_adjoint"]["Assembly"]["match_quadrature"] = False
     parameters["tlm_adjoint"]["EquationSolver"]["enable_jacobian_caching"] \
         = True
     parameters["tlm_adjoint"]["EquationSolver"]["cache_rhs_assembly"] = True

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -616,8 +616,8 @@ def test_Storage(setup_test, test_leaks,
             d = {}
         MemoryStorage(x_s, d, function_name(x_s), save=True).solve()
 
-        ProjectionSolver(x * x * x * x_s, y,
-                         solver_parameters=ls_parameters_cg).solve()
+        Projection(y, x * x * x * x_s,
+                   solver_parameters=ls_parameters_cg).solve()
 
         if h is None:
             function_assign(y_s, y)
@@ -735,7 +735,7 @@ def test_initial_guess(setup_test, test_leaks):
                           solver_parameters=ls_parameters_cg)
         x = Function(space_1, name="x")
 
-        class TestSolver(ProjectionSolver):
+        class TestSolver(Projection):
             def __init__(self, y, x, form_compiler_parameters=None,
                          solver_parameters=None):
                 if form_compiler_parameters is None:
@@ -745,7 +745,7 @@ def test_initial_guess(setup_test, test_leaks):
 
                 assert is_function(y)
                 super().__init__(
-                    inner(y, TestFunction(x.function_space())) * dx, x,
+                    x, inner(y, TestFunction(x.function_space())) * dx,
                     form_compiler_parameters=form_compiler_parameters,
                     solver_parameters=solver_parameters,
                     cache_jacobian=False, cache_rhs_assembly=False)
@@ -814,8 +814,8 @@ def test_initial_guess(setup_test, test_leaks):
         # Active equation which requires no adjoint initial condition, but
         # for which one will be supplied
         z = Function(space_1, name="z")
-        ProjectionSolver(
-            zero * x, z,
+        Projection(
+            z, zero * x,
             solver_parameters=ls_parameters_cg).solve()
         J.addto(dot(z, z) * dx)
 
@@ -1034,8 +1034,8 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
         Assignment(X[0], m).solve()
         LinearCombination(X[1], (1.0, X[0])).solve()
         ExprEvaluationSolver(m + X[1], X[2]).solve()
-        ProjectionSolver(m + X[2], X[3],
-                         solver_parameters=ls_parameters_cg).solve()
+        Projection(X[3], m + X[2],
+                   solver_parameters=ls_parameters_cg).solve()
 
         J = Functional(name="J")
         J.assign((dot(X[-1] + 1.0, X[-1] + 1.0) ** 2) * dx

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -282,8 +282,8 @@ def test_FixedPointSolver(setup_test, test_leaks):
 @pytest.mark.parametrize("N_x, N_y, N_z", [(5, 5, 2),
                                            (5, 5, 5)])
 @seed_test
-def test_InterpolationSolver(setup_test, test_leaks, test_ghost_modes,
-                             N_x, N_y, N_z):
+def test_Interpolation(setup_test, test_leaks, test_ghost_modes,
+                       N_x, N_y, N_z):
     mesh = UnitCubeMesh(N_x, N_y, N_z)
     X = SpatialCoordinate(mesh)
     z_space = FunctionSpace(mesh, "Lagrange", 3)
@@ -302,7 +302,7 @@ def test_InterpolationSolver(setup_test, test_leaks, test_ghost_modes,
             y = z
 
         x = Function(x_space, name="x")
-        eq = InterpolationSolver(y, x, P=P[0], tolerance=1.0e-15)
+        eq = Interpolation(x, y, P=P[0], tolerance=1.0e-15)
         eq.solve()
         P[0] = eq._B[0]._A._P
 

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -38,16 +38,16 @@ pytestmark = pytest.mark.skipif(
 @pytest.mark.fenics
 @no_space_type_checking
 @seed_test
-def test_AssignmentSolver(setup_test, test_leaks):
+def test_Assignment(setup_test, test_leaks):
     x = Constant(16.0, name="x", static=True)
 
     def forward(x):
         y = [Constant(name=f"y_{i:d}") for i in range(9)]
         z = Constant(name="z")
 
-        AssignmentSolver(x, y[0]).solve()
+        Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
-            AssignmentSolver(y[i], y[i + 1]).solve()
+            Assignment(y[i + 1], y[i]).solve()
         # Following line should have no effect on sensitivity
         DotProductSolver(y[-1], y[-1], z).solve()
         DotProductSolver(y[-1], y[-1], z).solve()
@@ -62,7 +62,7 @@ def test_AssignmentSolver(setup_test, test_leaks):
         AxpySolver(z_dot_z, 2.0, x_dot_x, J.function()).solve()
 
         K = Functional(name="K")
-        AssignmentSolver(z_dot_z, K.function()).solve()
+        Assignment(K.function(), z_dot_z).solve()
 
         return J, K
 
@@ -109,7 +109,7 @@ def test_AxpySolver(setup_test, test_leaks):
         z = [Constant(name=f"z_{i:d}") for i in range(2)]
         z[0].assign(7.0)
 
-        AssignmentSolver(x, y[0]).solve()
+        Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
             AxpySolver(y[i], i + 1, z[0], y[i + 1]).solve()
         DotProductSolver(y[-1], y[-1], z[1]).solve()
@@ -695,7 +695,7 @@ def test_InnerProductSolver(setup_test, test_leaks):
 
     def forward(F):
         G = Function(space, name="G")
-        AssignmentSolver(F, G).solve()
+        Assignment(G, F).solve()
 
         J = Functional(name="J")
         InnerProductSolver(F, G, J.function()).solve()
@@ -783,7 +783,7 @@ def test_initial_guess(setup_test, test_leaks):
                         form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                         solver_parameters=self._solver_parameters)
 
-        AssignmentSolver(x_0, x).solve()
+        Assignment(x, x_0).solve()
         TestSolver(
             y, x,
             solver_parameters={"linear_solver": "cg",
@@ -1031,7 +1031,7 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
     def forward(m):
         X = [Function(space, name=f"x_{i:d}") for i in range(4)]
 
-        AssignmentSolver(m, X[0]).solve()
+        Assignment(X[0], m).solve()
         ScaleSolver(1.0, X[0], X[1]).solve()
         ExprEvaluationSolver(m + X[1], X[2]).solve()
         ProjectionSolver(m + X[2], X[3],

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -358,8 +358,8 @@ def test_InterpolationSolver(setup_test, test_leaks, test_ghost_modes,
 @pytest.mark.parametrize("N_x, N_y, N_z", [(2, 2, 2),
                                            (5, 5, 5)])
 @seed_test
-def test_PointInterpolationSolver(setup_test, test_leaks, test_ghost_modes,
-                                  N_x, N_y, N_z):
+def test_PointInterpolation(setup_test, test_leaks, test_ghost_modes,
+                            N_x, N_y, N_z):
     mesh = UnitCubeMesh(N_x, N_y, N_z)
     X = SpatialCoordinate(mesh)
     z_space = FunctionSpace(mesh, "Lagrange", 3)
@@ -382,7 +382,7 @@ def test_PointInterpolationSolver(setup_test, test_leaks, test_ghost_modes,
 
         X_vals = [new_scalar_function(name=f"x_{i:d}")
                   for i in range(X_coords.shape[0])]
-        eq = PointInterpolationSolver(y, X_vals, X_coords, P=P[0])
+        eq = PointInterpolation(X_vals, y, X_coords, P=P[0])
         eq.solve()
         P[0] = eq._P
 

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -449,7 +449,7 @@ def test_ExprEvaluationSolver(setup_test, test_leaks):
     def forward(y):
         x = Function(space, name="x")
         y_int = Constant(name="y_int")
-        AssembleSolver(y * dx, y_int).solve()
+        Assembly(y_int, y * dx).solve()
         ExprEvaluationSolver(test_expression(y, y_int), x).solve()
 
         J = Functional(name="J")
@@ -553,7 +553,7 @@ def test_LocalProjectionSolver(setup_test, test_leaks):
 
 @pytest.mark.fenics
 @seed_test
-def test_AssembleSolver(setup_test, test_leaks):
+def test_Assembly(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -561,7 +561,7 @@ def test_AssembleSolver(setup_test, test_leaks):
     def forward(F):
         x = Constant(name="x")
 
-        AssembleSolver((dot(F, F) ** 2) * dx, x).solve()
+        Assembly(x, (dot(F, F) ** 2) * dx).solve()
 
         J = Functional(name="J")
         J.assign(x)

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -776,7 +776,7 @@ def test_initial_guess(setup_test, test_leaks):
                 x, y = self.dependencies()
                 tau_y = get_tangent_linear(y, M, dM, tlm_map)
                 if tau_y is None:
-                    return NullSolver(tlm_map[x])
+                    return ZeroAssignment(tlm_map[x])
                 else:
                     return TestSolver(
                         tau_y, tlm_map[x],
@@ -804,7 +804,7 @@ def test_initial_guess(setup_test, test_leaks):
                 == 4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,
                 adj_x_0, solver_parameters=ls_parameters_cg,
                 annotate=False, tlm=False)
-            NullSolver(x).solve()
+            ZeroAssignment(x).solve()
             J_term = function_new(J.function())
             InnerProductSolver(x, adj_x_0, J_term).solve()
             J.addto(J_term)

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -229,7 +229,7 @@ def test_FixedPointSolver(setup_test, test_leaks):
     b = Constant(3.0, name="b", static=True)
 
     def forward(a, b):
-        eqs = [LinearCombinationSolver(z, (1.0, x), (1.0, b)),
+        eqs = [LinearCombination(z, (1.0, x), (1.0, b)),
                ExprEvaluationSolver(a / sqrt(z), x)]
 
         fp_parameters = {"absolute_tolerance": 0.0,
@@ -1032,7 +1032,7 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
         X = [Function(space, name=f"x_{i:d}") for i in range(4)]
 
         Assignment(X[0], m).solve()
-        LinearCombinationSolver(X[1], (1.0, X[0])).solve()
+        LinearCombination(X[1], (1.0, X[0])).solve()
         ExprEvaluationSolver(m + X[1], X[2]).solve()
         ProjectionSolver(m + X[2], X[3],
                          solver_parameters=ls_parameters_cg).solve()

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -376,7 +376,7 @@ def test_PointInterpolation(setup_test, test_leaks, test_ghost_modes,
     def forward(z):
         if MPI.COMM_WORLD.size > 1:
             y = Function(y_space, name="y")
-            LocalProjectionSolver(z, y).solve()
+            LocalProjection(y, z).solve()
         else:
             y = z
 
@@ -494,7 +494,7 @@ def test_ExprEvaluation(setup_test, test_leaks):
 
 @pytest.mark.fenics
 @seed_test
-def test_LocalProjectionSolver(setup_test, test_leaks):
+def test_LocalProjection(setup_test, test_leaks):
     mesh = UnitSquareMesh(10, 10)
     X = SpatialCoordinate(mesh)
     space_1 = FunctionSpace(mesh, "Discontinuous Lagrange", 1)
@@ -503,7 +503,7 @@ def test_LocalProjectionSolver(setup_test, test_leaks):
 
     def forward(G):
         F = Function(space_1, name="F")
-        LocalProjectionSolver(G, F).solve()
+        LocalProjection(F, G).solve()
 
         J = Functional(name="J")
         J.assign((F ** 2 + F ** 3) * dx)

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -49,14 +49,14 @@ def test_Assignment(setup_test, test_leaks):
         for i in range(len(y) - 1):
             Assignment(y[i + 1], y[i]).solve()
         # Following line should have no effect on sensitivity
-        DotProductSolver(y[-1], y[-1], z).solve()
-        DotProductSolver(y[-1], y[-1], z).solve()
+        DotProduct(z, y[-1], y[-1]).solve()
+        DotProduct(z, y[-1], y[-1]).solve()
 
         x_dot_x = Constant(name="x_dot_x")
-        DotProductSolver(x, x, x_dot_x).solve()
+        DotProduct(x_dot_x, x, x).solve()
 
         z_dot_z = Constant(name="z_dot_z")
-        DotProductSolver(z, z, z_dot_z).solve()
+        DotProduct(z_dot_z, z, z).solve()
 
         J = Functional(name="J")
         Axpy(J.function(), z_dot_z, 2.0, x_dot_x).solve()
@@ -112,10 +112,10 @@ def test_Axpy(setup_test, test_leaks):
         Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
             Axpy(y[i + 1], y[i], i + 1, z[0]).solve()
-        DotProductSolver(y[-1], y[-1], z[1]).solve()
+        DotProduct(z[1], y[-1], y[-1]).solve()
 
         J = Functional(name="J")
-        DotProductSolver(z[1], z[1], J.function()).solve()
+        DotProduct(J.function(), z[1], z[1]).solve()
         return J
 
     start_manager()

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -1032,7 +1032,7 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
         X = [Function(space, name=f"x_{i:d}") for i in range(4)]
 
         Assignment(X[0], m).solve()
-        ScaleSolver(1.0, X[0], X[1]).solve()
+        LinearCombinationSolver(X[1], (1.0, X[0])).solve()
         ExprEvaluationSolver(m + X[1], X[2]).solve()
         ProjectionSolver(m + X[2], X[3],
                          solver_parameters=ls_parameters_cg).solve()

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -689,7 +689,7 @@ def test_Storage(setup_test, test_leaks,
 @pytest.mark.skipif(complex_mode, reason="real only")
 @no_space_type_checking
 @seed_test
-def test_InnerProductSolver(setup_test, test_leaks):
+def test_InnerProduct(setup_test, test_leaks):
     mesh = UnitIntervalMesh(10)
     space = FunctionSpace(mesh, "Discontinuous Lagrange", 0)
 
@@ -698,7 +698,7 @@ def test_InnerProductSolver(setup_test, test_leaks):
         Assignment(G, F).solve()
 
         J = Functional(name="J")
-        InnerProductSolver(F, G, J.function()).solve()
+        InnerProduct(J.function(), F, G).solve()
         return J
 
     F = Function(space, name="F", static=True)
@@ -806,7 +806,7 @@ def test_initial_guess(setup_test, test_leaks):
                 annotate=False, tlm=False)
             ZeroAssignment(x).solve()
             J_term = function_new(J.function())
-            InnerProductSolver(x, adj_x_0, J_term).solve()
+            InnerProduct(J_term, x, adj_x_0).solve()
             J.addto(J_term)
         else:
             adj_x_0 = None

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -150,7 +150,7 @@ def test_Axpy(setup_test, test_leaks):
 
 @pytest.mark.fenics
 @seed_test
-def test_DirichletBCSolver(setup_test, test_leaks, test_configurations):
+def test_DirichletBCApplication(setup_test, test_leaks, test_configurations):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -164,7 +164,7 @@ def test_DirichletBCSolver(setup_test, test_leaks, test_configurations):
         x_1 = Function(space, name="x_1")
         x = Function(space, name="x")
 
-        DirichletBCSolver(bc, x_1, "on_boundary").solve()
+        DirichletBCApplication(x_1, bc, "on_boundary").solve()
 
         EquationSolver(
             inner(grad(trial), grad(test)) * dx

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -735,8 +735,8 @@ def test_initial_guess(setup_test, test_leaks):
                           solver_parameters=ls_parameters_cg)
         x = Function(space_1, name="x")
 
-        class TestSolver(Projection):
-            def __init__(self, y, x, form_compiler_parameters=None,
+        class CustomProjection(Projection):
+            def __init__(self, x, y, *, form_compiler_parameters=None,
                          solver_parameters=None):
                 if form_compiler_parameters is None:
                     form_compiler_parameters = {}
@@ -778,14 +778,14 @@ def test_initial_guess(setup_test, test_leaks):
                 if tau_y is None:
                     return ZeroAssignment(tlm_map[x])
                 else:
-                    return TestSolver(
-                        tau_y, tlm_map[x],
+                    return CustomProjection(
+                        tlm_map[x], tau_y,
                         form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                         solver_parameters=self._solver_parameters)
 
         Assignment(x, x_0).solve()
-        TestSolver(
-            y, x,
+        CustomProjection(
+            x, y,
             solver_parameters={"linear_solver": "cg",
                                "preconditioner": "sor",
                                "krylov_solver": {"nonzero_initial_guess": True,

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -59,7 +59,7 @@ def test_Assignment(setup_test, test_leaks):
         DotProductSolver(z, z, z_dot_z).solve()
 
         J = Functional(name="J")
-        AxpySolver(z_dot_z, 2.0, x_dot_x, J.function()).solve()
+        Axpy(J.function(), z_dot_z, 2.0, x_dot_x).solve()
 
         K = Functional(name="K")
         Assignment(K.function(), z_dot_z).solve()
@@ -101,7 +101,7 @@ def test_Assignment(setup_test, test_leaks):
 @pytest.mark.fenics
 @no_space_type_checking
 @seed_test
-def test_AxpySolver(setup_test, test_leaks):
+def test_Axpy(setup_test, test_leaks):
     x = Constant(1.0, name="x", static=True)
 
     def forward(x):
@@ -111,7 +111,7 @@ def test_AxpySolver(setup_test, test_leaks):
 
         Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
-            AxpySolver(y[i], i + 1, z[0], y[i + 1]).solve()
+            Axpy(y[i + 1], y[i], i + 1, z[0]).solve()
         DotProductSolver(y[-1], y[-1], z[1]).solve()
 
         J = Functional(name="J")
@@ -172,7 +172,7 @@ def test_DirichletBCSolver(setup_test, test_leaks, test_configurations):
             x_0, HomogeneousDirichletBC(space, "on_boundary"),
             solver_parameters=ls_parameters_cg).solve()
 
-        AxpySolver(x_0, 1.0, x_1, x).solve()
+        Axpy(x, x_0, 1.0, x_1).solve()
 
         J = Functional(name="J")
         J.assign((dot(x, x) ** 2) * dx)

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -230,7 +230,7 @@ def test_FixedPointSolver(setup_test, test_leaks):
 
     def forward(a, b):
         eqs = [LinearCombination(z, (1.0, x), (1.0, b)),
-               ExprEvaluationSolver(a / sqrt(z), x)]
+               ExprEvaluation(x, a / sqrt(z))]
 
         fp_parameters = {"absolute_tolerance": 0.0,
                          "relative_tolerance": 1.0e-14}
@@ -389,7 +389,7 @@ def test_PointInterpolationSolver(setup_test, test_leaks, test_ghost_modes,
         J = Functional(name="J")
         for x in X_vals:
             term = new_scalar_function()
-            ExprEvaluationSolver(x ** 3, term).solve()
+            ExprEvaluation(term, x ** 3).solve()
             J.addto(term)
         return X_vals, J
 
@@ -437,7 +437,7 @@ def test_PointInterpolationSolver(setup_test, test_leaks, test_ghost_modes,
 
 @pytest.mark.fenics
 @seed_test
-def test_ExprEvaluationSolver(setup_test, test_leaks):
+def test_ExprEvaluation(setup_test, test_leaks):
     mesh = UnitIntervalMesh(20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -450,7 +450,7 @@ def test_ExprEvaluationSolver(setup_test, test_leaks):
         x = Function(space, name="x")
         y_int = Constant(name="y_int")
         Assembly(y_int, y * dx).solve()
-        ExprEvaluationSolver(test_expression(y, y_int), x).solve()
+        ExprEvaluation(x, test_expression(y, y_int)).solve()
 
         J = Functional(name="J")
         J.assign(x * x * x * dx)
@@ -1033,7 +1033,7 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
 
         Assignment(X[0], m).solve()
         LinearCombination(X[1], (1.0, X[0])).solve()
-        ExprEvaluationSolver(m + X[1], X[2]).solve()
+        ExprEvaluation(X[2], m + X[1]).solve()
         Projection(X[3], m + X[2],
                    solver_parameters=ls_parameters_cg).solve()
 

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -51,7 +51,7 @@ def test_long_range(setup_test, test_leaks,
     def forward(F, x_ref=None):
         x_old = Function(space, name="x_old")
         x = Function(space, name="x")
-        AssignmentSolver(F, x_old).solve()
+        Assignment(x_old, F).solve()
         J = Functional(name="J")
         gather_ref = x_ref is None
         if gather_ref:
@@ -65,7 +65,7 @@ def test_long_range(setup_test, test_leaks,
                 if gather_ref:
                     x_ref[n] = function_copy(x, name=f"x_ref_{n:d}")
                 J.addto(dot(x * x * x, x_ref[n]) * dx)
-            AssignmentSolver(x, x_old).solve()
+            Assignment(x_old, x).solve()
             if n < n_steps - 1:
                 new_block()
 
@@ -191,7 +191,7 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
 
         NullSolver(x).solve()
 
-        AssignmentSolver(y, x).solve()
+        Assignment(x, y).solve()
 
         J_0 = Functional(name="J_0")
         J_0.assign((dot(x, x) ** 2) * dx)
@@ -450,7 +450,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
         x1 = Constant(0.0, name="x1")
 
         eq0 = NewtonIterationSolver(m, x0, x1)
-        eq1 = AssignmentSolver(x1, x0)
+        eq1 = Assignment(x0, x1)
 
         fp_eq = FixedPointSolver(
             [eq0, eq1],
@@ -657,7 +657,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     reset_manager()
     configure_tlm((F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 2
@@ -666,7 +666,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta))
     start_manager()
     stop_annotating()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 0
@@ -675,7 +675,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), (F, zeta))
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 3
@@ -685,7 +685,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), annotate=False)
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 1
@@ -695,7 +695,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), (F, zeta), annotate=False)
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 2

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -290,7 +290,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         x = Constant(0.0, name="x")
 
         M = IdentityMatrix()
-        b = NormSqRHS(m, M=M)
+        b = InnerProductRHS(m, m, M=M)
         linear_eq = LinearEquation(x, [b, b], A=M)
         linear_eq.solve()
 
@@ -363,7 +363,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         M = IdentityMatrix()
 
         J = Functional(name="J")
-        NormSqSolver(z, J.function(), M=M).solve()
+        InnerProduct(J.function(), z, z, M=M).solve()
         return J
 
     m = Constant(np.sqrt(2.0), name="m")

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -189,7 +189,7 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
     def forward(y):
         x = Function(space, name="x")
 
-        NullSolver(x).solve()
+        ZeroAssignment(x).solve()
 
         Assignment(x, y).solve()
 
@@ -200,7 +200,7 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
         J_1.assign(x * dx)
 
         J_0_val = J_0.value()
-        NullSolver(x).solve()
+        ZeroAssignment(x).solve()
         assert function_linf_norm(x) == 0.0
         J_0.addto(dot(x, y) * dx)
         assert J_0.value() == J_0_val

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -332,7 +332,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         LinearEquation(b, y, A=M).solve()
 
         z = Constant(0.0, name="z")
-        AxpySolver(x, 1.0, y, z).solve()
+        Axpy(z, x, 1.0, y).solve()
 
         if forward_run:
             manager.drop_references()

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -291,7 +291,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
 
         M = IdentityMatrix()
         b = NormSqRHS(m, M=M)
-        linear_eq = LinearEquation([b, b], x, A=M)
+        linear_eq = LinearEquation(x, [b, b], A=M)
         linear_eq.solve()
 
         if forward_run:
@@ -329,7 +329,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                 assert not function_is_replacement(dep)
 
         y = Constant(0.0, name="y")
-        LinearEquation(b, y, A=M).solve()
+        LinearEquation(y, b, A=M).solve()
 
         z = Constant(0.0, name="z")
         Axpy(z, x, 1.0, y).solve()

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -105,8 +105,8 @@ def test_long_range(setup_test, test_leaks,
 @pytest.mark.fenics
 @no_space_type_checking
 @seed_test
-def test_EmptySolver(setup_test, test_leaks):
-    class EmptySolver(Equation):
+def test_EmptyEquation(setup_test, test_leaks):
+    class EmptyEquation(Equation):
         def __init__(self):
             super().__init__([], [], nl_deps=[], ic=False, adj_ic=False)
 
@@ -118,7 +118,7 @@ def test_EmptySolver(setup_test, test_leaks):
     space = FunctionSpace(mesh, "Lagrange", 1)
 
     def forward(F):
-        EmptySolver().solve()
+        EmptyEquation().solve()
 
         F_dot_F = Constant(name="F_dot_F")
         DotProduct(F_dot_F, F, F).solve()
@@ -588,7 +588,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
 
     n_forward_solves = [0]
 
-    class EmptySolver(Equation):
+    class EmptyEquation(Equation):
         def __init__(self):
             super().__init__([], [], nl_deps=[], ic=False, adj_ic=False)
 
@@ -602,7 +602,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
 
     def forward(m):
         for n in range(n_steps):
-            EmptySolver().solve()
+            EmptyEquation().solve()
             if n < n_steps - 1:
                 new_block()
 

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -60,7 +60,7 @@ def test_long_range(setup_test, test_leaks,
             terms = [(1.0, x_old)]
             if n % 11 == 0:
                 terms.append((1.0, F))
-            LinearCombinationSolver(x, *terms).solve()
+            LinearCombination(x, *terms).solve()
             if n % 17 == 0:
                 if gather_ref:
                     x_ref[n] = function_copy(x, name=f"x_ref_{n:d}")

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -405,11 +405,11 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
 @seed_test
 def test_Referrers_FixedPointEquation(setup_test, test_leaks):
     def forward(m, forward_run=False):
-        class NewtonIterationSolver(Equation):
-            def __init__(self, m, x0, x):
+        class NewtonSolver(Equation):
+            def __init__(self, x, m, x0):
+                check_space_type(x, "primal")
                 check_space_type(m, "primal")
                 check_space_type(x0, "primal")
-                check_space_type(x, "primal")
 
                 super().__init__(x, deps=[x, x0, m], nl_deps=[x0, m],
                                  ic=False, adj_ic=False)
@@ -449,7 +449,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
         x0 = Constant(1.0, name="x0")
         x1 = Constant(0.0, name="x1")
 
-        eq0 = NewtonIterationSolver(m, x0, x1)
+        eq0 = NewtonSolver(x1, m, x0)
         eq1 = Assignment(x0, x1)
 
         fp_eq = FixedPointSolver(

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -121,10 +121,10 @@ def test_EmptySolver(setup_test, test_leaks):
         EmptySolver().solve()
 
         F_dot_F = Constant(name="F_dot_F")
-        DotProductSolver(F, F, F_dot_F).solve()
+        DotProduct(F_dot_F, F, F).solve()
 
         J = Functional(name="J")
-        DotProductSolver(F_dot_F, F_dot_F, J.function()).solve()
+        DotProduct(J.function(), F_dot_F, F_dot_F).solve()
         return J
 
     F = Function(space, name="F")
@@ -607,7 +607,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
                 new_block()
 
         J = Functional(name="J")
-        DotProductSolver(m, m, J.function()).solve()
+        DotProduct(J.function(), m, m).solve()
         return J
 
     m = Constant(1.0, name="m", static=True)
@@ -643,7 +643,7 @@ def test_TangentLinearMap_finalizes(setup_test, test_leaks,
 
     start_manager()
     x = Constant(0.0, name="x")
-    DotProductSolver(m, m, x).solve()
+    DotProduct(x, m, m).solve()
     stop_manager()
 
 

--- a/tests/fenics/test_models.py
+++ b/tests/fenics/test_models.py
@@ -223,7 +223,7 @@ def test_diffusion_1d_timestepping(setup_test, test_leaks,
 
         system = TimeSystem()
 
-        system.add_solve(T_0, T[0])
+        system.add_solve(Assignment(T[0], T_0))
 
         system.add_solve(inner(trial, test) * dx
                          + dt * inner(kappa * grad(trial), grad(test)) * dx

--- a/tests/fenics/test_models.py
+++ b/tests/fenics/test_models.py
@@ -145,7 +145,7 @@ def test_oscillator(setup_test, test_leaks,
         T_np1 = Function(space, name="T_np1")
         T_s = 0.5 * (T_n + T_np1)
 
-        AssignmentSolver(T_0, T_n).solve()
+        Assignment(T_n, T_0).solve()
 
         solver_parameters = {"nonlinear_solver": "newton",
                              "newton_solver": ns_parameters_newton_gmres}
@@ -314,14 +314,14 @@ def test_diffusion_2d(setup_test, test_leaks,
         T_n = Function(space, name="T_n")
         T_np1 = Function(space, name="T_np1")
 
-        AssignmentSolver(T_0, T_n).solve()
+        Assignment(T_n, T_0).solve()
 
         eq = (inner(trial / dt, test) * dx
               + inner(dot(kappa, grad(trial)), grad(test)) * dx
               == inner(T_n / dt, test) * dx)
         eqs = [EquationSolver(eq, T_np1, bc,
                               solver_parameters=ls_parameters_cg),
-               AssignmentSolver(T_np1, T_n)]
+               Assignment(T_n, T_np1)]
 
         for n in range(n_steps):
             for eq in eqs:

--- a/tests/firedrake/test_base.py
+++ b/tests/firedrake/test_base.py
@@ -75,7 +75,7 @@ gc.disable()  # See Firedrake issue #1569
 
 @pytest.fixture
 def setup_test():
-    parameters["tlm_adjoint"]["AssembleSolver"]["match_quadrature"] = False
+    parameters["tlm_adjoint"]["Assembly"]["match_quadrature"] = False
     parameters["tlm_adjoint"]["EquationSolver"]["enable_jacobian_caching"] \
         = True
     parameters["tlm_adjoint"]["EquationSolver"]["cache_rhs_assembly"] = True

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -152,7 +152,7 @@ def test_Axpy(setup_test, test_leaks):
 
 @pytest.mark.firedrake
 @seed_test
-def test_DirichletBCSolver(setup_test, test_leaks, test_configurations):
+def test_DirichletBCApplication(setup_test, test_leaks, test_configurations):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -166,7 +166,7 @@ def test_DirichletBCSolver(setup_test, test_leaks, test_configurations):
         x_1 = Function(space, name="x_1")
         x = Function(space, name="x")
 
-        DirichletBCSolver(bc, x_1, "on_boundary").solve()
+        DirichletBCApplication(x_1, bc, "on_boundary").solve()
 
         EquationSolver(
             inner(grad(trial), grad(test)) * dx

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -380,7 +380,7 @@ def test_ExprEvaluationSolver(setup_test, test_leaks):
     def forward(y):
         x = Function(space, name="x")
         y_int = Constant(name="y_int")
-        AssembleSolver(y * dx, y_int).solve()
+        Assembly(y_int, y * dx).solve()
         ExprEvaluationSolver(test_expression(y, y_int), x).solve()
 
         J = Functional(name="J")
@@ -485,7 +485,7 @@ def test_LocalProjectionSolver(setup_test, test_leaks):
 
 @pytest.mark.firedrake
 @seed_test
-def test_AssembleSolver(setup_test, test_leaks):
+def test_Assembly(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -493,7 +493,7 @@ def test_AssembleSolver(setup_test, test_leaks):
     def forward(F):
         x = Constant(name="x")
 
-        AssembleSolver((dot(F, F) ** 2) * dx, x).solve()
+        Assembly(x, (dot(F, F) ** 2) * dx).solve()
 
         J = Functional(name="J")
         J.assign(x)

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -51,14 +51,14 @@ def test_Assignment(setup_test, test_leaks):
         for i in range(len(y) - 1):
             Assignment(y[i + 1], y[i]).solve()
         # Following line should have no effect on sensitivity
-        DotProductSolver(y[-1], y[-1], z).solve()
-        DotProductSolver(y[-1], y[-1], z).solve()
+        DotProduct(z, y[-1], y[-1]).solve()
+        DotProduct(z, y[-1], y[-1]).solve()
 
         x_dot_x = Constant(name="x_dot_x")
-        DotProductSolver(x, x, x_dot_x).solve()
+        DotProduct(x_dot_x, x, x).solve()
 
         z_dot_z = Constant(name="z_dot_z")
-        DotProductSolver(z, z, z_dot_z).solve()
+        DotProduct(z_dot_z, z, z).solve()
 
         J = Functional(name="J")
         Axpy(J.function(), z_dot_z, 2.0, x_dot_x).solve()
@@ -114,10 +114,10 @@ def test_Axpy(setup_test, test_leaks):
         Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
             Axpy(y[i + 1], y[i], i + 1, z[0]).solve()
-        DotProductSolver(y[-1], y[-1], z[1]).solve()
+        DotProduct(z[1], y[-1], y[-1]).solve()
 
         J = Functional(name="J")
-        DotProductSolver(z[1], z[1], J.function()).solve()
+        DotProduct(J.function(), z[1], z[1]).solve()
         return J
 
     start_manager()

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -426,7 +426,7 @@ def test_ExprEvaluation(setup_test, test_leaks):
 @pytest.mark.firedrake
 @pytest.mark.skipif(complex_mode, reason="real only")
 @seed_test
-def test_LocalProjectionSolver(setup_test, test_leaks):
+def test_LocalProjection(setup_test, test_leaks):
     mesh = UnitSquareMesh(10, 10)
     X = SpatialCoordinate(mesh)
     space_1 = FunctionSpace(mesh, "Discontinuous Lagrange", 1)
@@ -435,7 +435,7 @@ def test_LocalProjectionSolver(setup_test, test_leaks):
 
     def forward(G):
         F = Function(space_1, name="F")
-        LocalProjectionSolver(G, F).solve()
+        LocalProjection(F, G).solve()
 
         J = Functional(name="J")
         J.assign((F ** 2 + F ** 3) * dx)

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -712,7 +712,7 @@ def test_initial_guess(setup_test, test_leaks):
                 x, y = self.dependencies()
                 tau_y = get_tangent_linear(y, M, dM, tlm_map)
                 if tau_y is None:
-                    return NullSolver(tlm_map[x])
+                    return ZeroAssignment(tlm_map[x])
                 else:
                     return TestSolver(
                         tau_y, tlm_map[x],
@@ -740,7 +740,7 @@ def test_initial_guess(setup_test, test_leaks):
                 == 4 * dot(ufl.conj(dot(x, x) * x), ufl.conj(test_1)) * dx,
                 adj_x_0, solver_parameters=ls_parameters_cg,
                 annotate=False, tlm=False)
-            NullSolver(x).solve()
+            ZeroAssignment(x).solve()
             J_term = function_new(J.function())
             InnerProductSolver(x, adj_x_0, J_term).solve()
             J.addto(J_term)

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -61,7 +61,7 @@ def test_Assignment(setup_test, test_leaks):
         DotProductSolver(z, z, z_dot_z).solve()
 
         J = Functional(name="J")
-        AxpySolver(z_dot_z, 2.0, x_dot_x, J.function()).solve()
+        Axpy(J.function(), z_dot_z, 2.0, x_dot_x).solve()
 
         K = Functional(name="K")
         Assignment(K.function(), z_dot_z).solve()
@@ -103,7 +103,7 @@ def test_Assignment(setup_test, test_leaks):
 @pytest.mark.firedrake
 @no_space_type_checking
 @seed_test
-def test_AxpySolver(setup_test, test_leaks):
+def test_Axpy(setup_test, test_leaks):
     x = Constant(1.0, name="x", static=True)
 
     def forward(x):
@@ -113,7 +113,7 @@ def test_AxpySolver(setup_test, test_leaks):
 
         Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
-            AxpySolver(y[i], i + 1, z[0], y[i + 1]).solve()
+            Axpy(y[i + 1], y[i], i + 1, z[0]).solve()
         DotProductSolver(y[-1], y[-1], z[1]).solve()
 
         J = Functional(name="J")
@@ -174,7 +174,7 @@ def test_DirichletBCSolver(setup_test, test_leaks, test_configurations):
             x_0, HomogeneousDirichletBC(space, "on_boundary"),
             solver_parameters=ls_parameters_cg).solve()
 
-        AxpySolver(x_0, 1.0, x_1, x).solve()
+        Axpy(x, x_0, 1.0, x_1).solve()
 
         J = Functional(name="J")
         J.assign((dot(x, x) ** 2) * dx)

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -40,16 +40,16 @@ pytestmark = pytest.mark.skipif(
 @pytest.mark.firedrake
 @no_space_type_checking
 @seed_test
-def test_AssignmentSolver(setup_test, test_leaks):
+def test_Assignment(setup_test, test_leaks):
     x = Constant(16.0, name="x", static=True)
 
     def forward(x):
         y = [Constant(name=f"y_{i:d}") for i in range(9)]
         z = Constant(name="z")
 
-        AssignmentSolver(x, y[0]).solve()
+        Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
-            AssignmentSolver(y[i], y[i + 1]).solve()
+            Assignment(y[i + 1], y[i]).solve()
         # Following line should have no effect on sensitivity
         DotProductSolver(y[-1], y[-1], z).solve()
         DotProductSolver(y[-1], y[-1], z).solve()
@@ -64,7 +64,7 @@ def test_AssignmentSolver(setup_test, test_leaks):
         AxpySolver(z_dot_z, 2.0, x_dot_x, J.function()).solve()
 
         K = Functional(name="K")
-        AssignmentSolver(z_dot_z, K.function()).solve()
+        Assignment(K.function(), z_dot_z).solve()
 
         return J, K
 
@@ -111,7 +111,7 @@ def test_AxpySolver(setup_test, test_leaks):
         z = [Constant(name=f"z_{i:d}") for i in range(2)]
         z[0].assign(7.0)
 
-        AssignmentSolver(x, y[0]).solve()
+        Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
             AxpySolver(y[i], i + 1, z[0], y[i + 1]).solve()
         DotProductSolver(y[-1], y[-1], z[1]).solve()
@@ -628,7 +628,7 @@ def test_InnerProductSolver(setup_test, test_leaks):
 
     def forward(F):
         G = Function(space, name="G")
-        AssignmentSolver(F, G).solve()
+        Assignment(G, F).solve()
 
         J = Functional(name="J")
         InnerProductSolver(F, G, J.function()).solve()
@@ -719,7 +719,7 @@ def test_initial_guess(setup_test, test_leaks):
                         form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                         solver_parameters=self._solver_parameters)
 
-        AssignmentSolver(x_0, x).solve()
+        Assignment(x, x_0).solve()
         TestSolver(
             y, x,
             solver_parameters={"ksp_type": "cg",
@@ -967,7 +967,7 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
     def forward(m):
         X = [Function(space, name=f"x_{i:d}") for i in range(4)]
 
-        AssignmentSolver(m, X[0]).solve()
+        Assignment(X[0], m).solve()
         ScaleSolver(1.0, X[0], X[1]).solve()
         ExprEvaluationSolver(m + X[1], X[2]).solve()
         ProjectionSolver(m + X[2], X[3],

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -231,7 +231,7 @@ def test_FixedPointSolver(setup_test, test_leaks):
     b = Constant(3.0, name="b", static=True)
 
     def forward(a, b):
-        eqs = [LinearCombinationSolver(z, (1.0, x), (1.0, b)),
+        eqs = [LinearCombination(z, (1.0, x), (1.0, b)),
                ExprEvaluationSolver(a / sqrt(z), x)]
 
         fp_parameters = {"absolute_tolerance": 0.0,
@@ -968,7 +968,7 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
         X = [Function(space, name=f"x_{i:d}") for i in range(4)]
 
         Assignment(X[0], m).solve()
-        LinearCombinationSolver(X[1], (1.0, X[0])).solve()
+        LinearCombination(X[1], (1.0, X[0])).solve()
         ExprEvaluationSolver(m + X[1], X[2]).solve()
         ProjectionSolver(m + X[2], X[3],
                          solver_parameters=ls_parameters_cg).solve()

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -548,8 +548,8 @@ def test_Storage(setup_test, test_leaks,
             d = {}
         MemoryStorage(x_s, d, function_name(x_s), save=True).solve()
 
-        ProjectionSolver(x * x * x * x_s, y,
-                         solver_parameters=ls_parameters_cg).solve()
+        Projection(y, x * x * x * x_s,
+                   solver_parameters=ls_parameters_cg).solve()
 
         if h is None:
             function_assign(y_s, y)
@@ -668,7 +668,7 @@ def test_initial_guess(setup_test, test_leaks):
                           solver_parameters=ls_parameters_cg)
         x = Function(space_1, name="x")
 
-        class TestSolver(ProjectionSolver):
+        class TestSolver(Projection):
             def __init__(self, y, x, form_compiler_parameters=None,
                          solver_parameters=None):
                 if form_compiler_parameters is None:
@@ -678,7 +678,7 @@ def test_initial_guess(setup_test, test_leaks):
 
                 assert is_function(y)
                 super().__init__(
-                    inner(y, TestFunction(x.function_space())) * dx, x,
+                    x, inner(y, TestFunction(x.function_space())) * dx,
                     form_compiler_parameters=form_compiler_parameters,
                     solver_parameters=solver_parameters,
                     cache_jacobian=False, cache_rhs_assembly=False)
@@ -750,8 +750,8 @@ def test_initial_guess(setup_test, test_leaks):
         # Active equation which requires no adjoint initial condition, but
         # for which one will be supplied
         z = Function(space_1, name="z")
-        ProjectionSolver(
-            zero * x, z,
+        Projection(
+            z, zero * x,
             solver_parameters=ls_parameters_cg).solve()
         J.addto(dot(z, z) * dx)
 
@@ -970,8 +970,8 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
         Assignment(X[0], m).solve()
         LinearCombination(X[1], (1.0, X[0])).solve()
         ExprEvaluationSolver(m + X[1], X[2]).solve()
-        ProjectionSolver(m + X[2], X[3],
-                         solver_parameters=ls_parameters_cg).solve()
+        Projection(X[3], m + X[2],
+                   solver_parameters=ls_parameters_cg).solve()
 
         J = Functional(name="J")
         J.assign((dot(X[-1] + 1.0, X[-1] + 1.0) ** 2) * dx

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -232,7 +232,7 @@ def test_FixedPointSolver(setup_test, test_leaks):
 
     def forward(a, b):
         eqs = [LinearCombination(z, (1.0, x), (1.0, b)),
-               ExprEvaluationSolver(a / sqrt(z), x)]
+               ExprEvaluation(x, a / sqrt(z))]
 
         fp_parameters = {"absolute_tolerance": 0.0,
                          "relative_tolerance": 1.0e-14}
@@ -320,7 +320,7 @@ def test_PointInterpolationSolver(setup_test, test_leaks,
         J = Functional(name="J")
         for x in X_vals:
             term = new_scalar_function()
-            ExprEvaluationSolver(x ** 3, term).solve()
+            ExprEvaluation(term, x ** 3).solve()
             J.addto(term)
         return X_vals, J
 
@@ -368,7 +368,7 @@ def test_PointInterpolationSolver(setup_test, test_leaks,
 
 @pytest.mark.firedrake
 @seed_test
-def test_ExprEvaluationSolver(setup_test, test_leaks):
+def test_ExprEvaluation(setup_test, test_leaks):
     mesh = UnitIntervalMesh(20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -381,7 +381,7 @@ def test_ExprEvaluationSolver(setup_test, test_leaks):
         x = Function(space, name="x")
         y_int = Constant(name="y_int")
         Assembly(y_int, y * dx).solve()
-        ExprEvaluationSolver(test_expression(y, y_int), x).solve()
+        ExprEvaluation(x, test_expression(y, y_int)).solve()
 
         J = Functional(name="J")
         J.assign(x * x * x * dx)
@@ -969,7 +969,7 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
 
         Assignment(X[0], m).solve()
         LinearCombination(X[1], (1.0, X[0])).solve()
-        ExprEvaluationSolver(m + X[1], X[2]).solve()
+        ExprEvaluation(X[2], m + X[1]).solve()
         Projection(X[3], m + X[2],
                    solver_parameters=ls_parameters_cg).solve()
 

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -668,8 +668,8 @@ def test_initial_guess(setup_test, test_leaks):
                           solver_parameters=ls_parameters_cg)
         x = Function(space_1, name="x")
 
-        class TestSolver(Projection):
-            def __init__(self, y, x, form_compiler_parameters=None,
+        class CustomProjection(Projection):
+            def __init__(self, x, y, *, form_compiler_parameters=None,
                          solver_parameters=None):
                 if form_compiler_parameters is None:
                     form_compiler_parameters = {}
@@ -714,14 +714,14 @@ def test_initial_guess(setup_test, test_leaks):
                 if tau_y is None:
                     return ZeroAssignment(tlm_map[x])
                 else:
-                    return TestSolver(
-                        tau_y, tlm_map[x],
+                    return CustomProjection(
+                        tlm_map[x], tau_y,
                         form_compiler_parameters=self._form_compiler_parameters,  # noqa: E501
                         solver_parameters=self._solver_parameters)
 
         Assignment(x, x_0).solve()
-        TestSolver(
-            y, x,
+        CustomProjection(
+            x, y,
             solver_parameters={"ksp_type": "cg",
                                "pc_type": "sor",
                                "ksp_rtol": 1.0e-10,

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -968,7 +968,7 @@ def test_ZeroFunction(setup_test, test_leaks, test_configurations):
         X = [Function(space, name=f"x_{i:d}") for i in range(4)]
 
         Assignment(X[0], m).solve()
-        ScaleSolver(1.0, X[0], X[1]).solve()
+        LinearCombinationSolver(X[1], (1.0, X[0])).solve()
         ExprEvaluationSolver(m + X[1], X[2]).solve()
         ProjectionSolver(m + X[2], X[3],
                          solver_parameters=ls_parameters_cg).solve()

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -294,9 +294,9 @@ def test_FixedPointSolver(setup_test, test_leaks):
 @pytest.mark.parametrize("N_x, N_y, N_z", [(2, 2, 2),
                                            (5, 5, 5)])
 @seed_test
-def test_PointInterpolationSolver(setup_test, test_leaks,
-                                  overlap_type,
-                                  N_x, N_y, N_z):
+def test_PointInterpolation(setup_test, test_leaks,
+                            overlap_type,
+                            N_x, N_y, N_z):
     mesh = UnitCubeMesh(N_x, N_y, N_z,
                         distribution_parameters={"partition": True,
                                                  "overlap_type": overlap_type})
@@ -313,7 +313,7 @@ def test_PointInterpolationSolver(setup_test, test_leaks,
     def forward(y):
         X_vals = [new_scalar_function(name=f"x_{i:d}")
                   for i in range(X_coords.shape[0])]
-        eq = PointInterpolationSolver(y, X_vals, X_coords, P=P[0])
+        eq = PointInterpolation(X_vals, y, X_coords, P=P[0])
         eq.solve()
         P[0] = eq._P
 

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -622,7 +622,7 @@ def test_Storage(setup_test, test_leaks,
 @pytest.mark.skipif(complex_mode, reason="real only")
 @no_space_type_checking
 @seed_test
-def test_InnerProductSolver(setup_test, test_leaks):
+def test_InnerProduct(setup_test, test_leaks):
     mesh = UnitIntervalMesh(10)
     space = FunctionSpace(mesh, "Discontinuous Lagrange", 0)
 
@@ -631,7 +631,7 @@ def test_InnerProductSolver(setup_test, test_leaks):
         Assignment(G, F).solve()
 
         J = Functional(name="J")
-        InnerProductSolver(F, G, J.function()).solve()
+        InnerProduct(J.function(), F, G).solve()
         return J
 
     F = Function(space, name="F", static=True)
@@ -742,7 +742,7 @@ def test_initial_guess(setup_test, test_leaks):
                 annotate=False, tlm=False)
             ZeroAssignment(x).solve()
             J_term = function_new(J.function())
-            InnerProductSolver(x, adj_x_0, J_term).solve()
+            InnerProduct(J_term, x, adj_x_0).solve()
             J.addto(J_term)
         else:
             adj_x_0 = None

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -335,7 +335,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         LinearEquation(b, y, A=M).solve()
 
         z = Constant(0.0, name="z")
-        AxpySolver(x, 1.0, y, z).solve()
+        Axpy(z, x, 1.0, y).solve()
 
         if forward_run:
             manager.drop_references()

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -408,11 +408,11 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
 @seed_test
 def test_Referrers_FixedPointEquation(setup_test, test_leaks):
     def forward(m, forward_run=False):
-        class NewtonIterationSolver(Equation):
-            def __init__(self, m, x0, x):
+        class NewtonSolver(Equation):
+            def __init__(self, x, m, x0):
+                check_space_type(x, "primal")
                 check_space_type(m, "primal")
                 check_space_type(x0, "primal")
-                check_space_type(x, "primal")
 
                 super().__init__(x, deps=[x, x0, m], nl_deps=[x0, m],
                                  ic=False, adj_ic=False)
@@ -452,7 +452,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
         x0 = Constant(1.0, name="x0")
         x1 = Constant(0.0, name="x1")
 
-        eq0 = NewtonIterationSolver(m, x0, x1)
+        eq0 = NewtonSolver(x1, m, x0)
         eq1 = Assignment(x0, x1)
 
         fp_eq = FixedPointSolver(

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -61,7 +61,7 @@ def test_long_range(setup_test, test_leaks,
             terms = [(1.0, x_old)]
             if n % 11 == 0:
                 terms.append((1.0, F))
-            LinearCombinationSolver(x, *terms).solve()
+            LinearCombination(x, *terms).solve()
             if n % 17 == 0:
                 if gather_ref:
                     x_ref[n] = function_copy(x, name=f"x_ref_{n:d}")

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -122,10 +122,10 @@ def test_EmptySolver(setup_test, test_leaks):
         EmptySolver().solve()
 
         F_dot_F = Constant(name="F_dot_F")
-        DotProductSolver(F, F, F_dot_F).solve()
+        DotProduct(F_dot_F, F, F).solve()
 
         J = Functional(name="J")
-        DotProductSolver(F_dot_F, F_dot_F, J.function()).solve()
+        DotProduct(J.function(), F_dot_F, F_dot_F).solve()
         return J
 
     F = Function(space, name="F")
@@ -610,7 +610,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
                 new_block()
 
         J = Functional(name="J")
-        DotProductSolver(m, m, J.function()).solve()
+        DotProduct(J.function(), m, m).solve()
         return J
 
     m = Constant(1.0, name="m", static=True)
@@ -646,7 +646,7 @@ def test_TangentLinearMap_finalizes(setup_test, test_leaks,
 
     start_manager()
     x = Constant(0.0, name="x")
-    DotProductSolver(m, m, x).solve()
+    DotProduct(x, m, m).solve()
     stop_manager()
 
 

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -106,8 +106,8 @@ def test_long_range(setup_test, test_leaks,
 @pytest.mark.firedrake
 @no_space_type_checking
 @seed_test
-def test_EmptySolver(setup_test, test_leaks):
-    class EmptySolver(Equation):
+def test_EmptyEquation(setup_test, test_leaks):
+    class EmptyEquation(Equation):
         def __init__(self):
             super().__init__([], [], nl_deps=[], ic=False, adj_ic=False)
 
@@ -119,7 +119,7 @@ def test_EmptySolver(setup_test, test_leaks):
     space = FunctionSpace(mesh, "Lagrange", 1)
 
     def forward(F):
-        EmptySolver().solve()
+        EmptyEquation().solve()
 
         F_dot_F = Constant(name="F_dot_F")
         DotProduct(F_dot_F, F, F).solve()
@@ -591,7 +591,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
 
     n_forward_solves = [0]
 
-    class EmptySolver(Equation):
+    class EmptyEquation(Equation):
         def __init__(self):
             super().__init__([], [], nl_deps=[], ic=False, adj_ic=False)
 
@@ -605,7 +605,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
 
     def forward(m):
         for n in range(n_steps):
-            EmptySolver().solve()
+            EmptyEquation().solve()
             if n < n_steps - 1:
                 new_block()
 

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -192,7 +192,7 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
     def forward(y):
         x = Function(space, name="x")
 
-        NullSolver(x).solve()
+        ZeroAssignment(x).solve()
 
         Assignment(x, y).solve()
 
@@ -203,7 +203,7 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
         J_1.assign(x * dx)
 
         J_0_val = J_0.value()
-        NullSolver(x).solve()
+        ZeroAssignment(x).solve()
         assert function_linf_norm(x) == 0.0
         J_0.addto(dot(x, y) * dx)
         assert J_0.value() == J_0_val

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -294,7 +294,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
 
         M = IdentityMatrix()
         b = NormSqRHS(m, M=M)
-        linear_eq = LinearEquation([b, b], x, A=M)
+        linear_eq = LinearEquation(x, [b, b], A=M)
         linear_eq.solve()
 
         if forward_run:
@@ -332,7 +332,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                 assert not function_is_replacement(dep)
 
         y = Constant(0.0, name="y")
-        LinearEquation(b, y, A=M).solve()
+        LinearEquation(y, b, A=M).solve()
 
         z = Constant(0.0, name="z")
         Axpy(z, x, 1.0, y).solve()

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -52,7 +52,7 @@ def test_long_range(setup_test, test_leaks,
     def forward(F, x_ref=None):
         x_old = Function(space, name="x_old")
         x = Function(space, name="x")
-        AssignmentSolver(F, x_old).solve()
+        Assignment(x_old, F).solve()
         J = Functional(name="J")
         gather_ref = x_ref is None
         if gather_ref:
@@ -66,7 +66,7 @@ def test_long_range(setup_test, test_leaks,
                 if gather_ref:
                     x_ref[n] = function_copy(x, name=f"x_ref_{n:d}")
                 J.addto(dot(x * x * x, x_ref[n]) * dx)
-            AssignmentSolver(x, x_old).solve()
+            Assignment(x_old, x).solve()
             if n < n_steps - 1:
                 new_block()
 
@@ -194,7 +194,7 @@ def test_adjoint_graph_pruning(setup_test, test_leaks):
 
         NullSolver(x).solve()
 
-        AssignmentSolver(y, x).solve()
+        Assignment(x, y).solve()
 
         J_0 = Functional(name="J_0")
         J_0.assign((dot(x, x) ** 2) * dx)
@@ -453,7 +453,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
         x1 = Constant(0.0, name="x1")
 
         eq0 = NewtonIterationSolver(m, x0, x1)
-        eq1 = AssignmentSolver(x1, x0)
+        eq1 = Assignment(x0, x1)
 
         fp_eq = FixedPointSolver(
             [eq0, eq1],
@@ -660,7 +660,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     reset_manager()
     configure_tlm((F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 2
@@ -669,7 +669,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta))
     start_manager()
     stop_annotating()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 0
@@ -678,7 +678,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), (F, zeta))
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 3
@@ -688,7 +688,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), annotate=False)
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 1
@@ -698,7 +698,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), (F, zeta), annotate=False)
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 2

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -293,7 +293,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         x = Constant(0.0, name="x")
 
         M = IdentityMatrix()
-        b = NormSqRHS(m, M=M)
+        b = InnerProductRHS(m, m, M=M)
         linear_eq = LinearEquation(x, [b, b], A=M)
         linear_eq.solve()
 
@@ -366,7 +366,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         M = IdentityMatrix()
 
         J = Functional(name="J")
-        NormSqSolver(z, J.function(), M=M).solve()
+        InnerProduct(J.function(), z, z, M=M).solve()
         return J
 
     m = Constant(np.sqrt(2.0), name="m")

--- a/tests/firedrake/test_models.py
+++ b/tests/firedrake/test_models.py
@@ -218,7 +218,7 @@ def test_diffusion_1d_timestepping(setup_test, test_leaks,
 
         system = TimeSystem()
 
-        system.add_solve(T_0, T[0])
+        system.add_solve(Assignment(T[0], T_0))
 
         system.add_solve(inner(trial, test) * dx
                          + dt * inner(kappa * grad(trial), grad(test)) * dx

--- a/tests/firedrake/test_models.py
+++ b/tests/firedrake/test_models.py
@@ -143,7 +143,7 @@ def test_oscillator(setup_test, test_leaks,
         T_np1 = Function(space, name="T_np1")
         T_s = 0.5 * (T_n + T_np1)
 
-        AssignmentSolver(T_0, T_n).solve()
+        Assignment(T_n, T_0).solve()
 
         eq = EquationSolver(inner((T_np1 - T_n) / dt, test) * dx
                             - inner(T_s[1], test[0]) * dx
@@ -313,14 +313,14 @@ def test_diffusion_2d(setup_test, test_leaks,
         T_n = Function(space, name="T_n")
         T_np1 = Function(space, name="T_np1")
 
-        AssignmentSolver(T_0, T_n).solve()
+        Assignment(T_n, T_0).solve()
 
         eq = (inner(trial / dt, test) * dx
               + inner(dot(kappa, grad(trial)), grad(test)) * dx
               == inner(T_n / dt, test) * dx)
         eqs = [EquationSolver(eq, T_np1, bc,
                               solver_parameters=ls_parameters_cg),
-               AssignmentSolver(T_np1, T_n)]
+               Assignment(T_n, T_np1)]
 
         for n in range(n_steps):
             for eq in eqs:

--- a/tests/numpy/test_equations.py
+++ b/tests/numpy/test_equations.py
@@ -149,7 +149,7 @@ def test_Axpy(setup_test, test_leaks, test_default_dtypes):
 @pytest.mark.numpy
 @no_space_type_checking
 @seed_test
-def test_InnerProductSolver(setup_test, test_leaks):
+def test_InnerProduct(setup_test, test_leaks):
     space = FunctionSpace(10)
 
     def forward(F):
@@ -157,7 +157,7 @@ def test_InnerProductSolver(setup_test, test_leaks):
         Assignment(G, F).solve()
 
         J = Functional(name="J")
-        InnerProductSolver(F, G, J.function()).solve()
+        InnerProduct(J.function(), F, G).solve()
         return J
 
     F = Function(space, name="F", static=True)

--- a/tests/numpy/test_equations.py
+++ b/tests/numpy/test_equations.py
@@ -47,14 +47,14 @@ def test_Assignment(setup_test, test_leaks, test_default_dtypes):
         for i in range(len(y) - 1):
             Assignment(y[i + 1], y[i]).solve()
         # Following line should have no effect on sensitivity
-        DotProductSolver(y[-1], y[-1], z).solve()
-        DotProductSolver(y[-1], y[-1], z).solve()
+        DotProduct(z, y[-1], y[-1]).solve()
+        DotProduct(z, y[-1], y[-1]).solve()
 
         x_dot_x = Constant(name="x_dot_x")
-        DotProductSolver(x, x, x_dot_x).solve()
+        DotProduct(x_dot_x, x, x).solve()
 
         z_dot_z = Constant(name="z_dot_z")
-        DotProductSolver(z, z, z_dot_z).solve()
+        DotProduct(z_dot_z, z, z).solve()
 
         J = Functional(name="J")
         Axpy(J.function(), z_dot_z, 2.0, x_dot_x).solve()
@@ -110,10 +110,10 @@ def test_Axpy(setup_test, test_leaks, test_default_dtypes):
         Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
             Axpy(y[i + 1], y[i], i + 1, z[0]).solve()
-        DotProductSolver(y[-1], y[-1], z[1]).solve()
+        DotProduct(z[1], y[-1], y[-1]).solve()
 
         J = Functional(name="J")
-        DotProductSolver(z[1], z[1], J.function()).solve()
+        DotProduct(J.function(), z[1], z[1]).solve()
         return J
 
     start_manager()
@@ -197,10 +197,10 @@ def test_ContractionSolver(setup_test, test_leaks, test_default_dtypes):
         ContractionSolver(A, (1,), (m,), x).solve()
 
         x_dot_x = Constant(name="x_dot_x")
-        DotProductSolver(x, x, x_dot_x).solve()
+        DotProduct(x_dot_x, x, x).solve()
 
         J = Functional(name="J")
-        DotProductSolver(x_dot_x, x_dot_x, J.function()).solve()
+        DotProduct(J.function(), x_dot_x, x_dot_x).solve()
         return x, J
 
     m = Function(space, name="m", static=True)

--- a/tests/numpy/test_equations.py
+++ b/tests/numpy/test_equations.py
@@ -57,7 +57,7 @@ def test_Assignment(setup_test, test_leaks, test_default_dtypes):
         DotProductSolver(z, z, z_dot_z).solve()
 
         J = Functional(name="J")
-        AxpySolver(z_dot_z, 2.0, x_dot_x, J.function()).solve()
+        Axpy(J.function(), z_dot_z, 2.0, x_dot_x).solve()
 
         K = Functional(name="K")
         Assignment(K.function(), z_dot_z).solve()
@@ -99,7 +99,7 @@ def test_Assignment(setup_test, test_leaks, test_default_dtypes):
 @pytest.mark.numpy
 @no_space_type_checking
 @seed_test
-def test_AxpySolver(setup_test, test_leaks, test_default_dtypes):
+def test_Axpy(setup_test, test_leaks, test_default_dtypes):
     x = Constant(1.0, name="x", static=True)
 
     def forward(x):
@@ -109,7 +109,7 @@ def test_AxpySolver(setup_test, test_leaks, test_default_dtypes):
 
         Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
-            AxpySolver(y[i], i + 1, z[0], y[i + 1]).solve()
+            Axpy(y[i + 1], y[i], i + 1, z[0]).solve()
         DotProductSolver(y[-1], y[-1], z[1]).solve()
 
         J = Functional(name="J")

--- a/tests/numpy/test_equations.py
+++ b/tests/numpy/test_equations.py
@@ -36,16 +36,16 @@ except ImportError:
 @pytest.mark.numpy
 @no_space_type_checking
 @seed_test
-def test_AssignmentSolver(setup_test, test_leaks, test_default_dtypes):
+def test_Assignment(setup_test, test_leaks, test_default_dtypes):
     x = Constant(16.0, name="x", static=True)
 
     def forward(x):
         y = [Constant(name=f"y_{i:d}") for i in range(9)]
         z = Constant(name="z")
 
-        AssignmentSolver(x, y[0]).solve()
+        Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
-            AssignmentSolver(y[i], y[i + 1]).solve()
+            Assignment(y[i + 1], y[i]).solve()
         # Following line should have no effect on sensitivity
         DotProductSolver(y[-1], y[-1], z).solve()
         DotProductSolver(y[-1], y[-1], z).solve()
@@ -60,7 +60,7 @@ def test_AssignmentSolver(setup_test, test_leaks, test_default_dtypes):
         AxpySolver(z_dot_z, 2.0, x_dot_x, J.function()).solve()
 
         K = Functional(name="K")
-        AssignmentSolver(z_dot_z, K.function()).solve()
+        Assignment(K.function(), z_dot_z).solve()
 
         return J, K
 
@@ -107,7 +107,7 @@ def test_AxpySolver(setup_test, test_leaks, test_default_dtypes):
         z = [Constant(name=f"z_{i:d}") for i in range(2)]
         z[0].assign(7.0)
 
-        AssignmentSolver(x, y[0]).solve()
+        Assignment(y[0], x).solve()
         for i in range(len(y) - 1):
             AxpySolver(y[i], i + 1, z[0], y[i + 1]).solve()
         DotProductSolver(y[-1], y[-1], z[1]).solve()
@@ -154,7 +154,7 @@ def test_InnerProductSolver(setup_test, test_leaks):
 
     def forward(F):
         G = Function(space, name="G")
-        AssignmentSolver(F, G).solve()
+        Assignment(G, F).solve()
 
         J = Functional(name="J")
         InnerProductSolver(F, G, J.function()).solve()

--- a/tests/numpy/test_equations.py
+++ b/tests/numpy/test_equations.py
@@ -179,7 +179,7 @@ def test_InnerProduct(setup_test, test_leaks):
 @pytest.mark.numpy
 @no_space_type_checking
 @seed_test
-def test_ContractionSolver(setup_test, test_leaks, test_default_dtypes):
+def test_Contraction(setup_test, test_leaks, test_default_dtypes):
     dtype = default_dtype()
 
     space = FunctionSpace(3)
@@ -194,7 +194,7 @@ def test_ContractionSolver(setup_test, test_leaks, test_default_dtypes):
 
     def forward(m):
         x = Function(space, name="x")
-        ContractionSolver(A, (1,), (m,), x).solve()
+        Contraction(x, A, (1,), (m,)).solve()
 
         x_dot_x = Constant(name="x_dot_x")
         DotProduct(x_dot_x, x, x).solve()

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -153,7 +153,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
 
         M = IdentityMatrix()
         b = NormSqRHS(m, M=M)
-        linear_eq = LinearEquation([b, b], x, A=M)
+        linear_eq = LinearEquation(x, [b, b], A=M)
         linear_eq.solve()
 
         if forward_run:
@@ -191,7 +191,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
                 assert not function_is_replacement(dep)
 
         y = Constant(0.0, name="y")
-        LinearEquation(b, y, A=M).solve()
+        LinearEquation(y, b, A=M).solve()
 
         z = Constant(0.0, name="z")
         Axpy(z, x, 1.0, y).solve()

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -38,8 +38,8 @@ except ImportError:
 @pytest.mark.numpy
 @no_space_type_checking
 @seed_test
-def test_EmptySolver(setup_test, test_leaks, test_default_dtypes):
-    class EmptySolver(Equation):
+def test_EmptyEquation(setup_test, test_leaks, test_default_dtypes):
+    class EmptyEquation(Equation):
         def __init__(self):
             super().__init__([], [], nl_deps=[], ic=False, adj_ic=False)
 
@@ -49,7 +49,7 @@ def test_EmptySolver(setup_test, test_leaks, test_default_dtypes):
     space = FunctionSpace(100)
 
     def forward(F):
-        EmptySolver().solve()
+        EmptyEquation().solve()
 
         F_dot_F = Constant(name="F_dot_F")
         DotProduct(F_dot_F, F, F).solve()
@@ -450,7 +450,7 @@ def test_binomial_checkpointing(setup_test, test_leaks, test_default_dtypes,
 
     n_forward_solves = [0]
 
-    class EmptySolver(Equation):
+    class EmptyEquation(Equation):
         def __init__(self):
             super().__init__([], [], nl_deps=[], ic=False, adj_ic=False)
 
@@ -464,7 +464,7 @@ def test_binomial_checkpointing(setup_test, test_leaks, test_default_dtypes,
 
     def forward(m):
         for n in range(n_steps):
-            EmptySolver().solve()
+            EmptyEquation().solve()
             if n < n_steps - 1:
                 new_block()
 

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -52,10 +52,10 @@ def test_EmptySolver(setup_test, test_leaks, test_default_dtypes):
         EmptySolver().solve()
 
         F_dot_F = Constant(name="F_dot_F")
-        DotProductSolver(F, F, F_dot_F).solve()
+        DotProduct(F_dot_F, F, F).solve()
 
         J = Functional(name="J")
-        DotProductSolver(F_dot_F, F_dot_F, J.function()).solve()
+        DotProduct(J.function(), F_dot_F, F_dot_F).solve()
         return J
 
     F = Function(space, name="F")
@@ -469,7 +469,7 @@ def test_binomial_checkpointing(setup_test, test_leaks, test_default_dtypes,
                 new_block()
 
         J = Functional(name="J")
-        DotProductSolver(m, m, J.function()).solve()
+        DotProduct(J.function(), m, m).solve()
         return J
 
     m = Constant(1.0, name="m", static=True)
@@ -505,7 +505,7 @@ def test_TangentLinearMap_finalizes(setup_test, test_leaks, test_default_dtypes,
 
     start_manager()
     x = Constant(0.0, name="x")
-    DotProductSolver(m, m, x).solve()
+    DotProduct(x, m, m).solve()
     stop_manager()
 
 

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -312,7 +312,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtype
         x1 = Constant(0.0, name="x1")
 
         eq0 = NewtonIterationSolver(m, x0, x1)
-        eq1 = AssignmentSolver(x1, x0)
+        eq1 = Assignment(x0, x1)
 
         fp_eq = FixedPointSolver(
             [eq0, eq1],
@@ -519,7 +519,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     reset_manager()
     configure_tlm((F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 2
@@ -528,7 +528,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta))
     start_manager()
     stop_annotating()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 0
@@ -537,7 +537,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), (F, zeta))
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 3
@@ -547,7 +547,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), annotate=False)
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 1
@@ -557,7 +557,7 @@ def test_tlm_annotation(setup_test, test_leaks):
     configure_tlm((F, zeta), (F, zeta), annotate=False)
     manager().function_tlm(G, (F, zeta), (F, zeta))
     start_manager()
-    AssignmentSolver(F, G).solve()
+    Assignment(G, F).solve()
     stop_manager()
 
     assert len(manager()._blocks) == 0 and len(manager()._block) == 2

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -152,7 +152,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         x = Constant(0.0, name="x")
 
         M = IdentityMatrix()
-        b = NormSqRHS(m, M=M)
+        b = InnerProductRHS(m, m, M=M)
         linear_eq = LinearEquation(x, [b, b], A=M)
         linear_eq.solve()
 
@@ -225,7 +225,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         M = IdentityMatrix()
 
         J = Functional(name="J")
-        NormSqSolver(z, J.function(), M=M).solve()
+        InnerProduct(J.function(), z, z, M=M).solve()
         return J
 
     m = Constant(np.sqrt(2.0), name="m")

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -267,11 +267,11 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
 @seed_test
 def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtypes):  # noqa: E501
     def forward(m, forward_run=False):
-        class NewtonIterationSolver(Equation):
-            def __init__(self, m, x0, x):
+        class NewtonSolver(Equation):
+            def __init__(self, x, m, x0):
+                check_space_type(x, "primal")
                 check_space_type(m, "primal")
                 check_space_type(x0, "primal")
-                check_space_type(x, "primal")
 
                 super().__init__(x, deps=[x, x0, m], nl_deps=[x0, m],
                                  ic=False, adj_ic=False)
@@ -311,7 +311,7 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtype
         x0 = Constant(1.0, name="x0")
         x1 = Constant(0.0, name="x1")
 
-        eq0 = NewtonIterationSolver(m, x0, x1)
+        eq0 = NewtonSolver(x1, m, x0)
         eq1 = Assignment(x0, x1)
 
         fp_eq = FixedPointSolver(

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -194,7 +194,7 @@ def test_Referrers_LinearEquation(setup_test, test_leaks):
         LinearEquation(b, y, A=M).solve()
 
         z = Constant(0.0, name="z")
-        AxpySolver(x, 1.0, y, z).solve()
+        Axpy(z, x, 1.0, y).solve()
 
         if forward_run:
             manager.drop_references()

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -33,7 +33,8 @@ from .backend_code_generator_interface import assemble, \
     rhs_addto, rhs_copy, solve, update_parameters_dict, verify_assembly
 
 from ..caches import CacheRef
-from ..equations import Assignment, Equation, NullSolver, get_tangent_linear
+from ..equations import Assignment, Equation, ZeroAssignment, \
+    get_tangent_linear
 
 from .caches import assembly_cache, form_neg, is_cached, linear_solver_cache, \
     split_form
@@ -228,7 +229,7 @@ class AssembleSolver(ExprEquation):
 
         tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if tlm_rhs.empty():
-            return NullSolver(tlm_map[x])
+            return ZeroAssignment(tlm_map[x])
         else:
             return AssembleSolver(
                 tlm_rhs, tlm_map[x],
@@ -762,7 +763,7 @@ class EquationSolver(ExprEquation):
 
         tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if tlm_rhs.empty():
-            return NullSolver(tlm_map[x])
+            return ZeroAssignment(tlm_map[x])
         else:
             if self._tlm_solver_parameters is None:
                 tlm_solver_parameters = self._linear_solver_parameters
@@ -850,7 +851,7 @@ class DirichletBCSolver(Equation):
 
         tau_y = get_tangent_linear(y, M, dM, tlm_map)
         if tau_y is None:
-            return NullSolver(tlm_map[x])
+            return ZeroAssignment(tlm_map[x])
         else:
             return DirichletBCSolver(tau_y, tlm_map[x],
                                      *self._bc_args, **self._bc_kwargs)
@@ -930,9 +931,9 @@ class ExprEvaluationSolver(ExprEquation):
                     tlm_rhs += derivative(self._rhs, dep, argument=tau_dep)
 
         if isinstance(tlm_rhs, ufl.classes.Zero):
-            return NullSolver(tlm_map[x])
+            return ZeroAssignment(tlm_map[x])
         tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if isinstance(tlm_rhs, ufl.classes.Zero):
-            return NullSolver(tlm_map[x])
+            return ZeroAssignment(tlm_map[x])
         else:
             return ExprEvaluationSolver(tlm_rhs, tlm_map[x])

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -48,13 +48,14 @@ import warnings
 __all__ = \
     [
         "Assembly",
-        "DirichletBCSolver",
+        "DirichletBCApplication",
         "EquationSolver",
         "ExprEvaluation",
         "Projection",
         "linear_equation_new_x",
 
         "AssembleSolver",
+        "DirichletBCSolver",
         "ExprEvaluationSolver",
         "ProjectionSolver"
     ]
@@ -841,8 +842,8 @@ class ProjectionSolver(Projection):
         super().__init__(x, rhs, *args, **kwargs)
 
 
-class DirichletBCSolver(Equation):
-    def __init__(self, y, x, *args, **kwargs):
+class DirichletBCApplication(Equation):
+    def __init__(self, x, y, *args, **kwargs):
         check_space_type(x, "primal")
         check_space_type(y, "primal")
 
@@ -880,8 +881,17 @@ class DirichletBCSolver(Equation):
         if tau_y is None:
             return ZeroAssignment(tlm_map[x])
         else:
-            return DirichletBCSolver(tau_y, tlm_map[x],
-                                     *self._bc_args, **self._bc_kwargs)
+            return DirichletBCApplication(
+                tlm_map[x], tau_y,
+                *self._bc_args, **self._bc_kwargs)
+
+
+class DirichletBCSolver(DirichletBCApplication):
+    def __init__(self, y, x, *args, **kwargs):
+        warnings.warn("DirichletBCSolver is deprecated -- "
+                      "use DirichletBCApplication instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, y, *args, **kwargs)
 
 
 class ExprEvaluation(ExprEquation):

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -51,10 +51,11 @@ __all__ = \
         "DirichletBCSolver",
         "EquationSolver",
         "ExprEvaluationSolver",
-        "ProjectionSolver",
+        "Projection",
         "linear_equation_new_x",
 
-        "AssembleSolver"
+        "AssembleSolver",
+        "ProjectionSolver"
     ]
 
 
@@ -821,14 +822,22 @@ def linear_equation_new_x(eq, x, manager=None, annotate=None, tlm=None):
         return eq
 
 
-class ProjectionSolver(EquationSolver):
-    def __init__(self, rhs, x, *args, **kwargs):
+class Projection(EquationSolver):
+    def __init__(self, x, rhs, *args, **kwargs):
         space = function_space(x)
         test, trial = TestFunction(space), TrialFunction(space)
         if not isinstance(rhs, ufl.classes.Form):
             rhs = ufl.inner(rhs, test) * ufl.dx
         super().__init__(ufl.inner(trial, test) * ufl.dx == rhs, x,
                          *args, **kwargs)
+
+
+class ProjectionSolver(Projection):
+    def __init__(self, rhs, x, *args, **kwargs):
+        warnings.warn("ProjectionSolver is deprecated -- "
+                      "use Projection instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, rhs, *args, **kwargs)
 
 
 class DirichletBCSolver(Equation):

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -33,8 +33,7 @@ from .backend_code_generator_interface import assemble, \
     rhs_addto, rhs_copy, solve, update_parameters_dict, verify_assembly
 
 from ..caches import CacheRef
-from ..equations import AssignmentSolver, Equation, NullSolver, \
-    get_tangent_linear
+from ..equations import Assignment, Equation, NullSolver, get_tangent_linear
 
 from .caches import assembly_cache, form_neg, is_cached, linear_solver_cache, \
     split_form
@@ -794,8 +793,7 @@ def linear_equation_new_x(eq, x, manager=None, annotate=None, tlm=None):
     rhs_x_dep = x in rhs.coefficients()
     if lhs_x_dep or rhs_x_dep:
         x_old = function_new(x)
-        AssignmentSolver(x, x_old).solve(manager=manager, annotate=annotate,
-                                         tlm=tlm)
+        Assignment(x_old, x).solve(manager=manager, annotate=annotate, tlm=tlm)
         if lhs_x_dep:
             lhs = ufl.replace(lhs, {x: x_old})
         if rhs_x_dep:

--- a/tlm_adjoint/_code_generator/equations.py
+++ b/tlm_adjoint/_code_generator/equations.py
@@ -50,11 +50,12 @@ __all__ = \
         "Assembly",
         "DirichletBCSolver",
         "EquationSolver",
-        "ExprEvaluationSolver",
+        "ExprEvaluation",
         "Projection",
         "linear_equation_new_x",
 
         "AssembleSolver",
+        "ExprEvaluationSolver",
         "ProjectionSolver"
     ]
 
@@ -883,8 +884,8 @@ class DirichletBCSolver(Equation):
                                      *self._bc_args, **self._bc_kwargs)
 
 
-class ExprEvaluationSolver(ExprEquation):
-    def __init__(self, rhs, x):
+class ExprEvaluation(ExprEquation):
+    def __init__(self, x, rhs):
         if isinstance(rhs, ufl.classes.Form):
             raise TypeError("rhs should not be a Form")
 
@@ -962,4 +963,12 @@ class ExprEvaluationSolver(ExprEquation):
         if isinstance(tlm_rhs, ufl.classes.Zero):
             return ZeroAssignment(tlm_map[x])
         else:
-            return ExprEvaluationSolver(tlm_rhs, tlm_map[x])
+            return ExprEvaluation(tlm_map[x], tlm_rhs)
+
+
+class ExprEvaluationSolver(ExprEvaluation):
+    def __init__(self, rhs, x):
+        warnings.warn("ExprEvaluationSolver is deprecated -- "
+                      "use ExprEvaluation instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, rhs)

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -71,7 +71,7 @@ __all__ = \
         "DotProductRHS",
         "DotProduct",
         "InnerProductRHS",
-        "InnerProductSolver",
+        "InnerProduct",
         "MatrixActionRHS",
         "MatrixActionSolver",
         "NormSqRHS",
@@ -87,6 +87,7 @@ __all__ = \
         "AssignmentSolver",
         "AxpySolver",
         "DotProductSolver",
+        "InnerProductSolver",
         "LinearCombinationSolver",
         "NullSolver",
         "ScaleSolver"
@@ -1882,14 +1883,22 @@ class DotProductSolver(DotProduct):
         super().__init__(x, y, z, alpha=alpha)
 
 
-class InnerProductSolver(LinearEquation):
-    def __init__(self, y, z, x, alpha=1.0, M=None):
+class InnerProduct(LinearEquation):
+    def __init__(self, x, y, z, *, alpha=1.0, M=None):
         super().__init__(x, InnerProductRHS(y, z, alpha=alpha, M=M))
 
 
-class NormSqSolver(InnerProductSolver):
+class InnerProductSolver(InnerProduct):
+    def __init__(self, y, z, x, alpha=1.0, M=None):
+        warnings.warn("InnerProductSolver is deprecated -- "
+                      "use InnerProduct instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, y, z, alpha=alpha, M=M)
+
+
+class NormSqSolver(InnerProduct):
     def __init__(self, y, x, alpha=1.0, M=None):
-        super().__init__(y, y, x, alpha=alpha, M=M)
+        super().__init__(x, y, y, alpha=alpha, M=M)
 
 
 class SumSolver(LinearEquation):

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -58,7 +58,7 @@ __all__ = \
 
         "get_tangent_linear",
 
-        "AssignmentSolver",
+        "Assignment",
         "AxpySolver",
         "FixedPointSolver",
         "LinearCombinationSolver",
@@ -83,7 +83,9 @@ __all__ = \
         "Storage",
 
         "HDF5Storage",
-        "MemoryStorage"
+        "MemoryStorage",
+
+        "AssignmentSolver"
     ]
 
 
@@ -789,8 +791,8 @@ class NullSolver(Equation):
         return NullSolver([tlm_map[x] for x in self.X()])
 
 
-class AssignmentSolver(Equation):
-    def __init__(self, y, x):
+class Assignment(Equation):
+    def __init__(self, x, y):
         check_space_types(x, y)
         super().__init__(x, [x, y], nl_deps=[], ic=False, adj_ic=False)
 
@@ -815,7 +817,15 @@ class AssignmentSolver(Equation):
         if tau_y is None:
             return NullSolver(tlm_map[x])
         else:
-            return AssignmentSolver(tau_y, tlm_map[x])
+            return Assignment(tlm_map[x], tau_y)
+
+
+class AssignmentSolver(Assignment):
+    def __init__(self, y, x):
+        warnings.warn("AssignmentSolver is deprecated -- "
+                      "use Assignment instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, y)
 
 
 class LinearCombinationSolver(Equation):

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -62,7 +62,6 @@ __all__ = \
         "Axpy",
         "FixedPointSolver",
         "LinearCombinationSolver",
-        "ScaleSolver",
         "ZeroAssignment",
 
         "LinearEquation",
@@ -87,7 +86,8 @@ __all__ = \
 
         "AssignmentSolver",
         "AxpySolver",
-        "NullSolver"
+        "NullSolver",
+        "ScaleSolver"
     ]
 
 
@@ -880,6 +880,9 @@ class LinearCombinationSolver(Equation):
 
 class ScaleSolver(LinearCombinationSolver):
     def __init__(self, alpha, y, x):
+        warnings.warn("ScaleSolver is deprecated -- "
+                      "use LinearCombinationSolver instead",
+                      DeprecationWarning, stacklevel=2)
         super().__init__(x, (alpha, y))
 
 

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -73,10 +73,6 @@ __all__ = \
         "InnerProductRHS",
         "InnerProduct",
         "MatrixActionRHS",
-        "NormSqRHS",
-        "NormSqSolver",
-        "SumRHS",
-        "SumSolver",
 
         "Storage",
 
@@ -89,8 +85,12 @@ __all__ = \
         "InnerProductSolver",
         "LinearCombinationSolver",
         "MatrixActionSolver",
+        "NormSqRHS",
+        "NormSqSolver",
         "NullSolver",
-        "ScaleSolver"
+        "ScaleSolver",
+        "SumRHS",
+        "SumSolver"
     ]
 
 
@@ -1900,6 +1900,8 @@ class InnerProductSolver(InnerProduct):
 
 class NormSqSolver(InnerProduct):
     def __init__(self, y, x, alpha=1.0, M=None):
+        warnings.warn("NormSqSolver is deprecated",
+                      DeprecationWarning, stacklevel=2)
         super().__init__(x, y, y, alpha=alpha, M=M)
 
 
@@ -2245,6 +2247,8 @@ class InnerProductRHS(RHS):
 
 class NormSqRHS(InnerProductRHS):
     def __init__(self, x, alpha=1.0, M=None):
+        warnings.warn("NormSqRHS is deprecated",
+                      DeprecationWarning, stacklevel=2)
         super().__init__(x, x, alpha=alpha, M=M)
 
 

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -61,7 +61,7 @@ __all__ = \
         "Assignment",
         "Axpy",
         "FixedPointSolver",
-        "LinearCombinationSolver",
+        "LinearCombination",
         "ZeroAssignment",
 
         "LinearEquation",
@@ -86,6 +86,7 @@ __all__ = \
 
         "AssignmentSolver",
         "AxpySolver",
+        "LinearCombinationSolver",
         "NullSolver",
         "ScaleSolver"
     ]
@@ -838,7 +839,7 @@ class AssignmentSolver(Assignment):
         super().__init__(x, y)
 
 
-class LinearCombinationSolver(Equation):
+class LinearCombination(Equation):
     def __init__(self, x, *args):
         alpha = tuple(function_dtype(x)(arg[0]) for arg in args)
         Y = [arg[1] for arg in args]
@@ -875,18 +876,26 @@ class LinearCombinationSolver(Equation):
             tau_y = get_tangent_linear(y, M, dM, tlm_map)
             if tau_y is not None:
                 args.append((alpha, tau_y))
-        return LinearCombinationSolver(tlm_map[x], *args)
+        return LinearCombination(tlm_map[x], *args)
 
 
-class ScaleSolver(LinearCombinationSolver):
+class LinearCombinationSolver(LinearCombination):
+    def __init__(self, x, *args):
+        warnings.warn("LinearCombinationSolver is deprecated -- "
+                      "use LinearCombination instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, *args)
+
+
+class ScaleSolver(LinearCombination):
     def __init__(self, alpha, y, x):
         warnings.warn("ScaleSolver is deprecated -- "
-                      "use LinearCombinationSolver instead",
+                      "use LinearCombination instead",
                       DeprecationWarning, stacklevel=2)
         super().__init__(x, (alpha, y))
 
 
-class Axpy(LinearCombinationSolver):
+class Axpy(LinearCombination):
     def __init__(self, y_new, y_old, alpha, x):
         super().__init__(y_new, (1.0, y_old), (alpha, x))
 

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -73,7 +73,6 @@ __all__ = \
         "InnerProductRHS",
         "InnerProduct",
         "MatrixActionRHS",
-        "MatrixActionSolver",
         "NormSqRHS",
         "NormSqSolver",
         "SumRHS",
@@ -89,6 +88,7 @@ __all__ = \
         "DotProductSolver",
         "InnerProductSolver",
         "LinearCombinationSolver",
+        "MatrixActionSolver",
         "NullSolver",
         "ScaleSolver"
     ]
@@ -1867,6 +1867,8 @@ class RHS(Referrer):
 
 class MatrixActionSolver(LinearEquation):
     def __init__(self, Y, A, X):
+        warnings.warn("MatrixActionSolver is deprecated",
+                      DeprecationWarning, stacklevel=2)
         super().__init__(X, MatrixActionRHS(A, Y))
 
 

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -59,7 +59,7 @@ __all__ = \
         "get_tangent_linear",
 
         "Assignment",
-        "AxpySolver",
+        "Axpy",
         "FixedPointSolver",
         "LinearCombinationSolver",
         "NullSolver",
@@ -85,7 +85,8 @@ __all__ = \
         "HDF5Storage",
         "MemoryStorage",
 
-        "AssignmentSolver"
+        "AssignmentSolver",
+        "AxpySolver"
     ]
 
 
@@ -873,10 +874,17 @@ class ScaleSolver(LinearCombinationSolver):
         super().__init__(x, (alpha, y))
 
 
-class AxpySolver(LinearCombinationSolver):
-    def __init__(self, *args):  # self, y_old, alpha, x, y_new
-        y_old, alpha, x, y_new = args
+class Axpy(LinearCombinationSolver):
+    def __init__(self, y_new, y_old, alpha, x):
         super().__init__(y_new, (1.0, y_old), (alpha, x))
+
+
+class AxpySolver(Axpy):
+    def __init__(self, y_old, alpha, x, y_new, /):
+        warnings.warn("AxpySolver is deprecated -- "
+                      "use Axpy instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(y_new, y_old, alpha, x)
 
 
 @no_space_type_checking

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -69,7 +69,7 @@ __all__ = \
         "RHS",
 
         "DotProductRHS",
-        "DotProductSolver",
+        "DotProduct",
         "InnerProductRHS",
         "InnerProductSolver",
         "MatrixActionRHS",
@@ -86,6 +86,7 @@ __all__ = \
 
         "AssignmentSolver",
         "AxpySolver",
+        "DotProductSolver",
         "LinearCombinationSolver",
         "NullSolver",
         "ScaleSolver"
@@ -1858,9 +1859,17 @@ class MatrixActionSolver(LinearEquation):
         super().__init__(MatrixActionRHS(A, Y), X)
 
 
-class DotProductSolver(LinearEquation):
-    def __init__(self, y, z, x, alpha=1.0):
+class DotProduct(LinearEquation):
+    def __init__(self, x, y, z, *, alpha=1.0):
         super().__init__(DotProductRHS(y, z, alpha=alpha), x)
+
+
+class DotProductSolver(DotProduct):
+    def __init__(self, y, z, x, alpha=1.0):
+        warnings.warn("DotProductSolver is deprecated -- "
+                      "use DotProduct instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, y, z, alpha=alpha)
 
 
 class InnerProductSolver(LinearEquation):

--- a/tlm_adjoint/fenics/backend_code_generator_interface.py
+++ b/tlm_adjoint/fenics/backend_code_generator_interface.py
@@ -69,10 +69,10 @@ __all__ = \
 if "tlm_adjoint" not in parameters:
     parameters.add(Parameters("tlm_adjoint"))
 _parameters = parameters["tlm_adjoint"]
-if "AssembleSolver" not in _parameters:
-    _parameters.add(Parameters("AssembleSolver"))
-if "match_quadrature" not in _parameters["AssembleSolver"]:
-    _parameters["AssembleSolver"].add("match_quadrature", False)
+if "Assembly" not in _parameters:
+    _parameters.add(Parameters("Assembly"))
+if "match_quadrature" not in _parameters["Assembly"]:
+    _parameters["Assembly"].add("match_quadrature", False)
 if "EquationSolver" not in _parameters:
     _parameters.add(Parameters("EquationSolver"))
 if "enable_jacobian_caching" not in _parameters["EquationSolver"]:
@@ -89,6 +89,11 @@ if "jacobian_tolerance" not in _parameters["assembly_verification"]:
     _parameters["assembly_verification"].add("jacobian_tolerance", np.inf)
 if "rhs_tolerance" not in _parameters["assembly_verification"]:
     _parameters["assembly_verification"].add("rhs_tolerance", np.inf)
+# For deprecated AssembleSolver
+if "AssembleSolver" not in _parameters:
+    _parameters.add(Parameters("AssembleSolver"))
+if "match_quadrature" not in _parameters["AssembleSolver"]:
+    _parameters["AssembleSolver"].add("match_quadrature", False)
 del _parameters
 
 

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -484,7 +484,7 @@ add_finalize_adjoint_derivative_action(backend,
                                        _finalize_adjoint_derivative_action)
 
 
-def _functional_term_eq(term, x):
+def _functional_term_eq(x, term):
     if isinstance(term, ufl.classes.Form) \
             and len(term.arguments()) == 0 \
             and isinstance(x, (backend_Constant, backend_Function)):

--- a/tlm_adjoint/fenics/backend_interface.py
+++ b/tlm_adjoint/fenics/backend_interface.py
@@ -35,7 +35,7 @@ from .backend_code_generator_interface import assemble, is_valid_r0_space, \
     r0_space
 
 from .caches import form_neg
-from .equations import AssembleSolver, EquationSolver
+from .equations import Assembly, EquationSolver
 from .functions import Caches, Constant, ConstantInterface, \
     ConstantSpaceInterface, Function, ReplacementFunction, Zero, \
     define_function_alias
@@ -488,7 +488,7 @@ def _functional_term_eq(x, term):
     if isinstance(term, ufl.classes.Form) \
             and len(term.arguments()) == 0 \
             and isinstance(x, (backend_Constant, backend_Function)):
-        return AssembleSolver(term, x)
+        return Assembly(x, term)
     else:
         return NotImplemented
 

--- a/tlm_adjoint/fenics/backend_overrides.py
+++ b/tlm_adjoint/fenics/backend_overrides.py
@@ -32,7 +32,7 @@ from .backend_code_generator_interface import copy_parameters_dict, \
 from ..manager import annotation_enabled, tlm_enabled
 
 from ..equations import Assignment
-from .equations import EquationSolver, ExprEvaluationSolver, Projection, \
+from .equations import EquationSolver, ExprEvaluation, Projection, \
     linear_equation_new_x
 
 import numpy as np
@@ -385,7 +385,7 @@ def _Constant_assign(self, x, *, annotate=None, tlm=None):
                 Assignment(self_old, self).solve(
                     annotate=annotate, tlm=tlm)
                 x = ufl.replace(x, {self: self_old})
-            ExprEvaluationSolver(x, self).solve(annotate=annotate, tlm=tlm)
+            ExprEvaluation(self, x).solve(annotate=annotate, tlm=tlm)
             return
 
     return_value = backend_Constant._tlm_adjoint__orig_assign(
@@ -426,7 +426,7 @@ def _Function_assign(self, rhs, *, annotate=None, tlm=None):
                     Assignment(self_old, self).solve(
                         annotate=annotate, tlm=tlm)
                     rhs = ufl.replace(rhs, {self: self_old})
-                ExprEvaluationSolver(rhs, self).solve(
+                ExprEvaluation(self, rhs).solve(
                     annotate=annotate, tlm=tlm)
                 return
     elif isinstance(rhs, backend_Function) and rhs is not self:

--- a/tlm_adjoint/fenics/backend_overrides.py
+++ b/tlm_adjoint/fenics/backend_overrides.py
@@ -31,8 +31,9 @@ from .backend_code_generator_interface import copy_parameters_dict, \
 
 from ..manager import annotation_enabled, tlm_enabled
 
-from .equations import AssignmentSolver, EquationSolver, \
-    ExprEvaluationSolver, ProjectionSolver, linear_equation_new_x
+from ..equations import Assignment
+from .equations import EquationSolver, ExprEvaluationSolver, \
+    ProjectionSolver, linear_equation_new_x
 
 import numpy as np
 import ufl
@@ -309,7 +310,7 @@ def project(v, V=None, bcs=None, mesh=None, function=None, solver_type="lu",
 
         if x in ufl.algorithms.extract_coefficients(v):
             x_old = function_new(x)
-            AssignmentSolver(x, x_old).solve(annotate=annotate, tlm=tlm)
+            Assignment(x_old, x).solve(annotate=annotate, tlm=tlm)
             v = ufl.replace(v, {x: x_old})
 
         eq = ProjectionSolver(
@@ -371,17 +372,17 @@ def _Constant_assign(self, x, *, annotate=None, tlm=None):
     if annotate or tlm:
         if isinstance(x, (int, np.integer,
                           float, np.floating)):
-            AssignmentSolver(backend_Constant(x), self).solve(
+            Assignment(self, backend_Constant(x)).solve(
                 annotate=annotate, tlm=tlm)
             return
         elif isinstance(x, backend_Constant):
             if x is not self:
-                AssignmentSolver(x, self).solve(annotate=annotate, tlm=tlm)
+                Assignment(self, x).solve(annotate=annotate, tlm=tlm)
                 return
         elif isinstance(x, ufl.classes.Expr):
             if self in ufl.algorithms.extract_coefficients(x):
                 self_old = function_new(self)
-                AssignmentSolver(self, self_old).solve(
+                Assignment(self_old, self).solve(
                     annotate=annotate, tlm=tlm)
                 x = ufl.replace(x, {self: self_old})
             ExprEvaluationSolver(x, self).solve(annotate=annotate, tlm=tlm)
@@ -407,7 +408,7 @@ def _Function_assign(self, rhs, *, annotate=None, tlm=None):
         if isinstance(rhs, backend_Function) \
                 and space_id(function_space(rhs)) == space_id(function_space(self)):  # noqa: E501
             if rhs is not self:
-                AssignmentSolver(rhs, self).solve(
+                Assignment(self, rhs).solve(
                     annotate=annotate, tlm=tlm)
                 return
         elif isinstance(rhs, ufl.classes.Expr):
@@ -422,7 +423,7 @@ def _Function_assign(self, rhs, *, annotate=None, tlm=None):
             else:
                 if self in deps:
                     self_old = function_new(self)
-                    AssignmentSolver(self, self_old).solve(
+                    Assignment(self_old, self).solve(
                         annotate=annotate, tlm=tlm)
                     rhs = ufl.replace(rhs, {self: self_old})
                 ExprEvaluationSolver(rhs, self).solve(

--- a/tlm_adjoint/fenics/backend_overrides.py
+++ b/tlm_adjoint/fenics/backend_overrides.py
@@ -32,8 +32,8 @@ from .backend_code_generator_interface import copy_parameters_dict, \
 from ..manager import annotation_enabled, tlm_enabled
 
 from ..equations import Assignment
-from .equations import EquationSolver, ExprEvaluationSolver, \
-    ProjectionSolver, linear_equation_new_x
+from .equations import EquationSolver, ExprEvaluationSolver, Projection, \
+    linear_equation_new_x
 
 import numpy as np
 import ufl
@@ -313,8 +313,8 @@ def project(v, V=None, bcs=None, mesh=None, function=None, solver_type="lu",
             Assignment(x_old, x).solve(annotate=annotate, tlm=tlm)
             v = ufl.replace(v, {x: x_old})
 
-        eq = ProjectionSolver(
-            v, x, bcs, solver_parameters=solver_parameters,
+        eq = Projection(
+            x, v, bcs, solver_parameters=solver_parameters,
             form_compiler_parameters=form_compiler_parameters,
             cache_jacobian=False, cache_rhs_assembly=False)
         eq.solve(annotate=annotate, tlm=tlm)

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -50,6 +50,8 @@ __all__ = \
 
         "InterpolationSolver",
         "LocalProjectionSolver",
+        "PointInterpolation",
+
         "PointInterpolationSolver"
     ]
 
@@ -530,9 +532,9 @@ class InterpolationSolver(LinearEquation):
             x, MatrixActionRHS(LocalMatrix(P), y))
 
 
-class PointInterpolationSolver(Equation):
-    def __init__(self, y, X, X_coords=None, y_colors=None, y_cells=None,
-                 P=None, P_T=None, tolerance=0.0):
+class PointInterpolation(Equation):
+    def __init__(self, X, y, X_coords=None, *, y_colors=None, y_cells=None,
+                 P=None, tolerance=0.0):
         """
         Defines an equation which interpolates the scalar-valued Function y at
         the points X_coords.
@@ -562,10 +564,6 @@ class PointInterpolationSolver(Equation):
         tolerance  (Optional) Maximum distance of an interpolation point from
                    a cell. Ignored if P or y_cells are supplied.
         """
-
-        if P_T is not None:
-            warnings.warn("P_T argument is deprecated and has no effect",
-                          DeprecationWarning, stacklevel=2)
 
         if is_function(X):
             X = (X,)
@@ -649,5 +647,18 @@ class PointInterpolationSolver(Equation):
         if tlm_y is None:
             return ZeroAssignment([tlm_map[x] for x in X])
         else:
-            return PointInterpolationSolver(tlm_y, [tlm_map[x] for x in X],
-                                            P=self._P)
+            return PointInterpolation([tlm_map[x] for x in X], tlm_y,
+                                      P=self._P)
+
+
+class PointInterpolationSolver(PointInterpolation):
+    def __init__(self, y, X, X_coords=None, y_colors=None, y_cells=None,
+                 P=None, P_T=None, tolerance=0.0):
+        if P_T is not None:
+            warnings.warn("P_T argument is deprecated and has no effect",
+                          DeprecationWarning, stacklevel=2)
+        warnings.warn("PointInterpolationSolver is deprecated -- "
+                      "use PointInterpolation instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(X, y, X_coords, y_colors=y_colors, y_cells=y_cells,
+                         P=P, tolerance=tolerance)

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -29,7 +29,7 @@ from .backend_code_generator_interface import assemble, complex_mode
 
 from ..caches import Cache
 from ..equations import Equation, LinearEquation, Matrix, MatrixActionRHS, \
-    NullSolver, get_tangent_linear
+    ZeroAssignment, get_tangent_linear
 
 from .caches import form_dependencies, form_key
 from .equations import EquationSolver, bind_form, derivative, unbind_form, \
@@ -329,7 +329,7 @@ class LocalProjectionSolver(EquationSolver):
 
         tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if tlm_rhs.empty():
-            return NullSolver(tlm_map[x])
+            return ZeroAssignment(tlm_map[x])
         else:
             return LocalProjectionSolver(
                 tlm_rhs, tlm_map[x],
@@ -647,7 +647,7 @@ class PointInterpolationSolver(Equation):
 
         tlm_y = get_tangent_linear(y, M, dM, tlm_map)
         if tlm_y is None:
-            return NullSolver([tlm_map[x] for x in X])
+            return ZeroAssignment([tlm_map[x] for x in X])
         else:
             return PointInterpolationSolver(tlm_y, [tlm_map[x] for x in X],
                                             P=self._P)

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -49,9 +49,10 @@ __all__ = \
         "set_local_solver_cache",
 
         "InterpolationSolver",
-        "LocalProjectionSolver",
+        "LocalProjection",
         "PointInterpolation",
 
+        "LocalProjectionSolver",
         "PointInterpolationSolver"
     ]
 
@@ -246,8 +247,8 @@ def set_local_solver_cache(local_solver_cache):
     _local_solver_cache[0] = local_solver_cache
 
 
-class LocalProjectionSolver(EquationSolver):
-    def __init__(self, rhs, x, form_compiler_parameters=None,
+class LocalProjection(EquationSolver):
+    def __init__(self, x, rhs, *, form_compiler_parameters=None,
                  cache_jacobian=None, cache_rhs_assembly=None,
                  match_quadrature=None, defer_adjoint_assembly=None):
         if form_compiler_parameters is None:
@@ -333,12 +334,27 @@ class LocalProjectionSolver(EquationSolver):
         if tlm_rhs.empty():
             return ZeroAssignment(tlm_map[x])
         else:
-            return LocalProjectionSolver(
-                tlm_rhs, tlm_map[x],
+            return LocalProjection(
+                tlm_map[x], tlm_rhs,
                 form_compiler_parameters=self._form_compiler_parameters,
                 cache_jacobian=self._cache_jacobian,
                 cache_rhs_assembly=self._cache_rhs_assembly,
                 defer_adjoint_assembly=self._defer_adjoint_assembly)
+
+
+class LocalProjectionSolver(LocalProjection):
+    def __init__(self, rhs, x, form_compiler_parameters=None,
+                 cache_jacobian=None, cache_rhs_assembly=None,
+                 match_quadrature=None, defer_adjoint_assembly=None):
+        warnings.warn("LocalProjectionSolver is deprecated -- "
+                      "use LocalProjection instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(
+            x, rhs, form_compiler_parameters=form_compiler_parameters,
+            cache_jacobian=cache_jacobian,
+            cache_rhs_assembly=cache_rhs_assembly,
+            match_quadrature=match_quadrature,
+            defer_adjoint_assembly=defer_adjoint_assembly)
 
 
 def point_owners(x_coords, y_space, tolerance=0.0):

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -498,8 +498,8 @@ class Interpolation(LinearEquation):
 
         Arguments:
 
-        y          A scalar-valued Function. The Function to be interpolated.
         x          A scalar-valued Function. The solution to the equation.
+        y          A scalar-valued Function. The Function to be interpolated.
         x_coords   (Optional) A NumPy array. Coordinates at which to
                    interpolate the Function.
         y_colors   (Optional) An integer NumPy vector. Node-node graph coloring
@@ -576,9 +576,9 @@ class PointInterpolation(Equation):
 
         Arguments:
 
-        y         A scalar-valued Function. The Function to be interpolated.
         X         A scalar, or a sequence of scalars. The solution to the
                   equation.
+        y         A scalar-valued Function. The Function to be interpolated.
         X_coords  A NumPy matrix. Points at which to interpolate y.
                   Ignored if P is supplied, required otherwise.
         y_colors  (Optional) An integer NumPy vector. Node-node graph coloring

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -48,10 +48,11 @@ __all__ = \
         "local_solver_cache",
         "set_local_solver_cache",
 
-        "InterpolationSolver",
+        "Interpolation",
         "LocalProjection",
         "PointInterpolation",
 
+        "InterpolationSolver",
         "LocalProjectionSolver",
         "PointInterpolationSolver"
     ]
@@ -480,8 +481,8 @@ class InterpolationMatrix(LocalMatrix):
         super().__init__(*args, **kwargs)
 
 
-class InterpolationSolver(LinearEquation):
-    def __init__(self, y, x, x_coords=None, y_colors=None, P=None, P_T=None,
+class Interpolation(LinearEquation):
+    def __init__(self, x, y, *, x_coords=None, y_colors=None, P=None,
                  tolerance=0.0):
         """
         Defines an equation which interpolates the scalar-valued Function y.
@@ -508,10 +509,6 @@ class InterpolationSolver(LinearEquation):
         tolerance  (Optional) Maximum distance of an interpolation point from
                    a cell. Ignored if P is supplied.
         """
-
-        if P_T is not None:
-            warnings.warn("P_T argument is deprecated and has no effect",
-                          DeprecationWarning, stacklevel=2)
 
         check_space_type(x, "primal")
         check_space_type(y, "primal")
@@ -546,6 +543,19 @@ class InterpolationSolver(LinearEquation):
 
         super().__init__(
             x, MatrixActionRHS(LocalMatrix(P), y))
+
+
+class InterpolationSolver(Interpolation):
+    def __init__(self, y, x, x_coords=None, y_colors=None, P=None, P_T=None,
+                 tolerance=0.0):
+        if P_T is not None:
+            warnings.warn("P_T argument is deprecated and has no effect",
+                          DeprecationWarning, stacklevel=2)
+        warnings.warn("InterpolationSolver is deprecated -- "
+                      "use Interpolation instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, y, x_coords=x_coords, y_colors=y_colors, P=P,
+                         tolerance=tolerance)
 
 
 class PointInterpolation(Equation):

--- a/tlm_adjoint/fenics/fenics_equations.py
+++ b/tlm_adjoint/fenics/fenics_equations.py
@@ -527,7 +527,7 @@ class InterpolationSolver(LinearEquation):
             P = P.copy()
 
         super().__init__(
-            MatrixActionRHS(LocalMatrix(P), y), x)
+            x, MatrixActionRHS(LocalMatrix(P), y))
 
 
 class PointInterpolationSolver(Equation):

--- a/tlm_adjoint/firedrake/backend_code_generator_interface.py
+++ b/tlm_adjoint/firedrake/backend_code_generator_interface.py
@@ -63,8 +63,8 @@ __all__ = \
 
 
 _parameters = parameters.setdefault("tlm_adjoint", {})
-_parameters.setdefault("AssembleSolver", {})
-_parameters["AssembleSolver"].setdefault("match_quadrature", False)
+_parameters.setdefault("Assembly", {})
+_parameters["Assembly"].setdefault("match_quadrature", False)
 _parameters.setdefault("EquationSolver", {})
 _parameters["EquationSolver"].setdefault("enable_jacobian_caching", True)
 _parameters["EquationSolver"].setdefault("cache_rhs_assembly", True)
@@ -73,6 +73,9 @@ _parameters["EquationSolver"].setdefault("defer_adjoint_assembly", False)
 _parameters.setdefault("assembly_verification", {})
 _parameters["assembly_verification"].setdefault("jacobian_tolerance", np.inf)
 _parameters["assembly_verification"].setdefault("rhs_tolerance", np.inf)
+# For deprecated AssembleSolver
+_parameters.setdefault("AssembleSolver", {})
+_parameters["AssembleSolver"].setdefault("match_quadrature", False)
 del _parameters
 
 

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -35,7 +35,7 @@ from ..interface import FunctionInterface as _FunctionInterface
 from .backend_code_generator_interface import assemble, is_valid_r0_space
 
 from .caches import form_neg
-from .equations import AssembleSolver, EquationSolver
+from .equations import Assembly, EquationSolver
 from .functions import Caches, Constant, ConstantInterface, \
     ConstantSpaceInterface, Function, ReplacementFunction, Zero, \
     define_function_alias
@@ -451,7 +451,7 @@ def _functional_term_eq(x, term):
     if isinstance(term, ufl.classes.Form) \
             and len(term.arguments()) == 0 \
             and isinstance(x, (backend_Constant, backend_Function)):
-        return AssembleSolver(term, x)
+        return Assembly(x, term)
     else:
         return NotImplemented
 

--- a/tlm_adjoint/firedrake/backend_interface.py
+++ b/tlm_adjoint/firedrake/backend_interface.py
@@ -447,7 +447,7 @@ add_finalize_adjoint_derivative_action(backend,
                                        _finalize_adjoint_derivative_action)
 
 
-def _functional_term_eq(term, x):
+def _functional_term_eq(x, term):
     if isinstance(term, ufl.classes.Form) \
             and len(term.arguments()) == 0 \
             and isinstance(x, (backend_Constant, backend_Function)):

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -32,8 +32,8 @@ from .backend_code_generator_interface import copy_parameters_dict, \
 from ..manager import annotation_enabled, tlm_enabled
 
 from ..equations import Assignment
-from .equations import EquationSolver, ExprEvaluationSolver, \
-    ProjectionSolver, linear_equation_new_x
+from .equations import EquationSolver, ExprEvaluationSolver, Projection, \
+    linear_equation_new_x
 from .firedrake_equations import LocalProjectionSolver
 
 import copy
@@ -302,8 +302,8 @@ def project(v, V, bcs=None, solver_parameters=None,
                 cache_jacobian=False, cache_rhs_assembly=False)
             eq.solve(annotate=annotate, tlm=tlm)
         else:
-            eq = ProjectionSolver(
-                v, x, bcs, solver_parameters=solver_parameters,
+            eq = Projection(
+                x, v, bcs, solver_parameters=solver_parameters,
                 form_compiler_parameters=form_compiler_parameters,
                 cache_jacobian=False, cache_rhs_assembly=False)
             eq.solve(annotate=annotate, tlm=tlm)

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -32,7 +32,7 @@ from .backend_code_generator_interface import copy_parameters_dict, \
 from ..manager import annotation_enabled, tlm_enabled
 
 from ..equations import Assignment
-from .equations import EquationSolver, ExprEvaluationSolver, Projection, \
+from .equations import EquationSolver, ExprEvaluation, Projection, \
     linear_equation_new_x
 from .firedrake_equations import LocalProjectionSolver
 
@@ -341,7 +341,7 @@ def _Constant_assign(self, value, *, annotate=None, tlm=None):
                 Assignment(self_old, self).solve(
                     annotate=annotate, tlm=tlm)
                 value = ufl.replace(value, {self: self_old})
-            ExprEvaluationSolver(value, self).solve(annotate=annotate, tlm=tlm)
+            ExprEvaluation(self, value).solve(annotate=annotate, tlm=tlm)
             return
 
     return_value = backend_Constant._tlm_adjoint__orig_assign(
@@ -380,7 +380,7 @@ def _Function_assign(self, expr, subset=None, *, annotate=None, tlm=None):
                     Assignment(self_old, self).solve(
                         annotate=annotate, tlm=tlm)
                     expr = ufl.replace(expr, {self: self_old})
-                ExprEvaluationSolver(expr, self).solve(
+                ExprEvaluation(self, expr).solve(
                     annotate=annotate, tlm=tlm)
                 return self
 

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -34,7 +34,7 @@ from ..manager import annotation_enabled, tlm_enabled
 from ..equations import Assignment
 from .equations import EquationSolver, ExprEvaluation, Projection, \
     linear_equation_new_x
-from .firedrake_equations import LocalProjectionSolver
+from .firedrake_equations import LocalProjection
 
 import copy
 import numpy as np
@@ -297,8 +297,8 @@ def project(v, V, bcs=None, solver_parameters=None,
         if use_slate_for_inverse:
             if len(bcs) > 0:
                 raise NotImplementedError("Boundary conditions not supported")
-            eq = LocalProjectionSolver(
-                v, x, form_compiler_parameters=form_compiler_parameters,
+            eq = LocalProjection(
+                x, v, form_compiler_parameters=form_compiler_parameters,
                 cache_jacobian=False, cache_rhs_assembly=False)
             eq.solve(annotate=annotate, tlm=tlm)
         else:

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -31,8 +31,9 @@ from .backend_code_generator_interface import copy_parameters_dict, \
 
 from ..manager import annotation_enabled, tlm_enabled
 
-from .equations import AssignmentSolver, EquationSolver, \
-    ExprEvaluationSolver, ProjectionSolver, linear_equation_new_x
+from ..equations import Assignment
+from .equations import EquationSolver, ExprEvaluationSolver, \
+    ProjectionSolver, linear_equation_new_x
 from .firedrake_equations import LocalProjectionSolver
 
 import copy
@@ -291,7 +292,7 @@ def project(v, V, bcs=None, solver_parameters=None,
             form_compiler_parameters = {}
         if x in ufl.algorithms.extract_coefficients(v):
             x_old = function_new(x)
-            AssignmentSolver(x, x_old).solve(annotate=annotate, tlm=tlm)
+            Assignment(x_old, x).solve(annotate=annotate, tlm=tlm)
             v = ufl.replace(v, {x: x_old})
         if use_slate_for_inverse:
             if len(bcs) > 0:
@@ -327,17 +328,17 @@ def _Constant_assign(self, value, *, annotate=None, tlm=None):
         if isinstance(value, (int, np.integer,
                               float, np.floating,
                               complex, np.complexfloating)):
-            AssignmentSolver(backend_Constant(value), self).solve(
+            Assignment(self, backend_Constant(value)).solve(
                 annotate=annotate, tlm=tlm)
             return
         elif isinstance(value, backend_Constant):
             if value is not self:
-                AssignmentSolver(value, self).solve(annotate=annotate, tlm=tlm)
+                Assignment(self, value).solve(annotate=annotate, tlm=tlm)
                 return
         elif isinstance(value, ufl.classes.Expr):
             if self in ufl.algorithms.extract_coefficients(value):
                 self_old = function_new(self)
-                AssignmentSolver(self, self_old).solve(
+                Assignment(self_old, self).solve(
                     annotate=annotate, tlm=tlm)
                 value = ufl.replace(value, {self: self_old})
             ExprEvaluationSolver(value, self).solve(annotate=annotate, tlm=tlm)
@@ -370,13 +371,13 @@ def _Function_assign(self, expr, subset=None, *, annotate=None, tlm=None):
             if isinstance(expr, backend_Function) \
                     and space_id(function_space(expr)) == space_id(function_space(self)):  # noqa: E501
                 if expr is not self:
-                    AssignmentSolver(expr, self).solve(
+                    Assignment(self, expr).solve(
                         annotate=annotate, tlm=tlm)
                     return self
             elif isinstance(expr, ufl.classes.Expr):
                 if self in ufl.algorithms.extract_coefficients(expr):
                     self_old = function_new(self)
-                    AssignmentSolver(self, self_old).solve(
+                    Assignment(self_old, self).solve(
                         annotate=annotate, tlm=tlm)
                     expr = ufl.replace(expr, {self: self_old})
                 ExprEvaluationSolver(expr, self).solve(

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -47,9 +47,10 @@ __all__ = \
         "local_solver_cache",
         "set_local_solver_cache",
 
-        "LocalProjectionSolver",
+        "LocalProjection",
         "PointInterpolation",
 
+        "LocalProjectionSolver",
         "PointInterpolationSolver"
     ]
 
@@ -112,8 +113,8 @@ def set_local_solver_cache(local_solver_cache):
     _local_solver_cache[0] = local_solver_cache
 
 
-class LocalProjectionSolver(EquationSolver):
-    def __init__(self, rhs, x, form_compiler_parameters=None,
+class LocalProjection(EquationSolver):
+    def __init__(self, x, rhs, *, form_compiler_parameters=None,
                  cache_jacobian=None, cache_rhs_assembly=None,
                  match_quadrature=None, defer_adjoint_assembly=None):
         if form_compiler_parameters is None:
@@ -199,12 +200,27 @@ class LocalProjectionSolver(EquationSolver):
         if tlm_rhs.empty():
             return ZeroAssignment(tlm_map[x])
         else:
-            return LocalProjectionSolver(
-                tlm_rhs, tlm_map[x],
+            return LocalProjection(
+                tlm_map[x], tlm_rhs,
                 form_compiler_parameters=self._form_compiler_parameters,
                 cache_jacobian=self._cache_jacobian,
                 cache_rhs_assembly=self._cache_rhs_assembly,
                 defer_adjoint_assembly=self._defer_adjoint_assembly)
+
+
+class LocalProjectionSolver(LocalProjection):
+    def __init__(self, rhs, x, form_compiler_parameters=None,
+                 cache_jacobian=None, cache_rhs_assembly=None,
+                 match_quadrature=None, defer_adjoint_assembly=None):
+        warnings.warn("LocalProjectionSolver is deprecated -- "
+                      "use LocalProjection instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(
+            x, rhs, form_compiler_parameters=form_compiler_parameters,
+            cache_jacobian=cache_jacobian,
+            cache_rhs_assembly=cache_rhs_assembly,
+            match_quadrature=match_quadrature,
+            defer_adjoint_assembly=defer_adjoint_assembly)
 
 
 def interpolation_matrix(x_coords, y, y_nodes, dtype=backend_ScalarType):

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -259,10 +259,10 @@ class PointInterpolation(Equation):
 
         Arguments:
 
-        y          A continuous scalar-valued Function. The Function to be
-                   interpolated.
         X          A scalar, or a sequence of scalars. The solution to the
                    equation.
+        y          A continuous scalar-valued Function. The Function to be
+                   interpolated.
         X_coords   A NumPy matrix. Points at which to interpolate y.
                    Ignored if P is supplied, required otherwise.
         P          (Optional) Interpolation matrix.

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -48,6 +48,8 @@ __all__ = \
         "set_local_solver_cache",
 
         "LocalProjectionSolver",
+        "PointInterpolation",
+
         "PointInterpolationSolver"
     ]
 
@@ -233,8 +235,8 @@ def interpolation_matrix(x_coords, y, y_nodes, dtype=backend_ScalarType):
     return P.tocsr()
 
 
-class PointInterpolationSolver(Equation):
-    def __init__(self, y, X, X_coords=None, P=None, P_T=None, tolerance=None):
+class PointInterpolation(Equation):
+    def __init__(self, X, y, X_coords=None, *, P=None, tolerance=None):
         """
         Defines an equation which interpolates the continuous scalar-valued
         Function y at the points X_coords.
@@ -251,10 +253,6 @@ class PointInterpolationSolver(Equation):
         tolerance  (Optional) Cell containment tolerance, passed to the
                    MeshGeometry.locate_cell method. Ignored if P is supplied.
         """
-
-        if P_T is not None:
-            warnings.warn("P_T argument is deprecated and has no effect",
-                          DeprecationWarning, stacklevel=2)
 
         if is_function(X):
             X = (X,)
@@ -364,5 +362,16 @@ class PointInterpolationSolver(Equation):
         if tlm_y is None:
             return ZeroAssignment([tlm_map[x] for x in X])
         else:
-            return PointInterpolationSolver(tlm_y, [tlm_map[x] for x in X],
-                                            P=self._P)
+            return PointInterpolation([tlm_map[x] for x in X], tlm_y,
+                                      P=self._P)
+
+
+class PointInterpolationSolver(PointInterpolation):
+    def __init__(self, y, X, X_coords=None, P=None, P_T=None, tolerance=None):
+        if P_T is not None:
+            warnings.warn("P_T argument is deprecated and has no effect",
+                          DeprecationWarning, stacklevel=2)
+        warnings.warn("PointInterpolationSolver is deprecated -- "
+                      "use PointInterpolation instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(X, y, X_coords, P=P, tolerance=tolerance)

--- a/tlm_adjoint/firedrake/firedrake_equations.py
+++ b/tlm_adjoint/firedrake/firedrake_equations.py
@@ -29,7 +29,7 @@ from .backend_code_generator_interface import assemble, complex_mode, \
     matrix_multiply
 
 from ..caches import Cache
-from ..equations import Equation, NullSolver, get_tangent_linear
+from ..equations import Equation, ZeroAssignment, get_tangent_linear
 
 from .caches import form_dependencies, form_key, parameters_key
 from .equations import EquationSolver, bind_form, derivative, unbind_form, \
@@ -195,7 +195,7 @@ class LocalProjectionSolver(EquationSolver):
 
         tlm_rhs = ufl.algorithms.expand_derivatives(tlm_rhs)
         if tlm_rhs.empty():
-            return NullSolver(tlm_map[x])
+            return ZeroAssignment(tlm_map[x])
         else:
             return LocalProjectionSolver(
                 tlm_rhs, tlm_map[x],
@@ -362,7 +362,7 @@ class PointInterpolationSolver(Equation):
 
         tlm_y = get_tangent_linear(y, M, dM, tlm_map)
         if tlm_y is None:
-            return NullSolver([tlm_map[x] for x in X])
+            return ZeroAssignment([tlm_map[x] for x in X])
         else:
             return PointInterpolationSolver(tlm_y, [tlm_map[x] for x in X],
                                             P=self._P)

--- a/tlm_adjoint/functional.py
+++ b/tlm_adjoint/functional.py
@@ -22,7 +22,7 @@ from .interface import check_space_type, function_is_scalar, function_name, \
     function_new, function_scalar_value, function_space, functional_term_eq, \
     is_function, space_id, space_new
 
-from .equations import Assignment, AxpySolver
+from .equations import Assignment, Axpy
 from .manager import manager as _manager
 
 import warnings
@@ -124,7 +124,7 @@ class Functional:
                 term_fn = function_new(self._fn, name=f"{self._name:s}_term")
                 term_eq = functional_term_eq(term, term_fn)
                 term_eq.solve(manager=manager, annotate=annotate, tlm=tlm)
-            new_fn_eq = AxpySolver(self._fn, 1.0, term_fn, new_fn)
+            new_fn_eq = Axpy(new_fn, self._fn, 1.0, term_fn)
             new_fn_eq.solve(manager=manager, annotate=annotate, tlm=tlm)
         self._fn = new_fn
 

--- a/tlm_adjoint/functional.py
+++ b/tlm_adjoint/functional.py
@@ -22,7 +22,7 @@ from .interface import check_space_type, function_is_scalar, function_name, \
     function_new, function_scalar_value, function_space, functional_term_eq, \
     is_function, space_id, space_new
 
-from .equations import AssignmentSolver, AxpySolver
+from .equations import Assignment, AxpySolver
 from .manager import manager as _manager
 
 import warnings
@@ -88,7 +88,7 @@ class Functional:
 
         new_fn = function_new(self._fn, name=self._name)
         if is_function(term) and function_is_scalar(term):
-            new_fn_eq = AssignmentSolver(term, new_fn)
+            new_fn_eq = Assignment(new_fn, term)
         else:
             new_fn_eq = functional_term_eq(term, new_fn)
         new_fn_eq.solve(manager=manager, annotate=annotate, tlm=tlm)
@@ -115,7 +115,7 @@ class Functional:
 
         new_fn = function_new(self._fn, name=self._name)
         if term is None:
-            new_fn_eq = AssignmentSolver(self._fn, new_fn)
+            new_fn_eq = Assignment(new_fn, self._fn)
             new_fn_eq.solve(manager=manager, annotate=annotate, tlm=tlm)
         else:
             if is_function(term) and function_is_scalar(term):

--- a/tlm_adjoint/functional.py
+++ b/tlm_adjoint/functional.py
@@ -90,7 +90,7 @@ class Functional:
         if is_function(term) and function_is_scalar(term):
             new_fn_eq = Assignment(new_fn, term)
         else:
-            new_fn_eq = functional_term_eq(term, new_fn)
+            new_fn_eq = functional_term_eq(new_fn, term)
         new_fn_eq.solve(manager=manager, annotate=annotate, tlm=tlm)
         self._fn = new_fn
 
@@ -122,7 +122,7 @@ class Functional:
                 term_fn = term
             else:
                 term_fn = function_new(self._fn, name=f"{self._name:s}_term")
-                term_eq = functional_term_eq(term, term_fn)
+                term_eq = functional_term_eq(term_fn, term)
                 term_eq.solve(manager=manager, annotate=annotate, tlm=tlm)
             new_fn_eq = Axpy(new_fn, self._fn, 1.0, term_fn)
             new_fn_eq.solve(manager=manager, annotate=annotate, tlm=tlm)

--- a/tlm_adjoint/hessian.py
+++ b/tlm_adjoint/hessian.py
@@ -24,7 +24,7 @@ from .interface import check_space_types_conjugate_dual, function_axpy, \
     function_new, function_new_conjugate, function_set_values, is_function
 
 from .caches import local_caches
-from .equations import InnerProductSolver
+from .equations import InnerProduct
 from .functional import Functional
 from .manager import manager as _manager, restore_manager, set_manager
 
@@ -231,7 +231,7 @@ class GaussNewton:
         assert len(X) == len(R_inv_tau_X)
         for x, R_inv_tau_x in zip(X, R_inv_tau_X):
             J_term = function_new(J.function())
-            InnerProductSolver(x, function_copy(R_inv_tau_x), J_term).solve(
+            InnerProduct(J_term, x, function_copy(R_inv_tau_x)).solve(
                 manager=manager, tlm=False)
             J.addto(J_term, manager=manager, tlm=False)
         manager.stop()

--- a/tlm_adjoint/interface.py
+++ b/tlm_adjoint/interface.py
@@ -869,9 +869,9 @@ def add_functional_term_eq(backend, fn):
     _functional_term_eq[backend] = fn
 
 
-def functional_term_eq(term, x):
+def functional_term_eq(x, term):
     for fn in _functional_term_eq.values():
-        eq = fn(term, x)
+        eq = fn(x=x, term=term)
         if eq != NotImplemented:
             return eq
     raise RuntimeError("Unexpected case encountered in functional_term_eq")

--- a/tlm_adjoint/numpy/equations.py
+++ b/tlm_adjoint/numpy/equations.py
@@ -227,4 +227,4 @@ class ContractionSolver(LinearEquation):
             warnings.warn("A_T argument is deprecated and has no effect",
                           DeprecationWarning, stacklevel=2)
 
-        super().__init__(ContractionRHS(A, I, Y, alpha=alpha), x)
+        super().__init__(x, ContractionRHS(A, I, Y, alpha=alpha))

--- a/tlm_adjoint/numpy/equations.py
+++ b/tlm_adjoint/numpy/equations.py
@@ -30,6 +30,8 @@ __all__ = \
     [
         "ConstantMatrix",
         "ContractionRHS",
+        "Contraction",
+
         "ContractionSolver"
     ]
 
@@ -221,10 +223,17 @@ class ContractionRHS(RHS):
             return tlm_B
 
 
-class ContractionSolver(LinearEquation):
+class Contraction(LinearEquation):
+    def __init__(self, x, A, I, Y, *, alpha=1.0):  # noqa: E741
+        super().__init__(x, ContractionRHS(A, I, Y, alpha=alpha))
+
+
+class ContractionSolver(Contraction):
     def __init__(self, A, I, Y, x, A_T=None, alpha=1.0):  # noqa: E741
         if A_T is not None:
             warnings.warn("A_T argument is deprecated and has no effect",
                           DeprecationWarning, stacklevel=2)
-
-        super().__init__(x, ContractionRHS(A, I, Y, alpha=alpha))
+        warnings.warn("ContactionSolver is deprecated -- "
+                      "use Contraction instead",
+                      DeprecationWarning, stacklevel=2)
+        super().__init__(x, A, I, Y, alpha=alpha)

--- a/tlm_adjoint/timestepping.py
+++ b/tlm_adjoint/timestepping.py
@@ -21,7 +21,7 @@
 from .interface import function_id, is_function, space_new, time_system_eq
 
 from .alias import Alias
-from .equations import AssignmentSolver, Equation
+from .equations import Assignment, Equation
 
 from collections import OrderedDict
 from operator import itemgetter
@@ -190,8 +190,8 @@ class TimeFunction:
 
     def cycle(self, *, manager=None):
         if self._cycle_eqs is None:
-            self._cycle_eqs = tuple(AssignmentSolver(self[source_level],
-                                                     self[target_level])
+            self._cycle_eqs = tuple(Assignment(self[target_level],
+                                               self[source_level])
                                     for target_level, source_level
                                     in self._levels._cycle_map.items())
         for eq in self._cycle_eqs:
@@ -220,7 +220,7 @@ class TimeSystem:
               and is_function(args[0])
               and is_function(args[1])
               and hasattr(args[1], "_tlm_adjoint__tfn")):
-            eq = AssignmentSolver(args[0], args[1])
+            eq = Assignment(args[1], args[0])
         else:
             eq = time_system_eq(*args, **kwargs)
 

--- a/tlm_adjoint/timestepping.py
+++ b/tlm_adjoint/timestepping.py
@@ -25,6 +25,7 @@ from .equations import Assignment, Equation
 
 from collections import OrderedDict
 from operator import itemgetter
+import warnings
 
 __all__ = \
     [
@@ -208,6 +209,8 @@ class TimeSystem:
         self._tfns = None
 
     def add_assignment(self, y, x):
+        warnings.warn("TimeSystem.add_assignment method is deprecated",
+                      DeprecationWarning, stacklevel=2)
         self.add_solve(y, x)
 
     def add_solve(self, *args, **kwargs):
@@ -220,6 +223,8 @@ class TimeSystem:
               and is_function(args[0])
               and is_function(args[1])
               and hasattr(args[1], "_tlm_adjoint__tfn")):
+            warnings.warn("TimeSystem.add_solve(y, x) signature is deprecated",
+                          DeprecationWarning, stacklevel=2)
             eq = Assignment(args[1], args[0])
         else:
             eq = time_system_eq(*args, **kwargs)

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -31,7 +31,7 @@ from .checkpoint_schedules import MemoryCheckpointSchedule, \
 from .checkpointing import CheckpointStorage, HDF5Checkpoints, \
     PickleCheckpoints, ReplayStorage
 from .equations import AdjointModelRHS, ControlsMarker, Equation, \
-    FunctionalMarker, NullSolver
+    FunctionalMarker, ZeroAssignment
 from .functional import Functional
 from .manager import restore_manager, set_manager
 
@@ -1167,7 +1167,7 @@ class EquationManager:
                 if dep in M or dep in tlm_map:
                     tlm_eq = eq.tangent_linear(M, dM, tlm_map)
                     if tlm_eq is None:
-                        tlm_eq = NullSolver([tlm_map[x] for x in X])
+                        tlm_eq = ZeroAssignment([tlm_map[x] for x in X])
                     tlm_eq._tlm_adjoint__tlm_root_id = getattr(
                         eq, "_tlm_adjoint__tlm_root_id", eq.id())
                     tlm_eq._tlm_adjoint__tlm_key = tuple(


### PR DESCRIPTION
Reorder `Equation` constructor arguments, so that the solution is the first argument.

Backwards compatibility is largely retained by renaming the `Equation` classes, with reordered arguments in the new classes.

Renamed in tlm_adjoint, and where necessary argument order updated:

- `NullSolver` $\rightarrow$ `ZeroAssignment`
- `AssignmentSolver` $\rightarrow$ `Assignment`
- `AxpySolver` $\rightarrow$ `Axpy`
- `LinearCombinationSolver` $\rightarrow$ `LinearCombination`
- `DotProductSolver` $\rightarrow$ `DotProduct`
- `InnerProductSolver`$\rightarrow$ `InnerProduct`
- `ContractionSolver`$\rightarrow$ `Contraction`
- `AssembleSolver`$\rightarrow$ `Assembly` (with new global variables defined for default configuration)
- `ProjectionSolver`$\rightarrow$ `Projection`
- `ExprEvaluationSolver`$\rightarrow$ `ExprEvaluation`
- `DirichletBCSolver`$\rightarrow$ `DirichletBCApplication`
- `InterpolationSolver`$\rightarrow$ `Interpolation`
- `PointInterpolationSolver`$\rightarrow$ `PointInterpolation`
- `LocalProjectionSolver`$\rightarrow$ `LocalProjection`

Argument order updated without renaming:

- `LinearEquation`
- `functional_term_eq` (no backwards compatibility)

Renamed in tests and examples, and where necessary argument order updated:

- `InteriorAssignmentSolver` $\rightarrow$ `InteriorAssignment`
- `EmptySolver`$\rightarrow$ `EmptyEquation`
- `TestSolver`$\rightarrow$ `CustomProjection`
- `NewtonIterationSolver`$\rightarrow$ `NewtonSolver`

Deprecated, with documentation and test code removed

- `TimeSystem.add_assignment`
- `TimeSystem.add_solve` for assignments
- `ScaleSolver`
- `MatrixActionSolver`
- `NormSqRHS`
- `NormSqSolver`

Revolves #179