### PR TITLE
Mixed non-linear dependency / forward restart checkpoint schedule

### DIFF
--- a/README
+++ b/README
@@ -52,5 +52,6 @@ tlm_adjoint optionally uses
     petsc4py and slepc4py, for eigendecomposition functionality
     H-Revolve, for H-Revolve checkpointing schedules
     more-itertools
+    Numba
 
 License: GNU LGPL version 3

--- a/tests/checkpoint_schedules/test_mixed.py
+++ b/tests/checkpoint_schedules/test_mixed.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# For tlm_adjoint copyright information see ACKNOWLEDGEMENTS in the tlm_adjoint
+# root directory
+
+# This file is part of tlm_adjoint.
+#
+# tlm_adjoint is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# tlm_adjoint is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+from tlm_adjoint.checkpoint_schedules import MixedCheckpointSchedule, Clear, \
+    Configure, Forward, Reverse, Read, Write, EndForward, EndReverse
+from tlm_adjoint.checkpoint_schedules.mixed import mixed_step, optimal_steps
+
+import functools
+import pytest
+
+
+@pytest.mark.parametrize("n, S", [(1, (0,)),
+                                  (2, (1,)),
+                                  (3, (1, 2)),
+                                  (10, tuple(range(1, 10))),
+                                  (100, tuple(range(1, 100))),
+                                  (250, tuple(range(25, 250, 25)))])
+def test_MixedCheckpointSchedule(n, S):
+    @functools.singledispatch
+    def action(cp_action):
+        raise TypeError("Unexpected action")
+
+    @action.register(Clear)
+    def action_clear(cp_action):
+        if cp_action.clear_ics:
+            ics.clear()
+        if cp_action.clear_data:
+            data.clear()
+
+    @action.register(Configure)
+    def action_configure(cp_action):
+        nonlocal store_ics, store_data
+
+        store_ics = cp_action.store_ics
+        store_data = cp_action.store_data
+
+    @action.register(Forward)
+    def action_forward(cp_action):
+        nonlocal model_n, model_steps
+
+        # Start at the current location of the forward
+        assert model_n is not None and model_n == cp_action.n0
+
+        if store_ics:
+            # Advance at least two steps when storing forward restart data
+            assert cp_action.n1 > cp_action.n0 + 1
+            # Do not advance further than one step before the current location
+            # of the adjoint
+            assert cp_action.n1 < n - model_r
+            # No data for these steps is stored
+            assert len(ics.intersection(range(cp_action.n0, cp_action.n1))) == 0  # noqa: E501
+
+        if store_data:
+            # Advance exactly one step when storing non-linear dependency data
+            assert cp_action.n1 == cp_action.n0 + 1
+            # Do not advance further than the current location of the adjoint
+            assert cp_action.n1 <= n - model_r
+            # No data for this step is stored
+            assert len(data.intersection(range(cp_action.n0, cp_action.n1))) == 0  # noqa: E501
+
+        model_n = cp_action.n1
+        model_steps += cp_action.n1 - cp_action.n0
+        if store_ics:
+            ics.update(range(cp_action.n0, cp_action.n1))
+        if store_data:
+            data.update(range(cp_action.n0, cp_action.n1))
+
+    @action.register(Reverse)
+    def action_reverse(cp_action):
+        nonlocal model_r
+
+        # Start at the current location of the adjoint
+        assert cp_action.n1 == n - model_r
+        # Advance exactly one step
+        assert cp_action.n0 == cp_action.n1 - 1
+        # Non-linear dependency data for the step is stored
+        assert cp_action.n0 in data
+
+        model_r += 1
+
+    @action.register(Read)
+    def action_read(cp_action):
+        nonlocal model_n
+
+        assert cp_action.storage == "disk"
+
+        # No data is currently stored for this step
+        assert cp_action.n not in ics
+        assert cp_action.n not in data
+        # The checkpoint contains either forward restart or non-linear
+        # dependency data, but not both
+        assert len(snapshots[cp_action.n][0]) == 0 or len(snapshots[cp_action.n][1]) == 0  # noqa: E501
+        assert len(snapshots[cp_action.n][0]) > 0 or len(snapshots[cp_action.n][1]) > 0  # noqa: E501
+
+        if len(snapshots[cp_action.n][0]) > 0:
+            # Loading a forward restart checkpoint:
+
+            # The checkpoint data is at least two steps away from the current
+            # location of the adjoint
+            assert cp_action.n < n - model_r - 1
+            # The loaded data is deleted iff non-linear dependency data for all
+            # remaining steps can be checkpoint and stored
+            assert cp_action.delete is (cp_action.n >= n - model_r - 1
+                                        - (s - len(snapshots) + 1))
+
+            ics.clear()
+            ics.update(snapshots[cp_action.n][0])
+            model_n = cp_action.n
+
+        if len(snapshots[cp_action.n][1]) > 0:
+            # Loading a non-linear dependency data checkpoint:
+
+            # The checkpoint data is exactly one step away from the current
+            # location of the adjoint
+            assert cp_action.n == n - model_r - 1
+            # The loaded data is always deleted
+            assert cp_action.delete
+
+            data.clear()
+            data.update(snapshots[cp_action.n][1])
+            model_n = None
+
+        if cp_action.delete:
+            del snapshots[cp_action.n]
+
+    @action.register(Write)
+    def action_write(cp_action):
+        assert cp_action.storage == "disk"
+
+        # Written data consists of either forward restart or non-linear
+        # dependency data, but not both
+        assert len(ics) == 0 or len(data) == 0
+        assert len(ics) > 0 or len(data) > 0
+
+        # Non-linear dependency data is either not stored, or is stored for a
+        # single step
+        assert len(data) <= 1
+
+        # The checkpoint location is associated with the earliest step for
+        # which data has been stored
+        if len(ics) > 0:
+            assert cp_action.n == min(ics)
+        if len(data) > 0:
+            assert cp_action.n == min(data)
+
+        snapshots[cp_action.n] = (set(ics), set(data))
+
+    @action.register(EndForward)
+    def action_end_forward(cp_action):
+        # The correct number of forward steps has been taken
+        assert model_n is not None and model_n == n
+
+    @action.register(EndReverse)
+    def action_end_reverse(cp_action):
+        # The correct number of adjoint steps has been taken
+        assert model_r == n
+        # The schedule has concluded
+        assert cp_action.exhausted
+
+    for s in S:
+        print(f"{n=:d} {s=:d}")
+
+        model_n = 0
+        model_r = 0
+        model_steps = 0
+
+        store_ics = False
+        ics = set()
+        store_data = False
+        data = set()
+
+        snapshots = {}
+
+        cp_schedule = MixedCheckpointSchedule(n, s, storage="disk")
+        assert cp_schedule.uses_disk_storage()
+        assert cp_schedule.max_n() == n
+
+        while True:
+            cp_action = next(cp_schedule)
+            action(cp_action)
+
+            # The schedule state is consistent with both the forward and
+            # adjoint
+            assert model_n is None or model_n == cp_schedule.n()
+            assert model_r == cp_schedule.r()
+
+            # Either no data is being stored, or exactly one of forward restart
+            # or non-linear dependency data is being stored
+            assert not store_ics or not store_data
+            assert len(ics) == 0 or len(data) == 0
+            # Non-linear dependency data is stored for at most one step
+            assert len(data) <= 1
+            # Checkpoint storage limits are not exceeded
+            assert len(snapshots) <= s
+
+            if isinstance(cp_action, EndReverse):
+                break
+
+        # The correct total number of forward steps has been taken
+        assert model_steps == optimal_steps(n, s)
+        assert model_steps == mixed_step(n, s)[2]
+        # No data is stored
+        assert len(ics) == 0 and len(data) == 0
+        # No checkpoints are stored
+        assert len(snapshots) == 0
+
+        # The schedule has concluded
+        assert cp_schedule.is_exhausted()
+        try:
+            next(cp_schedule)
+        except StopIteration:
+            pass
+        except Exception:
+            raise RuntimeError("Iterator not exhausted")

--- a/tests/checkpoint_schedules/test_mixed.py
+++ b/tests/checkpoint_schedules/test_mixed.py
@@ -20,7 +20,8 @@
 
 from tlm_adjoint.checkpoint_schedules import MixedCheckpointSchedule, Clear, \
     Configure, Forward, Reverse, Read, Write, EndForward, EndReverse
-from tlm_adjoint.checkpoint_schedules.mixed import mixed_step, optimal_steps
+from tlm_adjoint.checkpoint_schedules.mixed import mixed_step_memoization, \
+    optimal_steps
 
 import functools
 import pytest
@@ -215,7 +216,7 @@ def test_MixedCheckpointSchedule(n, S):
 
         # The correct total number of forward steps has been taken
         assert model_steps == optimal_steps(n, s)
-        assert model_steps == mixed_step(n, s)[2]
+        assert model_steps == mixed_step_memoization(n, s)[2]
         # No data is stored
         assert len(ics) == 0 and len(data) == 0
         # No checkpoints are stored

--- a/tests/checkpoint_schedules/test_mixed.py
+++ b/tests/checkpoint_schedules/test_mixed.py
@@ -100,6 +100,8 @@ def test_MixedCheckpointSchedule(n, S):
     def action_read(cp_action):
         nonlocal model_n
 
+        # The checkpoint exists
+        assert cp_action.n in snapshots
         assert cp_action.storage == "disk"
 
         # No data is currently stored for this step

--- a/tests/fenics/test_models.py
+++ b/tests/fenics/test_models.py
@@ -111,23 +111,29 @@ def diffusion_ref():
      pytest.param(
          "H-Revolve", {"snapshots_on_disk": 1, "snapshots_in_ram": 2},
          marks=pytest.mark.skipif(hrevolve is None,
-                                  reason="H-Revolve not available"))])
+                                  reason="H-Revolve not available")),
+     ("mixed", {"snapshots": 2, "storage": "disk"})])
 @seed_test
 def test_oscillator(setup_test, test_leaks,
                     tmp_path, cp_method, cp_parameters):
     n_steps = 20
     cp_parameters = copy.copy(cp_parameters)
-    if cp_method in ["periodic_disk", "multistage", "H-Revolve"]:
+    if cp_method != "memory":
         cp_parameters["path"] = str(tmp_path / "checkpoints~")
     if cp_method == "multistage":
         cp_parameters["blocks"] = n_steps
     if cp_method in ["memory", "periodic_disk", "multistage"]:
         configure_checkpointing(cp_method, cp_parameters)
-    else:
-        assert cp_method == "H-Revolve"
+    elif cp_method == "H-Revolve":
         from tlm_adjoint.checkpoint_schedules import HRevolveCheckpointSchedule
         configure_checkpointing(
             lambda **cp_parameters: HRevolveCheckpointSchedule(max_n=n_steps, **cp_parameters),  # noqa: E501
+            cp_parameters)
+    else:
+        assert cp_method == "mixed"
+        from tlm_adjoint.checkpoint_schedules import MixedCheckpointSchedule
+        configure_checkpointing(
+            lambda **cp_parameters: MixedCheckpointSchedule(max_n=n_steps, **cp_parameters),  # noqa: E501
             cp_parameters)
 
     mesh = UnitIntervalMesh(20)

--- a/tlm_adjoint/checkpoint_schedules/__init__.py
+++ b/tlm_adjoint/checkpoint_schedules/__init__.py
@@ -4,3 +4,4 @@ from .memory import *  # noqa: F401
 from .periodic import *  # noqa: F401
 from .binomial import *  # noqa: F401
 from .h_revolve import *  # noqa: F401
+from .mixed import *  # noqa: F401

--- a/tlm_adjoint/checkpoint_schedules/mixed.py
+++ b/tlm_adjoint/checkpoint_schedules/mixed.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# For tlm_adjoint copyright information see ACKNOWLEDGEMENTS in the tlm_adjoint
+# root directory
+
+# This file is part of tlm_adjoint.
+#
+# tlm_adjoint is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# tlm_adjoint is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+from .schedule import CheckpointSchedule, Clear, Configure, Forward, Reverse, \
+    Read, Write, EndForward, EndReverse
+
+import enum
+import functools
+
+
+class StepType(enum.Enum):
+    FORWARD = 1
+    DATA = 2
+    ICS = 3
+
+
+def cache_step(fn):
+    _cache = {}
+
+    @functools.wraps(fn)
+    def wrapped_fn(n, s):
+        # Avoid some cache misses
+        s = min(s, n - 1)
+        if (n, s) not in _cache:
+            _cache[(n, s)] = fn(n, s)
+        return _cache[(n, s)]
+
+    return wrapped_fn
+
+
+@cache_step
+def mixed_step(n, s):
+    if n <= 0:
+        raise ValueError("Invalid number of steps")
+    if s < min(1, n - 1) or s > n - 1:
+        raise ValueError("Invalid number of snapshots")
+
+    if n == 1:
+        return (StepType.FORWARD, 1, 1)
+    elif n <= s + 1:
+        return (StepType.DATA, 1, n)
+    elif s == 1:
+        return (StepType.ICS, n - 1, n * (n + 1) // 2 - 1)
+    else:
+        m = None
+        for i in range(2, n):
+            m1 = (
+                i
+                + mixed_step(i, s)[2]
+                + mixed_step(n - i, s - 1)[2])
+            if m is None or m1 <= m[2]:
+                m = (StepType.ICS, i, m1)
+        if m is None:
+            raise RuntimeError("Failed to determine total number of steps")
+        m1 = 1 + mixed_step(n - 1, s - 1)[2]
+        if m1 <= m[2]:
+            m = (StepType.DATA, 1, m1)
+        return m
+
+
+def cache_step_0(fn):
+    _cache = {}
+
+    @functools.wraps(fn)
+    def wrapped_fn(n, s):
+        # Avoid some cache misses
+        s = min(s, n - 2)
+        if (n, s) not in _cache:
+            _cache[(n, s)] = fn(n, s)
+        return _cache[(n, s)]
+
+    return wrapped_fn
+
+
+@cache_step_0
+def mixed_step_0(n, s):
+    if s < 0:
+        raise ValueError("Invalid number of snapshots")
+    if n < s + 2:
+        raise ValueError("Invalid number of steps")
+
+    if s == 0:
+        return (StepType.FORWARD, n, n * (n + 1) // 2 - 1)
+    else:
+        m = None
+        for i in range(1, n):
+            m1 = (
+                i
+                + mixed_step(i, s + 1)[2]
+                + mixed_step(n - i, s)[2])
+            if m is None or m1 <= m[2]:
+                m = (StepType.FORWARD, i, m1)
+        if m is None:
+            raise RuntimeError("Failed to determine total number of steps")
+        return m
+
+
+def optimal_steps(n, s):
+    return mixed_step(n, s)[2]
+
+
+class MixedCheckpointSchedule(CheckpointSchedule):
+    def __init__(self, max_n, snapshots, *, storage="disk"):
+        if snapshots < min(1, max_n - 1):
+            raise ValueError("Invalid number of snapshots")
+        if storage not in ["RAM", "disk"]:
+            raise ValueError("Invalid storage")
+
+        super().__init__(max_n)
+        self._exhausted = False
+        self._snapshots = min(snapshots, max_n - 1)
+        self._storage = storage
+
+    def iter(self):
+        snapshot_n = set()
+        snapshots = []
+
+        steps = 0
+
+        def forward(n0, n1):
+            nonlocal steps
+            steps += n1 - n0
+            return Forward(n0, n1)
+
+        if self._max_n is None:
+            raise RuntimeError("Invalid checkpointing state")
+
+        while True:
+            while self._n < self._max_n - self._r:
+                n0 = self._n
+                if n0 in snapshot_n:
+                    # A checkpoint is at the start of the n0 block
+                    step_type, n1, _ = mixed_step_0(
+                        self._max_n - self._r - n0,
+                        self._snapshots - len(snapshots))
+                else:
+                    # No checkpoint is at the start of the n0 block
+                    step_type, n1, _ = mixed_step(
+                        self._max_n - self._r - n0,
+                        self._snapshots - len(snapshots))
+                n1 += n0
+
+                if step_type == StepType.FORWARD:
+                    if n1 > n0 + 1:
+                        yield Configure(False, False)
+                        self._n = n1 - 1
+                        yield forward(n0, n1 - 1)
+                        yield Clear(True, True)
+                    elif n1 <= n0:
+                        raise RuntimeError("Invalid step")
+                    yield Configure(False, True)
+                    self._n += 1
+                    yield forward(n1 - 1, n1)
+                elif step_type == StepType.DATA:
+                    if n1 != n0 + 1:
+                        raise RuntimeError("Invalid step")
+                    yield Configure(False, True)
+                    self._n = n1
+                    yield forward(n0, n1)
+                    if n0 in snapshot_n:
+                        raise RuntimeError("Invalid checkpointing state")
+                    elif len(snapshots) > self._snapshots - 1:
+                        raise RuntimeError("Invalid checkpointing state")
+                    snapshot_n.add(n0)
+                    snapshots.append((StepType.DATA, n0))
+                    yield Write(n0, self._storage)
+                    yield Clear(True, True)
+                elif step_type == StepType.ICS:
+                    if n1 <= n0 + 1:
+                        raise ValueError("Invalid step")
+                    yield Configure(True, False)
+                    self._n = n1
+                    yield forward(n0, n1)
+                    if n0 in snapshot_n:
+                        raise RuntimeError("Invalid checkpointing state")
+                    elif len(snapshots) > self._snapshots - 1:
+                        raise RuntimeError("Invalid checkpointing state")
+                    snapshot_n.add(n0)
+                    snapshots.append((StepType.ICS, n0))
+                    yield Write(n0, self._storage)
+                    yield Clear(True, True)
+                else:
+                    raise RuntimeError("Unexpected step type")
+            if self._n != self._max_n - self._r:
+                raise RuntimeError("Invalid checkpointing state")
+
+            if self._r == 0:
+                yield EndForward()
+
+            self._r += 1
+            yield Reverse(self._max_n - self._r + 1, self._max_n - self._r)
+            yield Clear(True, True)
+
+            if self._r == self._max_n:
+                break
+
+            step_type, cp_n = snapshots[-1]
+
+            # Delete if we have (possibly after deleting this checkpoint)
+            # enough storage left to store all non-linear dependency data
+            cp_delete = (cp_n >= (self._max_n - self._r - 1
+                                  - (self._snapshots - len(snapshots) + 1)))
+            if cp_delete:
+                snapshot_n.remove(cp_n)
+                snapshots.pop()
+
+            self._n = cp_n
+            if step_type == StepType.DATA:
+                # Non-linear dependency data checkpoint
+                if not cp_delete:
+                    # We cannot advance from a loaded non-linear dependency
+                    # checkpoint, and so we expect to use it immediately
+                    raise RuntimeError("Invalid checkpointing state")
+                # Note that we cannot in general restart the forward here
+                self._n += 1
+            elif step_type != StepType.ICS:
+                raise RuntimeError("Invalid checkpointing state")
+            yield Read(cp_n, self._storage, cp_delete)
+            if step_type == StepType.ICS:
+                yield Clear(True, True)
+
+        if steps != optimal_steps(self._max_n, self._snapshots):
+            raise RuntimeError("Unexpected total number of steps")
+
+        if len(snapshot_n) > 0 or len(snapshots) > 0:
+            raise RuntimeError("Invalid checkpointing state")
+
+        self._exhausted = True
+        yield EndReverse(True)
+
+    def is_exhausted(self):
+        return self._exhausted
+
+    def uses_disk_storage(self):
+        return self._storage == "disk"

--- a/tlm_adjoint/checkpoint_schedules/mixed.py
+++ b/tlm_adjoint/checkpoint_schedules/mixed.py
@@ -49,6 +49,28 @@ def cache_step(fn):
 
 
 @cache_step
+def optimal_steps(n, s):
+    if n <= 0:
+        raise ValueError("Invalid number of steps")
+    if s < min(1, n - 1) or s > n - 1:
+        raise ValueError("Invalid number of snapshots")
+
+    if n <= s + 1:
+        return n
+    elif s == 1:
+        return n * (n + 1) // 2 - 1
+    else:
+        m = 1 + optimal_steps(n - 1, s - 1)
+        for i in range(2, n):
+            m = min(
+                m,
+                i
+                + optimal_steps(i, s)
+                + optimal_steps(n - i, s - 1))
+        return m
+
+
+@cache_step
 def mixed_step(n, s):
     if n <= 0:
         raise ValueError("Invalid number of steps")
@@ -113,10 +135,6 @@ def mixed_step_0(n, s):
         if m is None:
             raise RuntimeError("Failed to determine total number of steps")
         return m
-
-
-def optimal_steps(n, s):
-    return mixed_step(n, s)[2]
 
 
 class MixedCheckpointSchedule(CheckpointSchedule):

--- a/tlm_adjoint/checkpoint_schedules/mixed.py
+++ b/tlm_adjoint/checkpoint_schedules/mixed.py
@@ -266,9 +266,6 @@ class MixedCheckpointSchedule(CheckpointSchedule):
             if step_type == StepType.READ_ICS:
                 yield Clear(True, True)
 
-        if steps != optimal_steps(self._max_n, self._snapshots):
-            raise RuntimeError("Unexpected total number of steps")
-
         if len(snapshot_n) > 0 or len(snapshots) > 0:
             raise RuntimeError("Invalid checkpointing state")
 

--- a/tlm_adjoint/checkpoint_schedules/mixed.py
+++ b/tlm_adjoint/checkpoint_schedules/mixed.py
@@ -169,12 +169,12 @@ class MixedCheckpointSchedule(CheckpointSchedule):
             while self._n < self._max_n - self._r:
                 n0 = self._n
                 if n0 in snapshot_n:
-                    # A checkpoint is at the start of the n0 block
+                    # n0 checkpoint exists
                     step_type, n1, _ = mixed_step_0(
                         self._max_n - self._r - n0,
                         self._snapshots - len(snapshots))
                 else:
-                    # No checkpoint is at the start of the n0 block
+                    # n0 checkpoint does not exist
                     step_type, n1, _ = mixed_step(
                         self._max_n - self._r - n0,
                         self._snapshots - len(snapshots))

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -1404,6 +1404,8 @@ class EquationManager:
                     storage_state = storage.pop()
                     assert storage_state == (n1, i)
             cp_n = cp_action.n1
+            if cp_n == n + 1:
+                assert len(storage) == 0
 
         @action.register(Reverse)
         def action_reverse(cp_action):
@@ -1412,8 +1414,6 @@ class EquationManager:
                 raise RuntimeError("Invalid checkpointing state")
             if cp_action.n0 > n:
                 raise RuntimeError("Invalid checkpointing state")
-            if storage is not None:
-                assert len(storage) == 0
 
         @action.register(Read)
         def action_read(cp_action):


### PR DESCRIPTION
Add a checkpointing schedule optimized for the case of zero storage costs, forward non-reversibility, and in-step adjoint dependency data size equal to forward restart checkpoint data size.

The schedules switch between storing forward restart checkpoints, and storage of non-linear dependency data for use by the adjoint. This generalises the $l = 1$ Runge-Kutta stage CAMS-GEN approach (https://doi.org/10.1016/j.jocs.2022.101913).