### PR TITLE
Add further checkpoint schedules tests

### DIFF
--- a/tests/checkpoint_schedules/test_binomial.py
+++ b/tests/checkpoint_schedules/test_binomial.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# For tlm_adjoint copyright information see ACKNOWLEDGEMENTS in the tlm_adjoint
+# root directory
+
+# This file is part of tlm_adjoint.
+#
+# tlm_adjoint is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# tlm_adjoint is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+from tlm_adjoint.checkpoint_schedules import MultistageCheckpointSchedule, \
+    Clear, Configure, Forward, Reverse, Read, Write, EndForward, EndReverse
+from tlm_adjoint.checkpoint_schedules.binomial import optimal_steps
+
+import functools
+import pytest
+
+
+@pytest.mark.parametrize("trajectory", ["revolve",
+                                        "maximum"])
+@pytest.mark.parametrize("n, S", [(1, (0,)),
+                                  (2, (1,)),
+                                  (3, (1, 2)),
+                                  (10, tuple(range(1, 10))),
+                                  (100, tuple(range(1, 100))),
+                                  (250, tuple(range(25, 250, 25)))])
+def test_MultistageCheckpointSchedule(trajectory,
+                                      n, S):
+    @functools.singledispatch
+    def action(cp_action):
+        raise TypeError("Unexpected action")
+
+    @action.register(Clear)
+    def action_clear(cp_action):
+        if cp_action.clear_ics:
+            ics.clear()
+        if cp_action.clear_data:
+            data.clear()
+
+    @action.register(Configure)
+    def action_configure(cp_action):
+        nonlocal store_ics, store_data
+
+        store_ics = cp_action.store_ics
+        store_data = cp_action.store_data
+
+    @action.register(Forward)
+    def action_forward(cp_action):
+        nonlocal model_n, model_steps
+
+        # Start at the current location of the forward
+        assert model_n == cp_action.n0
+
+        if store_ics:
+            # Advance at least one step when storing forward restart data
+            assert cp_action.n1 > cp_action.n0
+            # Do not advance further than one step before the current location
+            # of the adjoint
+            assert cp_action.n1 < n - model_r
+            # No data for these steps is stored
+            assert len(ics.intersection(range(cp_action.n0, cp_action.n1))) == 0  # noqa: E501
+
+        if store_data:
+            # Advance exactly one step when storing non-linear dependency data
+            assert cp_action.n1 == cp_action.n0 + 1
+            # Start from one step before the current location of the adjoint
+            assert cp_action.n0 == n - model_r - 1
+            # No data for this step is stored
+            assert len(data.intersection(range(cp_action.n0, cp_action.n1))) == 0  # noqa: E501
+
+        model_n = cp_action.n1
+        model_steps += cp_action.n1 - cp_action.n0
+        if store_ics:
+            ics.update(range(cp_action.n0, cp_action.n1))
+        if store_data:
+            data.update(range(cp_action.n0, cp_action.n1))
+
+    @action.register(Reverse)
+    def action_reverse(cp_action):
+        nonlocal model_r
+
+        # Start at the current location of the adjoint
+        assert cp_action.n1 == n - model_r
+        # Advance exactly one step
+        assert cp_action.n0 == cp_action.n1 - 1
+        # Non-linear dependency data for the step is stored
+        assert cp_action.n0 in data
+
+        model_r += 1
+
+    @action.register(Read)
+    def action_read(cp_action):
+        nonlocal model_n
+
+        # The checkpoint exists
+        assert cp_action.n in snapshots
+        assert cp_action.storage == "disk"
+
+        cp = snapshots[cp_action.n]
+
+        # No data is currently stored for this step
+        assert cp_action.n not in ics
+        assert cp_action.n not in data
+        # The checkpoint contains forward restart data
+        assert len(cp[0]) > 0
+        assert len(cp[1]) == 0
+
+        # The checkpoint data is at least one step away from the current
+        # location of the adjoint
+        assert cp_action.n < n - model_r
+        # The loaded data is deleted iff it is exactly one step away from the
+        # current location of the adjoint
+        assert cp_action.delete is (cp_action.n == n - model_r - 1)
+
+        ics.clear()
+        ics.update(cp[0])
+        model_n = cp_action.n
+
+        if cp_action.delete:
+            del snapshots[cp_action.n]
+
+    @action.register(Write)
+    def action_write(cp_action):
+        assert cp_action.storage == "disk"
+        assert cp_schedule.uses_disk_storage()
+
+        # Written data consists of forward restart data
+        assert len(ics) > 0
+        assert len(data) == 0
+
+        # The checkpoint location is associated with the earliest step for
+        # which data has been stored
+        assert cp_action.n == min(ics)
+
+        snapshots[cp_action.n] = (set(ics), set(data))
+
+    @action.register(EndForward)
+    def action_end_forward(cp_action):
+        # The correct number of forward steps has been taken
+        assert model_n == n
+
+    @action.register(EndReverse)
+    def action_end_reverse(cp_action):
+        # The correct number of adjoint steps has been taken
+        assert model_r == n
+        # The schedule has concluded
+        assert cp_action.exhausted
+
+    for s in S:
+        print(f"{n=:d} {s=:d}")
+
+        model_n = 0
+        model_r = 0
+        model_steps = 0
+
+        store_ics = False
+        ics = set()
+        store_data = False
+        data = set()
+
+        snapshots = {}
+
+        cp_schedule = MultistageCheckpointSchedule(n, 0, s,
+                                                   trajectory=trajectory)
+        assert n == 1 or cp_schedule.uses_disk_storage()
+        assert cp_schedule.n() == 0
+        assert cp_schedule.r() == 0
+        assert cp_schedule.max_n() == n
+
+        while True:
+            cp_action = next(cp_schedule)
+            action(cp_action)
+
+            # The schedule state is consistent with both the forward and
+            # adjoint
+            assert model_n == cp_schedule.n()
+            assert model_r == cp_schedule.r()
+
+            # Either no data is being stored, or exactly one of forward restart
+            # or non-linear dependency data is being stored
+            assert not store_ics or not store_data
+            assert len(ics) == 0 or len(data) == 0
+            # Non-linear dependency data is stored for at most one step
+            assert len(data) <= 1
+            # Checkpoint storage limits are not exceeded
+            assert len(snapshots) <= s
+
+            if isinstance(cp_action, EndReverse):
+                break
+
+        # The correct total number of forward steps has been taken
+        assert model_steps == optimal_steps(n, s)
+        # No data is stored
+        assert len(ics) == 0 and len(data) == 0
+        # No checkpoints are stored
+        assert len(snapshots) == 0
+
+        # The schedule has concluded
+        assert cp_schedule.is_exhausted()
+        try:
+            next(cp_schedule)
+        except StopIteration:
+            pass
+        except Exception:
+            raise RuntimeError("Iterator not exhausted")

--- a/tests/checkpoint_schedules/test_validity.py
+++ b/tests/checkpoint_schedules/test_validity.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# For tlm_adjoint copyright information see ACKNOWLEDGEMENTS in the tlm_adjoint
+# root directory
+
+# This file is part of tlm_adjoint.
+#
+# tlm_adjoint is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# tlm_adjoint is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with tlm_adjoint.  If not, see <https://www.gnu.org/licenses/>.
+
+from tlm_adjoint.checkpoint_schedules import \
+    Clear, Configure, Forward, Reverse, Read, Write, EndForward, EndReverse
+from tlm_adjoint.checkpoint_schedules import \
+    (MemoryCheckpointSchedule,
+     PeriodicDiskCheckpointSchedule,
+     MultistageCheckpointSchedule,
+     TwoLevelCheckpointSchedule,
+     HRevolveCheckpointSchedule,
+     MixedCheckpointSchedule)
+
+import functools
+import pytest
+
+try:
+    import hrevolve
+except ImportError:
+    hrevolve = None
+
+
+def memory(n, s):
+    return (MemoryCheckpointSchedule(),
+            {"RAM": 0, "disk": 0}, n)
+
+
+def periodic_disk(n, s, *, period):
+    return (PeriodicDiskCheckpointSchedule(period),
+            {"RAM": 0, "disk": 1 + (n - 1) // period}, period)
+
+
+def multistage(n, s):
+    return (MultistageCheckpointSchedule(n, 0, s),
+            {"RAM": 0, "disk": s}, 1)
+
+
+def two_level(n, s, *, period):
+    return (TwoLevelCheckpointSchedule(period, s, binomial_storage="RAM"),
+            {"RAM": s, "disk": 1 + (n - 1) // period}, 1)
+
+
+def h_revolve(n, s):
+    if s <= 1:
+        return (None,
+                {"RAM": 0, "disk": 0}, 0)
+    else:
+        return (HRevolveCheckpointSchedule(n, s // 2, s - (s // 2)),
+                {"RAM": s // 2, "disk": s - (s // 2)}, 1)
+
+
+def mixed(n, s):
+    return (MixedCheckpointSchedule(n, s),
+            {"RAM": 0, "disk": s}, 1)
+
+
+@pytest.mark.parametrize(
+    "schedule, schedule_kwargs",
+    [(memory, {}),
+     (periodic_disk, {"period": 1}),
+     (periodic_disk, {"period": 2}),
+     (periodic_disk, {"period": 7}),
+     (periodic_disk, {"period": 10}),
+     (multistage, {}),
+     (two_level, {"period": 1}),
+     (two_level, {"period": 2}),
+     (two_level, {"period": 7}),
+     (two_level, {"period": 10}),
+     pytest.param(
+         h_revolve, {},
+         marks=pytest.mark.skipif(hrevolve is None,
+                                  reason="H-Revolve not available")),
+     (mixed, {})])
+@pytest.mark.parametrize("n, S", [(1, (0,)),
+                                  (2, (1,)),
+                                  (3, (1, 2)),
+                                  (10, tuple(range(1, 10))),
+                                  (100, tuple(range(1, 100))),
+                                  (250, tuple(range(25, 250, 25)))])
+def test_validity(schedule, schedule_kwargs,
+                  n, S):
+    @functools.singledispatch
+    def action(cp_action):
+        raise TypeError("Unexpected action")
+
+    @action.register(Clear)
+    def action_clear(cp_action):
+        if cp_action.clear_ics:
+            ics.clear()
+        if cp_action.clear_data:
+            data.clear()
+
+    @action.register(Configure)
+    def action_configure(cp_action):
+        nonlocal store_ics, store_data
+
+        store_ics = cp_action.store_ics
+        store_data = cp_action.store_data
+
+    @action.register(Forward)
+    def action_forward(cp_action):
+        nonlocal model_n
+
+        # Start at the current location of the forward
+        assert model_n is not None and model_n == cp_action.n0
+
+        if cp_schedule.max_n() is not None:
+            # Do not advance further than the current location of the adjoint
+            assert cp_action.n1 <= n - model_r
+        n1 = min(cp_action.n1, n)
+
+        if store_ics:
+            # No forward restart data for these steps is stored
+            assert len(ics.intersection(range(cp_action.n0, n1))) == 0
+
+        if store_data:
+            # No non-linear dependency data for these steps is stored
+            assert len(data.intersection(range(cp_action.n0, n1))) == 0
+
+        model_n = n1
+        if store_ics:
+            ics.update(range(cp_action.n0, n1))
+        if store_data:
+            data.update(range(cp_action.n0, n1))
+        if n1 == n:
+            cp_schedule.finalize(n1)
+
+    @action.register(Reverse)
+    def action_reverse(cp_action):
+        nonlocal model_r
+
+        # Start at the current location of the adjoint
+        assert cp_action.n1 == n - model_r
+        # Advance at least one step
+        assert cp_action.n0 < cp_action.n1
+        # Non-linear dependency data for these steps is stored
+        assert data.issuperset(range(cp_action.n0, cp_action.n1))
+
+        model_r += cp_action.n1 - cp_action.n0
+
+    @action.register(Read)
+    def action_read(cp_action):
+        nonlocal model_n
+
+        # The checkpoint exists
+        assert cp_action.n in snapshots[cp_action.storage]
+
+        cp = snapshots[cp_action.storage][cp_action.n]
+
+        # No data is currently stored for this step
+        assert cp_action.n not in ics
+        assert cp_action.n not in data
+        # The checkpoint contains forward restart or non-linear dependency data
+        assert len(cp[0]) > 0 or len(cp[1]) > 0
+
+        # The checkpoint data is before the current location of the adjoint
+        assert cp_action.n < n - model_r
+
+        model_n = None
+
+        if len(cp[0]) > 0:
+            ics.clear()
+            ics.update(cp[0])
+            model_n = cp_action.n
+
+        if len(cp[1]) > 0:
+            data.clear()
+            data.update(cp[1])
+
+        if cp_action.delete:
+            del snapshots[cp_action.storage][cp_action.n]
+
+    @action.register(Write)
+    def action_write(cp_action):
+        # The checkpoint contains forward restart or non-linear dependency data
+        assert len(ics) > 0 or len(data) > 0
+
+        # The checkpoint location is associated with the earliest step for
+        # which data has been stored
+        if len(ics) > 0:
+            if len(data) > 0:
+                assert cp_action.n == min(min(ics), min(data))
+            else:
+                assert cp_action.n == min(ics)
+        elif len(data) > 0:
+            assert cp_action.n == min(data)
+
+        snapshots[cp_action.storage][cp_action.n] = (set(ics), set(data))
+
+    @action.register(EndForward)
+    def action_end_forward(cp_action):
+        # The correct number of forward steps has been taken
+        assert model_n is not None and model_n == n
+
+    @action.register(EndReverse)
+    def action_end_reverse(cp_action):
+        nonlocal model_r
+
+        # The correct number of adjoint steps has been taken
+        assert model_r == n
+
+        if not cp_action.exhausted:
+            model_r = 0
+
+    for s in S:
+        print(f"{n=:d} {s=:d}")
+
+        model_n = 0
+        model_r = 0
+
+        store_ics = False
+        ics = set()
+        store_data = False
+        data = set()
+
+        snapshots = {"RAM": {}, "disk": {}}
+
+        cp_schedule, storage_limits, data_limit = schedule(n, s, **schedule_kwargs)  # noqa: E501
+        if cp_schedule is None:
+            pytest.skip("Incompatible with schedule type")
+        assert cp_schedule.n() == 0
+        assert cp_schedule.r() == 0
+        assert cp_schedule.max_n() is None or cp_schedule.max_n() == n
+
+        while True:
+            cp_action = next(cp_schedule)
+            action(cp_action)
+
+            # The schedule state is consistent with both the forward and
+            # adjoint
+            assert model_n is None or model_n == cp_schedule.n()
+            assert model_r == cp_schedule.r()
+
+            # Checkpoint storage limits are not exceeded
+            for storage_type, storage_limit in storage_limits.items():
+                assert len(snapshots[storage_type]) <= storage_limit
+            # Non-linear dependency data storage limit is not exceeded
+            assert len(data) <= data_limit
+
+            if isinstance(cp_action, EndReverse):
+                break

--- a/tests/fenics/test_manager.py
+++ b/tests/fenics/test_manager.py
@@ -22,6 +22,7 @@ from fenics import *
 from tlm_adjoint.fenics import *
 from tlm_adjoint.fenics import manager as _manager
 from tlm_adjoint.alias import WeakAlias
+from tlm_adjoint.checkpoint_schedules.binomial import optimal_steps
 
 from .test_base import *
 
@@ -560,32 +561,6 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
 def test_binomial_checkpointing(setup_test, test_leaks,
                                 tmp_path, n_steps, snaps_in_ram,
                                 prune):
-    _minimal_n_extra_steps = {}
-
-    def minimal_n_extra_steps(n, s):
-        """
-        Implementation of equation (2) in
-            A. Griewank and A. Walther, "Algorithm 799: Revolve: An
-            implementation of checkpointing for the reverse or adjoint mode of
-            computational differentiation", ACM Transactions on Mathematical
-            Software, 26(1), pp. 19--45, 2000
-        Used in place of their equation (3) to allow verification without reuse
-        of code used to compute t or evaluate beta.
-        """
-
-        assert n > 0
-        assert s > 0
-        if (n, s) not in _minimal_n_extra_steps:
-            m = n * (n - 1) // 2
-            if s > 1:
-                for i in range(1, n):
-                    m = min(m,
-                            i
-                            + minimal_n_extra_steps(i, s)
-                            + minimal_n_extra_steps(n - i, s - 1))
-            _minimal_n_extra_steps[(n, s)] = m
-        return _minimal_n_extra_steps[(n, s)]
-
     n_forward_solves = [0]
 
     class EmptySolver(Equation):
@@ -622,8 +597,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
     if prune:
         assert n_forward_solves[0] == n_steps
     else:
-        n_forward_solves_optimal = (n_steps
-                                    + minimal_n_extra_steps(n_steps, snaps_in_ram))  # noqa: E501
+        n_forward_solves_optimal = optimal_steps(n_steps, snaps_in_ram)
         info(f"Optimal number of forward steps: {n_forward_solves_optimal:d}")
         assert n_forward_solves[0] == n_forward_solves_optimal
 

--- a/tests/firedrake/test_manager.py
+++ b/tests/firedrake/test_manager.py
@@ -22,6 +22,7 @@ from firedrake import *
 from tlm_adjoint.firedrake import *
 from tlm_adjoint.firedrake import manager as _manager
 from tlm_adjoint.alias import WeakAlias
+from tlm_adjoint.checkpoint_schedules.binomial import optimal_steps
 
 from .test_base import *
 
@@ -563,32 +564,6 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks):
 def test_binomial_checkpointing(setup_test, test_leaks,
                                 tmp_path, n_steps, snaps_in_ram,
                                 prune):
-    _minimal_n_extra_steps = {}
-
-    def minimal_n_extra_steps(n, s):
-        """
-        Implementation of equation (2) in
-            A. Griewank and A. Walther, "Algorithm 799: Revolve: An
-            implementation of checkpointing for the reverse or adjoint mode of
-            computational differentiation", ACM Transactions on Mathematical
-            Software, 26(1), pp. 19--45, 2000
-        Used in place of their equation (3) to allow verification without reuse
-        of code used to compute t or evaluate beta.
-        """
-
-        assert n > 0
-        assert s > 0
-        if (n, s) not in _minimal_n_extra_steps:
-            m = n * (n - 1) // 2
-            if s > 1:
-                for i in range(1, n):
-                    m = min(m,
-                            i
-                            + minimal_n_extra_steps(i, s)
-                            + minimal_n_extra_steps(n - i, s - 1))
-            _minimal_n_extra_steps[(n, s)] = m
-        return _minimal_n_extra_steps[(n, s)]
-
     n_forward_solves = [0]
 
     class EmptySolver(Equation):
@@ -625,8 +600,7 @@ def test_binomial_checkpointing(setup_test, test_leaks,
     if prune:
         assert n_forward_solves[0] == n_steps
     else:
-        n_forward_solves_optimal = (n_steps
-                                    + minimal_n_extra_steps(n_steps, snaps_in_ram))  # noqa: E501
+        n_forward_solves_optimal = optimal_steps(n_steps, snaps_in_ram)
         info(f"Optimal number of forward steps: {n_forward_solves_optimal:d}")
         assert n_forward_solves[0] == n_forward_solves_optimal
 

--- a/tests/numpy/test_manager.py
+++ b/tests/numpy/test_manager.py
@@ -21,6 +21,7 @@
 from tlm_adjoint.numpy import *
 from tlm_adjoint.numpy import manager as _manager
 from tlm_adjoint.alias import WeakAlias
+from tlm_adjoint.checkpoint_schedules.binomial import optimal_steps
 
 from .test_base import *
 
@@ -422,32 +423,6 @@ def test_Referrers_FixedPointEquation(setup_test, test_leaks, test_default_dtype
 def test_binomial_checkpointing(setup_test, test_leaks, test_default_dtypes,
                                 tmp_path, n_steps, snaps_in_ram,
                                 prune):
-    _minimal_n_extra_steps = {}
-
-    def minimal_n_extra_steps(n, s):
-        """
-        Implementation of equation (2) in
-            A. Griewank and A. Walther, "Algorithm 799: Revolve: An
-            implementation of checkpointing for the reverse or adjoint mode of
-            computational differentiation", ACM Transactions on Mathematical
-            Software, 26(1), pp. 19--45, 2000
-        Used in place of their equation (3) to allow verification without reuse
-        of code used to compute t or evaluate beta.
-        """
-
-        assert n > 0
-        assert s > 0
-        if (n, s) not in _minimal_n_extra_steps:
-            m = n * (n - 1) // 2
-            if s > 1:
-                for i in range(1, n):
-                    m = min(m,
-                            i
-                            + minimal_n_extra_steps(i, s)
-                            + minimal_n_extra_steps(n - i, s - 1))
-            _minimal_n_extra_steps[(n, s)] = m
-        return _minimal_n_extra_steps[(n, s)]
-
     n_forward_solves = [0]
 
     class EmptySolver(Equation):
@@ -484,8 +459,7 @@ def test_binomial_checkpointing(setup_test, test_leaks, test_default_dtypes,
     if prune:
         assert n_forward_solves[0] == n_steps
     else:
-        n_forward_solves_optimal = (n_steps
-                                    + minimal_n_extra_steps(n_steps, snaps_in_ram))  # noqa: E501
+        n_forward_solves_optimal = optimal_steps(n_steps, snaps_in_ram)
         info(f"Optimal number of forward steps: {n_forward_solves_optimal:d}")
         assert n_forward_solves[0] == n_forward_solves_optimal
 

--- a/tlm_adjoint/checkpoint_schedules/binomial.py
+++ b/tlm_adjoint/checkpoint_schedules/binomial.py
@@ -24,6 +24,18 @@ from .schedule import CheckpointSchedule, Clear, Configure, Forward, Reverse, \
 import functools
 from operator import itemgetter
 
+try:
+    import numba
+    from numba import njit
+except ImportError:
+    numba = None
+
+    def njit(fn):
+        @functools.wraps(fn)
+        def wrapped_fn(*args, **kwargs):
+            return fn(*args, **kwargs)
+        return wrapped_fn
+
 __all__ = \
     [
         "MultistageCheckpointSchedule",
@@ -31,6 +43,7 @@ __all__ = \
     ]
 
 
+@njit
 def n_advance(n, snapshots, *, trajectory="maximum"):
     """
     Determine an optimal offline snapshot interval, taking n steps and with the

--- a/tlm_adjoint/checkpoint_schedules/mixed.py
+++ b/tlm_adjoint/checkpoint_schedules/mixed.py
@@ -376,4 +376,4 @@ class MixedCheckpointSchedule(CheckpointSchedule):
         return self._exhausted
 
     def uses_disk_storage(self):
-        return self._storage == "disk"
+        return self._max_n > 1 and self._storage == "disk"


### PR DESCRIPTION
Also
- Add missing data transfer behavior for H-Revolve schedules.
- Do not use disk storage for the single step case in `MixedCheckpointSchedule`.
- Use Numba in `n_advance` for binomial schedules.