### PR TITLE
Firedrake backend: Interpolation annotation

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -429,7 +429,7 @@ test, trial = TestFunction(space), TrialFunction(space)
 F = Function(space, name="F")
 G = Function(space, name="G")
 
-F.interpolate(sin(pi * X[0]))
+F.interpolate(sin(pi * X[0]), annotate=False, tlm=False)
 solve(inner(trial, test) * dx == inner(F * F, test) * dx,
       G, solver_parameters={"ksp_type": "preonly",
                             "pc_type": "lu"})
@@ -462,6 +462,8 @@ classes, and methods in this way, but this is limited to
   \item (Firedrake only) \texttt{LinearSolver}
   \item \texttt{LinearVariationalSolver}
   \item \texttt{NonlinearVariationalSolver}
+  \item (Firedrake only) \texttt{interpolate}, \texttt{Function.interpolate},
+    and \texttt{Interpolator.interpolate}
 \end{itemize}
 
 Note that the full functionality of intercepted or overridden functions,

--- a/examples/firedrake/manual/override_adjoint.py
+++ b/examples/firedrake/manual/override_adjoint.py
@@ -12,7 +12,7 @@ test, trial = TestFunction(space), TrialFunction(space)
 F = Function(space, name="F")
 G = Function(space, name="G")
 
-F.interpolate(sin(pi * X[0]))
+F.interpolate(sin(pi * X[0]), annotate=False, tlm=False)
 solve(inner(trial, test) * dx == inner(F * F, test) * dx,
       G, solver_parameters={"ksp_type": "preonly",
                             "pc_type": "lu"})

--- a/tlm_adjoint/equations.py
+++ b/tlm_adjoint/equations.py
@@ -509,11 +509,8 @@ class Equation(Referrer):
 
         self._pre_process(manager=manager, annotate=annotate)
 
-        annotation_enabled, tlm_enabled = manager.stop()
-        try:
+        with manager.paused():
             self.forward(self.X())
-        finally:
-            manager.start(annotate=annotation_enabled, tlm=tlm_enabled)
 
         self._post_process(manager=manager, annotate=annotate, tlm=tlm)
 

--- a/tlm_adjoint/firedrake/backend.py
+++ b/tlm_adjoint/firedrake/backend.py
@@ -22,7 +22,8 @@ from firedrake import Constant, DirichletBC, Function, FunctionSpace, \
     Interpolator, LinearSolver, LinearVariationalProblem, \
     LinearVariationalSolver, NonlinearVariationalSolver, Parameters, \
     Projector, Tensor, TestFunction, TrialFunction, UnitIntervalMesh, Vector, \
-    adjoint, assemble, homogenize, info, parameters, project, solve
+    adjoint, assemble, homogenize, info, interpolate, parameters, project, \
+    solve
 from firedrake.utils import complex_mode
 import firedrake
 
@@ -44,6 +45,7 @@ backend_Matrix = firedrake.matrix.Matrix
 backend_NonlinearVariationalSolver = NonlinearVariationalSolver
 backend_Vector = Vector
 backend_assemble = assemble
+backend_interpolate = interpolate
 backend_project = project
 backend_solve = solve
 
@@ -67,6 +69,7 @@ __all__ = \
         "backend_NonlinearVariationalSolver",
         "backend_Vector",
         "backend_assemble",
+        "backend_interpolate",
         "backend_project",
         "backend_solve",
 

--- a/tlm_adjoint/firedrake/backend_overrides.py
+++ b/tlm_adjoint/firedrake/backend_overrides.py
@@ -29,8 +29,7 @@ from ..interface import check_space_type, function_new, function_space, \
 from .backend_code_generator_interface import copy_parameters_dict, \
     update_parameters_dict
 
-from ..manager import annotation_enabled, start_manager, stop_manager, \
-    tlm_enabled
+from ..manager import annotation_enabled, paused_manager, tlm_enabled
 
 from ..equations import Assignment
 from .equations import EquationSolver, ExprEvaluation, Projection, \
@@ -633,11 +632,8 @@ def _Function_interpolate(*args, annotate=None, tlm=None, **kwargs):
         annotate = annotation_enabled()
     if tlm is None:
         tlm = tlm_enabled()
-    annotate, tlm = stop_manager(annotate=not annotate, tlm=not tlm)
-    try:
+    with paused_manager(annotate=not annotate, tlm=not tlm):
         return backend_Function._tlm_adjoint__orig_interpolate(*args, **kwargs)
-    finally:
-        start_manager(annotate=annotate, tlm=tlm)
 
 
 assert not hasattr(backend_Function, "_tlm_adjoint__orig_interpolate")
@@ -650,8 +646,5 @@ def interpolate(*args, annotate=None, tlm=None, **kwargs):
         annotate = annotation_enabled()
     if tlm is None:
         tlm = tlm_enabled()
-    annotate, tlm = stop_manager(annotate=not annotate, tlm=not tlm)
-    try:
+    with paused_manager(annotate=not annotate, tlm=not tlm):
         return backend_interpolate(*args, **kwargs)
-    finally:
-        start_manager(annotate=annotate, tlm=tlm)

--- a/tlm_adjoint/manager.py
+++ b/tlm_adjoint/manager.py
@@ -30,6 +30,7 @@ __all__ = \
         "function_tlm",
         "manager",
         "manager_info",
+        "paused_manager",
         "new_block",
         "reset_manager",
         "restore_manager",
@@ -138,6 +139,12 @@ def stop_tlm(manager=None):
     if manager is None:
         manager = globals()["manager"]()
     return manager.stop(annotate=False, tlm=True)
+
+
+def paused_manager(*, annotate=True, tlm=True, manager=None):
+    if manager is None:
+        manager = globals()["manager"]()
+    return manager.paused(annotate=annotate, tlm=tlm)
 
 
 def configure_tlm(*args, annotate=None, tlm=True, manager=None):

--- a/tlm_adjoint/manager.py
+++ b/tlm_adjoint/manager.py
@@ -125,19 +125,19 @@ def start_tlm(manager=None):
 def stop_manager(*, annotate=True, tlm=True, manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.stop(annotate=annotate, tlm=tlm)
+    return manager.stop(annotate=annotate, tlm=tlm)
 
 
 def stop_annotating(manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.stop(annotate=True, tlm=False)
+    return manager.stop(annotate=True, tlm=False)
 
 
 def stop_tlm(manager=None):
     if manager is None:
         manager = globals()["manager"]()
-    manager.stop(annotate=False, tlm=True)
+    return manager.stop(annotate=False, tlm=True)
 
 
 def configure_tlm(*args, annotate=None, tlm=True, manager=None):

--- a/tlm_adjoint/tlm_adjoint.py
+++ b/tlm_adjoint/tlm_adjoint.py
@@ -37,6 +37,7 @@ from .manager import restore_manager, set_manager
 
 from collections import defaultdict, deque
 from collections.abc import Sequence
+import contextlib
 import copy
 import enum
 import functools
@@ -1067,6 +1068,14 @@ class EquationManager:
                    TangentLinearState.FINAL: TangentLinearState.FINAL}[self._tlm_state]  # noqa: E501
 
         return state
+
+    @contextlib.contextmanager
+    def paused(self, *, annotate=True, tlm=True):
+        annotate, tlm = self.stop(annotate=annotate, tlm=tlm)
+        try:
+            yield
+        finally:
+            self.start(annotate=annotate, tlm=tlm)
 
     def add_initial_condition(self, x, annotate=None):
         """

--- a/tlm_adjoint/verification.py
+++ b/tlm_adjoint/verification.py
@@ -149,11 +149,8 @@ def taylor_test(forward, M, J_val, dJ=None, ddJ=None, seed=1.0e-2, dM=None,
             function_assign(m1, m0)
             function_axpy(m1, eps[i], dm)
         clear_caches()
-        annotation_enabled, tlm_enabled = manager.stop()
-        try:
+        with manager.paused():
             J_vals[i] = forward(*M1).value()
-        finally:
-            manager.start(annotate=annotation_enabled, tlm=tlm_enabled)
     if abs(J_vals.imag).max() == 0.0:
         J_vals = J_vals.real
 


### PR DESCRIPTION
Automatic annotation / TLM derivation for `interpolate`, `Function.interpolate`, and `Interpolator.interpolate`.

Also add `EquationManager.paused` and `paused_annotation` context managers, which pause and restart the `EquationManager`.