### PR TITLE
Add rank 1 form support to Assembly

### DIFF
--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -735,16 +735,15 @@ directly to the \texttt{DirichletBC} constructor.
 
 \subsubsection{\texttt{Assembly}}\label{sect:Assembly}
 
-An \texttt{Assembly} represents the assembly of a rank zero form. The
-\texttt{Assembly} constructor has the form
+An \texttt{Assembly} represents the assembly of a rank zero or rank one form.
+The \texttt{Assembly} constructor has the form
 \begin{lstlisting}
 def __init__(self, x, rhs, *, form_compiler_parameters=None,
              match_quadrature=None):
 \end{lstlisting}
 with constructor arguments
 \begin{itemize}
-  \item \texttt{rhs}, a \texttt{ufl.classes.Form}, defining a form of rank
-    zero.
+  \item \texttt{rhs}, a \texttt{ufl.classes.Form}, defining the form.
   \item \texttt{x}, a function, the solution to the equation.
   \item \texttt{form\_compiler\_parameters}, a dictionary of parameters passed
     to the form compiler.
@@ -755,8 +754,8 @@ with constructor arguments
     which by default is false.
 \end{itemize}
 
-The solution \texttt{x} must be a scalar, for example as returned by the
-\texttt{new\_scalar\_function} function
+For a rank zero form the solution \texttt{x} must be a scalar, for example as
+returned by the \texttt{new\_scalar\_function} function
 \begin{lstlisting}
 x = new_scalar_function(comm=comm)
 \end{lstlisting}

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -607,7 +607,7 @@ def test_Assembly_rank_1(setup_test, test_leaks):
 
     def forward(F):
         x = Function(space, name="x", space_type="conjugate_dual")
-        Assembly(x, inner(F ** 3, test) * dx).solve()
+        Assembly(x, inner(ufl.conj(F ** 3), test) * dx).solve()
 
         J = Functional(name="J")
         InnerProduct(J.function(), F, x).solve()

--- a/tests/fenics/test_equations.py
+++ b/tests/fenics/test_equations.py
@@ -553,7 +553,7 @@ def test_LocalProjection(setup_test, test_leaks):
 
 @pytest.mark.fenics
 @seed_test
-def test_Assembly(setup_test, test_leaks):
+def test_Assembly_rank_0(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -561,7 +561,7 @@ def test_Assembly(setup_test, test_leaks):
     def forward(F):
         x = Constant(name="x")
 
-        Assembly(x, (dot(F, F) ** 2) * dx).solve()
+        Assembly(x, (F ** 4) * dx).solve()
 
         J = Functional(name="J")
         J.assign(x)
@@ -575,7 +575,53 @@ def test_Assembly(setup_test, test_leaks):
     stop_manager()
 
     J_val = J.value()
-    assert abs(J_val - assemble((dot(F, F) ** 2) * dx)) == 0.0
+    assert abs(J_val - assemble((F ** 4) * dx)) == 0.0
+
+    dJ = compute_gradient(J, F)
+
+    min_order = taylor_test(forward, F, J_val=J_val, dJ=dJ)
+    assert min_order > 2.00
+
+    ddJ = Hessian(forward)
+    min_order = taylor_test(forward, F, J_val=J_val, ddJ=ddJ)
+    assert min_order > 3.00
+
+    min_order = taylor_test_tlm(forward, F, tlm_order=1)
+    assert min_order > 2.00
+
+    min_order = taylor_test_tlm_adjoint(forward, F, adjoint_order=1)
+    assert min_order > 2.00
+
+    min_order = taylor_test_tlm_adjoint(forward, F, adjoint_order=2)
+    assert min_order > 2.00
+
+
+@pytest.mark.fenics
+@pytest.mark.skipif(complex_mode, reason="real only")
+@seed_test
+def test_Assembly_rank_1(setup_test, test_leaks):
+    mesh = UnitSquareMesh(20, 20)
+    X = SpatialCoordinate(mesh)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    test = TestFunction(space)
+
+    def forward(F):
+        x = Function(space, name="x", space_type="conjugate_dual")
+        Assembly(x, inner(F ** 3, test) * dx).solve()
+
+        J = Functional(name="J")
+        InnerProduct(J.function(), F, x).solve()
+        return J
+
+    F = Function(space, name="F", static=True)
+    interpolate_expression(F, X[0] * sin(pi * X[1]))
+
+    start_manager()
+    J = forward(F)
+    stop_manager()
+
+    J_val = J.value()
+    assert abs(J_val - assemble((F ** 4) * dx)) < 1.0e-16
 
     dJ = compute_gradient(J, F)
 

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -547,7 +547,7 @@ def test_LocalProjection(setup_test, test_leaks):
 
 @pytest.mark.firedrake
 @seed_test
-def test_Assembly(setup_test, test_leaks):
+def test_Assembly_rank_0(setup_test, test_leaks):
     mesh = UnitSquareMesh(20, 20)
     X = SpatialCoordinate(mesh)
     space = FunctionSpace(mesh, "Lagrange", 1)
@@ -555,7 +555,7 @@ def test_Assembly(setup_test, test_leaks):
     def forward(F):
         x = Constant(name="x")
 
-        Assembly(x, (dot(F, F) ** 2) * dx).solve()
+        Assembly(x, (F ** 4) * dx).solve()
 
         J = Functional(name="J")
         J.assign(x)
@@ -569,7 +569,53 @@ def test_Assembly(setup_test, test_leaks):
     stop_manager()
 
     J_val = J.value()
-    assert abs(J_val - assemble((dot(F, F) ** 2) * dx)) == 0.0
+    assert abs(J_val - assemble((F ** 4) * dx)) == 0.0
+
+    dJ = compute_gradient(J, F)
+
+    min_order = taylor_test(forward, F, J_val=J_val, dJ=dJ)
+    assert min_order > 2.00
+
+    ddJ = Hessian(forward)
+    min_order = taylor_test(forward, F, J_val=J_val, ddJ=ddJ)
+    assert min_order > 3.00
+
+    min_order = taylor_test_tlm(forward, F, tlm_order=1)
+    assert min_order > 2.00
+
+    min_order = taylor_test_tlm_adjoint(forward, F, adjoint_order=1)
+    assert min_order > 2.00
+
+    min_order = taylor_test_tlm_adjoint(forward, F, adjoint_order=2)
+    assert min_order > 2.00
+
+
+@pytest.mark.firedrake
+@pytest.mark.skipif(complex_mode, reason="real only")
+@seed_test
+def test_Assembly_rank_1(setup_test, test_leaks):
+    mesh = UnitSquareMesh(20, 20)
+    X = SpatialCoordinate(mesh)
+    space = FunctionSpace(mesh, "Lagrange", 1)
+    test = TestFunction(space)
+
+    def forward(F):
+        x = Function(space, name="x", space_type="conjugate_dual")
+        Assembly(x, inner(F ** 3, test) * dx).solve()
+
+        J = Functional(name="J")
+        InnerProduct(J.function(), F, x).solve()
+        return J
+
+    F = Function(space, name="F", static=True)
+    interpolate_expression(F, X[0] * sin(pi * X[1]))
+
+    start_manager()
+    J = forward(F)
+    stop_manager()
+
+    J_val = J.value()
+    assert abs(J_val - assemble((F ** 4) * dx)) < 1.0e-16
 
     dJ = compute_gradient(J, F)
 

--- a/tests/firedrake/test_equations.py
+++ b/tests/firedrake/test_equations.py
@@ -601,7 +601,7 @@ def test_Assembly_rank_1(setup_test, test_leaks):
 
     def forward(F):
         x = Function(space, name="x", space_type="conjugate_dual")
-        Assembly(x, inner(F ** 3, test) * dx).solve()
+        Assembly(x, inner(ufl.conj(F ** 3), test) * dx).solve()
 
         J = Functional(name="J")
         InnerProduct(J.function(), F, x).solve()

--- a/tests/firedrake/test_overrides.py
+++ b/tests/firedrake/test_overrides.py
@@ -25,6 +25,7 @@ from .test_base import *
 
 import mpi4py.MPI as MPI
 import pytest
+import ufl
 
 pytestmark = pytest.mark.skipif(
     MPI.COMM_WORLD.size not in [1, 4],
@@ -337,7 +338,7 @@ def test_Assemble_rank_1(setup_test, test_leaks):
     test = TestFunction(space)
 
     def forward(F):
-        x = assemble(inner(F ** 3, test) * dx)
+        x = assemble(inner(ufl.conj(F ** 3), test) * dx)
 
         J = Functional(name="J")
         InnerProduct(J.function(), F, x).solve()


### PR DESCRIPTION
With the Firedrake backend, add automatic annotation / TLM derivation for rank one assembly via `assemble`.